### PR TITLE
Add explain-file command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Every command supports `--format json` for machine-readable output.
 | Command | What it does |
 |---|---|
 | `index --rebuild` | Rebuild the SQLite index from all configured sources |
+| `preview-sources` | Show which files each configured source will index |
+| `explain-file PATH` | Explain how one file is classified by configured sources |
 | `search-specs --query "..."` | Semantic search across indexed spec sections |
 | `check-overlap --spec-ref SPEC-042` | Detect specs that cover overlapping ground |
 | `compare-specs --spec-ref SPEC-008 --spec-ref SPEC-042` | Side-by-side tradeoff analysis of two specs |
@@ -184,7 +186,7 @@ Before feature work continues, the repository treats these v1 rules as fixed:
 - Canonical `ref` values use declared spec IDs such as `SPEC-042` for specs, `doc://...` refs derived from workspace-relative Markdown paths for docs, and logical `code://...` / `config://...` refs for governed artifacts.
 - `source_ref` is provenance-only and uses workspace-rooted `file://...` URIs.
 - Persisted spec statuses are `draft`, `review`, `accepted`, `superseded`, and `deprecated`. Default search covers active specs (`draft`, `review`, `accepted`), while overlap analysis may still surface `superseded` specs as historical context.
-- `spec_bundle` sources are discovered recursively by directories containing `spec.toml`; nested bundles are invalid. Markdown docs are discovered recursively as `*.md`.
+- `spec_bundle` sources are discovered recursively by directories containing `spec.toml`; nested bundles are invalid after selector filtering. Markdown docs are discovered recursively as `*.md`, then narrowed by optional source selectors.
 - `search-specs` normalizes an optional `limit` request field; it defaults to `10` and must stay within `1..50`.
 - JSON CLI responses share one envelope with normalized `request`, tool-specific `result`, and structured `warnings` / `errors`.
 - `check_doc_drift` accepts exactly one of `doc_ref`, `doc_refs`, or `scope = "all"`. `review_spec` reuses `check_doc_drift` with targeted `doc_refs` from impact analysis rather than widening to the whole workspace by default.

--- a/cmd/explain_file.go
+++ b/cmd/explain_file.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+type explainFileRequest struct {
+	Path string `json:"path"`
+}
+
+func runExplainFile(args []string, stdout, stderr io.Writer) int {
+	return runExplainFileContext(context.Background(), args, stdout, stderr)
+}
+
+func runExplainFileContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	args = reorderExplainFileArgs(args)
+
+	fs := flag.NewFlagSet("explain-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var (
+		format     string
+		configPath string
+	)
+	fs.StringVar(&format, "format", "text", "output format")
+	fs.StringVar(&configPath, "config", "", "path to workspace config")
+
+	if err := fs.Parse(args); err != nil {
+		return writeCLIError(stdout, stderr, format, "explain-file", nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+	if !isSupportedFormat(format) {
+		return writeCLIError(stdout, stderr, format, "explain-file", nil, cliIssue{
+			Code:    "validation_error",
+			Message: fmt.Sprintf("unsupported format %q", format),
+		}, 2)
+	}
+	if fs.NArg() != 1 {
+		return writeCLIError(stdout, stderr, format, "explain-file", nil, cliIssue{
+			Code:    "validation_error",
+			Message: "exactly one file path is required",
+		}, 2)
+	}
+
+	request := explainFileRequest{Path: fs.Arg(0)}
+
+	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "explain-file", request, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	cfg, err := config.Load(resolvedConfigPath)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "explain-file", request, cliIssue{
+			Code:    "config_error",
+			Message: "invalid config:\n" + err.Error(),
+		}, 2)
+	}
+
+	targetPath, err := resolveExplainPath(request.Path)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "explain-file", request, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	result, err := source.ExplainFile(cfg, targetPath)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "explain-file", request, cliIssue{
+			Code:    "source_error",
+			Message: "file explanation failed:\n" + err.Error(),
+		}, 2)
+	}
+
+	return writeCLISuccess(stdout, stderr, format, "explain-file", request, result, nil)
+}
+
+func reorderExplainFileArgs(args []string) []string {
+	flagArgs := make([]string, 0, len(args))
+	positionalArgs := make([]string, 0, len(args))
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			positionalArgs = append(positionalArgs, args[i+1:]...)
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			positionalArgs = append(positionalArgs, arg)
+			continue
+		}
+
+		flagArgs = append(flagArgs, arg)
+		if explainFileFlagTakesValue(arg) && !strings.Contains(arg, "=") && i+1 < len(args) {
+			flagArgs = append(flagArgs, args[i+1])
+			i++
+		}
+	}
+
+	return append(flagArgs, positionalArgs...)
+}
+
+func explainFileFlagTakesValue(arg string) bool {
+	switch arg {
+	case "-format", "--format", "-config", "--config":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveExplainPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("path must not be empty")
+	}
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	return filepath.Join(cwd, path), nil
+}

--- a/cmd/explain_file_test.go
+++ b/cmd/explain_file_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunExplainFileJSON(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	mustWriteFileCmd(t, filepath.Join(repo, "docs", "development", "testing-guide.md"), "# Testing Guide\n")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runExplainFile([]string{"docs/development/testing-guide.md", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runExplainFile() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runExplainFile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request struct {
+			Path string `json:"path"`
+		} `json:"request"`
+		Result struct {
+			WorkspacePath string `json:"workspace_path"`
+			Summary       struct {
+				Status string `json:"status"`
+			} `json:"summary"`
+			Sources []struct {
+				Name         string `json:"name"`
+				Reason       string `json:"reason"`
+				Selected     bool   `json:"selected"`
+				RelativePath string `json:"relative_path"`
+			} `json:"sources"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal explain payload: %v", err)
+	}
+	if got, want := payload.Request.Path, "docs/development/testing-guide.md"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.Summary.Status, "excluded"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.WorkspacePath, "docs/development/testing-guide.md"; got != want {
+		t.Fatalf("workspace path = %q, want %q", got, want)
+	}
+	if len(payload.Result.Sources) != 2 {
+		t.Fatalf("sources = %+v, want 2 explanations", payload.Result.Sources)
+	}
+	if payload.Result.Sources[1].Name != "docs" || payload.Result.Sources[1].Reason != "not_matched_by_include" || payload.Result.Sources[1].Selected {
+		t.Fatalf("docs explanation = %+v, want excluded docs explanation", payload.Result.Sources[1])
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
+func TestRunExplainFileRejectsMissingPath(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runExplainFile([]string{"--format", "json"}, &stdout, &stderr)
+	if exitCode != 2 {
+		t.Fatalf("runExplainFile() exit code = %d, want 2", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runExplainFile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result any        `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal explain error payload: %v", err)
+	}
+	if payload.Result != nil {
+		t.Fatalf("result = %#v, want nil", payload.Result)
+	}
+	if len(payload.Errors) != 1 || payload.Errors[0].Code != "validation_error" {
+		t.Fatalf("errors = %+v, want one validation_error", payload.Errors)
+	}
+}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -23,6 +23,8 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 		renderIndexResult(w, typed)
 	case *source.PreviewResult:
 		renderPreviewSourcesResult(w, typed)
+	case *source.ExplainFileResult:
+		renderExplainFileResult(w, typed)
 	case *index.SearchSpecResult:
 		renderSearchSpecsResult(w, typed)
 	case *analysis.OverlapResult:
@@ -70,6 +72,41 @@ func renderPreviewSourcesResult(w io.Writer, result *source.PreviewResult) {
 		}
 		if i < len(result.Sources)-1 {
 			fmt.Fprintln(w)
+		}
+	}
+}
+
+func renderExplainFileResult(w io.Writer, result *source.ExplainFileResult) {
+	fmt.Fprintf(w, "file: %s\n", result.AbsolutePath)
+	if result.WorkspacePath != "" {
+		fmt.Fprintf(w, "workspace path: %s\n", result.WorkspacePath)
+	}
+	fmt.Fprintf(w, "summary: %s\n", result.Summary.Status)
+	if len(result.Summary.IndexedBy) > 0 {
+		fmt.Fprintf(w, "indexed by: %s\n", strings.Join(result.Summary.IndexedBy, ", "))
+	}
+	for i, explanation := range result.Sources {
+		fmt.Fprintf(w, "%d. %s | %s | reason: %s\n", i+1, explanation.Name, explanation.Kind, explanation.Reason)
+		if explanation.UnderSourceRoot {
+			fmt.Fprintf(w, "   relative path: %s\n", explanation.RelativePath)
+			fmt.Fprintf(w, "   selected: %t\n", explanation.Selected)
+		} else {
+			fmt.Fprintln(w, "   outside source root")
+		}
+		if explanation.ArtifactKind != "" {
+			fmt.Fprintf(w, "   artifact: %s\n", explanation.ArtifactKind)
+		}
+		if explanation.BundlePath != "" {
+			fmt.Fprintf(w, "   bundle: %s\n", explanation.BundlePath)
+		}
+		if len(explanation.IncludeMatches) > 0 {
+			fmt.Fprintf(w, "   include matches: %s\n", strings.Join(explanation.IncludeMatches, ", "))
+		}
+		if len(explanation.ExcludeMatches) > 0 {
+			fmt.Fprintf(w, "   exclude matches: %s\n", strings.Join(explanation.ExcludeMatches, ", "))
+		}
+		if explanation.ConflictsWith != "" {
+			fmt.Fprintf(w, "   conflicts with: %s\n", explanation.ConflictsWith)
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 var commands = map[string]string{
 	"index":           "rebuild the local Pituitary index",
 	"preview-sources": "show which files each source will index",
+	"explain-file":    "explain how one file is classified by configured sources",
 	"search-specs":    "search spec sections semantically",
 	"check-overlap":   "find overlapping specs",
 	"compare-specs":   "compare design tradeoffs across specs",
@@ -61,6 +62,9 @@ func RunContext(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	}
 	if name == "preview-sources" {
 		return runPreviewSourcesContext(ctx, remainingArgs[1:], stdout, stderr)
+	}
+	if name == "explain-file" {
+		return runExplainFileContext(ctx, remainingArgs[1:], stdout, stderr)
 	}
 	if name == "search-specs" {
 		return runSearchSpecsContext(ctx, remainingArgs[1:], stdout, stderr)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -31,12 +31,14 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 				return
 			}
 
-			if name == "index" || name == "preview-sources" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-doc-drift" || name == "review-spec" {
+			if name == "index" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-doc-drift" || name == "review-spec" {
 				repoRoot := writeSearchWorkspace(t)
 				if name == "index" {
 					args = []string{name, "--rebuild"}
 				} else if name == "preview-sources" {
 					args = []string{name}
+				} else if name == "explain-file" {
+					args = []string{name, "docs/guides/api-rate-limits.md"}
 				} else if name == "search-specs" {
 					indexStdout := bytes.Buffer{}
 					indexStderr := bytes.Buffer{}

--- a/internal/source/explain.go
+++ b/internal/source/explain.go
@@ -1,0 +1,304 @@
+package source
+
+import (
+	"fmt"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+const (
+	explainReasonOutsideSourceRoot      = "outside_source_root"
+	explainReasonExcludedBySelector     = "excluded_by_selector"
+	explainReasonNotMatchedByInclude    = "not_matched_by_include"
+	explainReasonNotMarkdownDoc         = "not_markdown_doc"
+	explainReasonIndexedMarkdownDoc     = "indexed_markdown_doc"
+	explainReasonIndexedSpecBundle      = "indexed_spec_bundle"
+	explainReasonBundleMemberNotIndexed = "bundle_member_not_indexed_directly"
+	explainReasonNotInSpecBundle        = "not_in_spec_bundle"
+	explainReasonNestedBundleConflict   = "nested_bundle_conflict"
+)
+
+// ExplainFileResult describes how a single file is treated across configured sources.
+type ExplainFileResult struct {
+	AbsolutePath  string                  `json:"absolute_path"`
+	WorkspacePath string                  `json:"workspace_path,omitempty"`
+	Summary       ExplainFileSummary      `json:"summary"`
+	Sources       []SourceFileExplanation `json:"sources"`
+}
+
+// ExplainFileSummary provides a high-level classification outcome for the file.
+type ExplainFileSummary struct {
+	Status    string   `json:"status"`
+	IndexedBy []string `json:"indexed_by,omitempty"`
+}
+
+// SourceFileExplanation describes how one source evaluates the target file.
+type SourceFileExplanation struct {
+	Name            string   `json:"name"`
+	Kind            string   `json:"kind"`
+	Path            string   `json:"path"`
+	RelativePath    string   `json:"relative_path,omitempty"`
+	UnderSourceRoot bool     `json:"under_source_root"`
+	Selected        bool     `json:"selected"`
+	ArtifactKind    string   `json:"artifact_kind,omitempty"`
+	Reason          string   `json:"reason"`
+	IncludeMatches  []string `json:"include_matches,omitempty"`
+	ExcludeMatches  []string `json:"exclude_matches,omitempty"`
+	BundlePath      string   `json:"bundle_path,omitempty"`
+	ConflictsWith   string   `json:"conflicts_with,omitempty"`
+}
+
+type sourcePathSelection struct {
+	Selected       bool
+	Reason         string
+	IncludeMatches []string
+	ExcludeMatches []string
+}
+
+// ExplainFile reports how the configured sources classify one concrete file path.
+func ExplainFile(cfg *config.Config, path string) (*ExplainFileResult, error) {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve path: %w", err)
+	}
+
+	info, err := os.Stat(absolutePath)
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	case info.IsDir():
+		return nil, fmt.Errorf("%s is a directory", path)
+	}
+
+	result := &ExplainFileResult{
+		AbsolutePath: absolutePath,
+		Sources:      make([]SourceFileExplanation, 0, len(cfg.Sources)),
+	}
+	if pathWithinRoot(cfg.Workspace.RootPath, absolutePath) {
+		result.WorkspacePath = workspaceRelative(cfg.Workspace.RootPath, absolutePath)
+	}
+
+	indexedBy := make([]string, 0, len(cfg.Sources))
+	hasExcludedReason := false
+	hasSourceCoverage := false
+	for _, source := range cfg.Sources {
+		explanation, err := explainFileInSource(cfg.Workspace.RootPath, source, absolutePath)
+		if err != nil {
+			return nil, err
+		}
+		if explanation.Selected {
+			indexedBy = append(indexedBy, source.Name)
+		}
+		if explanation.UnderSourceRoot {
+			hasSourceCoverage = true
+		}
+		if explanation.Reason == explainReasonExcludedBySelector || explanation.Reason == explainReasonNotMatchedByInclude {
+			hasExcludedReason = true
+		}
+		result.Sources = append(result.Sources, explanation)
+	}
+
+	result.Summary.IndexedBy = indexedBy
+	switch {
+	case len(indexedBy) > 0:
+		result.Summary.Status = "indexed"
+	case hasExcludedReason:
+		result.Summary.Status = "excluded"
+	case hasSourceCoverage:
+		result.Summary.Status = "not_indexed"
+	default:
+		result.Summary.Status = "outside_sources"
+	}
+
+	return result, nil
+}
+
+func explainFileInSource(workspaceRoot string, source config.Source, absolutePath string) (SourceFileExplanation, error) {
+	explanation := SourceFileExplanation{
+		Name: source.Name,
+		Kind: source.Kind,
+		Path: source.Path,
+	}
+	if !pathWithinRoot(source.ResolvedPath, absolutePath) {
+		explanation.Reason = explainReasonOutsideSourceRoot
+		return explanation, nil
+	}
+
+	relPath, err := filepath.Rel(source.ResolvedPath, absolutePath)
+	if err != nil {
+		return SourceFileExplanation{}, fmt.Errorf("source %q file %q: resolve relative path: %w", source.Name, workspaceRelative(workspaceRoot, absolutePath), err)
+	}
+	relPath = filepath.ToSlash(relPath)
+	explanation.UnderSourceRoot = true
+	explanation.RelativePath = relPath
+
+	switch source.Kind {
+	case config.SourceKindMarkdownDocs:
+		return explainMarkdownDocSource(explanation, source, relPath)
+	case config.SourceKindSpecBundle:
+		return explainSpecBundleSource(workspaceRoot, explanation, source, absolutePath)
+	default:
+		return SourceFileExplanation{}, fmt.Errorf("source %q: unsupported kind %q", source.Name, source.Kind)
+	}
+}
+
+func explainMarkdownDocSource(explanation SourceFileExplanation, source config.Source, relPath string) (SourceFileExplanation, error) {
+	selection, err := evaluateSourcePathSelection(source, relPath)
+	if err != nil {
+		return SourceFileExplanation{}, err
+	}
+	explanation.IncludeMatches = selection.IncludeMatches
+	explanation.ExcludeMatches = selection.ExcludeMatches
+	if filepath.Ext(relPath) != ".md" {
+		explanation.Reason = explainReasonNotMarkdownDoc
+		return explanation, nil
+	}
+	if !selection.Selected {
+		explanation.Reason = selection.Reason
+		return explanation, nil
+	}
+
+	explanation.Selected = true
+	explanation.ArtifactKind = "doc"
+	explanation.Reason = explainReasonIndexedMarkdownDoc
+	return explanation, nil
+}
+
+func explainSpecBundleSource(workspaceRoot string, explanation SourceFileExplanation, source config.Source, absolutePath string) (SourceFileExplanation, error) {
+	candidateDirs, err := discoverSpecBundleDirs(source.ResolvedPath)
+	if err != nil {
+		return SourceFileExplanation{}, err
+	}
+
+	targetBundleDir := findTargetSpecBundleDir(candidateDirs, absolutePath)
+	if targetBundleDir == "" {
+		explanation.Reason = explainReasonNotInSpecBundle
+		return explanation, nil
+	}
+
+	targetBundleSpecPath := filepath.Join(targetBundleDir, "spec.toml")
+	bundleSpecRel := filepath.ToSlash(filepath.Join(workspaceRelative(source.ResolvedPath, targetBundleDir), "spec.toml"))
+	explanation.BundlePath = workspaceRelative(workspaceRoot, targetBundleSpecPath)
+
+	selection, err := evaluateSourcePathSelection(source, bundleSpecRel)
+	if err != nil {
+		return SourceFileExplanation{}, err
+	}
+	explanation.IncludeMatches = selection.IncludeMatches
+	explanation.ExcludeMatches = selection.ExcludeMatches
+	if !selection.Selected {
+		explanation.Reason = selection.Reason
+		return explanation, nil
+	}
+
+	selectedDirs := make([]string, 0, len(candidateDirs))
+	for _, bundleDir := range candidateDirs {
+		relBundleSpec := filepath.ToSlash(filepath.Join(workspaceRelative(source.ResolvedPath, bundleDir), "spec.toml"))
+		bundleSelection, err := evaluateSourcePathSelection(source, relBundleSpec)
+		if err != nil {
+			return SourceFileExplanation{}, err
+		}
+		if bundleSelection.Selected {
+			selectedDirs = append(selectedDirs, bundleDir)
+		}
+	}
+
+	if conflictDir := findBundleConflict(targetBundleDir, selectedDirs); conflictDir != "" {
+		explanation.Reason = explainReasonNestedBundleConflict
+		explanation.ConflictsWith = workspaceRelative(workspaceRoot, filepath.Join(conflictDir, "spec.toml"))
+		return explanation, nil
+	}
+
+	if filepath.Base(absolutePath) != "spec.toml" {
+		explanation.Reason = explainReasonBundleMemberNotIndexed
+		return explanation, nil
+	}
+
+	explanation.Selected = true
+	explanation.ArtifactKind = "spec"
+	explanation.Reason = explainReasonIndexedSpecBundle
+	return explanation, nil
+}
+
+func evaluateSourcePathSelection(source config.Source, relPath string) (sourcePathSelection, error) {
+	selection := sourcePathSelection{
+		Selected: true,
+		Reason:   explainReasonIndexedMarkdownDoc,
+	}
+	relPath = filepath.ToSlash(relPath)
+
+	if len(source.Include) > 0 {
+		selection.Selected = false
+		selection.Reason = explainReasonNotMatchedByInclude
+		for _, pattern := range source.Include {
+			ok, err := matchSourceSelector(pattern, relPath)
+			if err != nil {
+				return sourcePathSelection{}, err
+			}
+			if ok {
+				selection.IncludeMatches = append(selection.IncludeMatches, pattern)
+				selection.Selected = true
+			}
+		}
+	}
+
+	for _, pattern := range source.Exclude {
+		ok, err := matchSourceSelector(pattern, relPath)
+		if err != nil {
+			return sourcePathSelection{}, err
+		}
+		if ok {
+			selection.ExcludeMatches = append(selection.ExcludeMatches, pattern)
+			selection.Selected = false
+			selection.Reason = explainReasonExcludedBySelector
+		}
+	}
+
+	if selection.Selected {
+		selection.Reason = ""
+	}
+	return selection, nil
+}
+
+func matchSourceSelector(pattern, relPath string) (bool, error) {
+	ok, err := pathpkg.Match(pattern, relPath)
+	if err != nil {
+		return false, fmt.Errorf("selector pattern %q is invalid: %w", pattern, err)
+	}
+	return ok, nil
+}
+
+func findTargetSpecBundleDir(candidateDirs []string, absolutePath string) string {
+	if filepath.Base(absolutePath) == "spec.toml" {
+		targetDir := filepath.Dir(absolutePath)
+		for _, bundleDir := range candidateDirs {
+			if bundleDir == targetDir {
+				return targetDir
+			}
+		}
+		return ""
+	}
+
+	var target string
+	for _, bundleDir := range candidateDirs {
+		if pathWithinRoot(bundleDir, absolutePath) {
+			target = bundleDir
+		}
+	}
+	return target
+}
+
+func findBundleConflict(targetBundleDir string, selectedDirs []string) string {
+	for _, bundleDir := range selectedDirs {
+		if bundleDir == targetBundleDir {
+			continue
+		}
+		if isNestedBundle(bundleDir, targetBundleDir) || isNestedBundle(targetBundleDir, bundleDir) {
+			return bundleDir
+		}
+	}
+	return ""
+}

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	pathpkg "path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -356,33 +355,11 @@ func loadMarkdownDocs(workspaceRoot string, source config.Source) ([]model.DocRe
 }
 
 func sourcePathAllowed(source config.Source, relPath string) (bool, error) {
-	relPath = filepath.ToSlash(relPath)
-	if len(source.Include) > 0 {
-		matched := false
-		for _, pattern := range source.Include {
-			ok, err := pathpkg.Match(pattern, relPath)
-			if err != nil {
-				return false, fmt.Errorf("include pattern %q is invalid: %w", pattern, err)
-			}
-			if ok {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return false, nil
-		}
+	selection, err := evaluateSourcePathSelection(source, relPath)
+	if err != nil {
+		return false, err
 	}
-	for _, pattern := range source.Exclude {
-		ok, err := pathpkg.Match(pattern, relPath)
-		if err != nil {
-			return false, fmt.Errorf("exclude pattern %q is invalid: %w", pattern, err)
-		}
-		if ok {
-			return false, nil
-		}
-	}
-	return true, nil
+	return selection.Selected, nil
 }
 
 func docRefForPath(sourceRoot, path string) (string, error) {

--- a/internal/source/filesystem_test.go
+++ b/internal/source/filesystem_test.go
@@ -534,6 +534,92 @@ func TestPreviewFromConfigUsesSelectors(t *testing.T) {
 	}
 }
 
+func TestExplainFileReportsExcludedMarkdownDoc(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "pituitary.toml"), `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md", "runbooks/*.md"]
+`)
+	mustWriteFile(t, filepath.Join(repo, "docs", "development", "testing-guide.md"), "# Testing Guide\n")
+
+	cfg, err := config.Load(filepath.Join(repo, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := ExplainFile(cfg, filepath.Join(repo, "docs", "development", "testing-guide.md"))
+	if err != nil {
+		t.Fatalf("ExplainFile() error = %v", err)
+	}
+	if got, want := result.Summary.Status, "excluded"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	if got, want := result.Sources[0].Reason, explainReasonNotMatchedByInclude; got != want {
+		t.Fatalf("docs source reason = %q, want %q", got, want)
+	}
+	if got, want := result.Sources[0].RelativePath, "development/testing-guide.md"; got != want {
+		t.Fatalf("docs source relative path = %q, want %q", got, want)
+	}
+}
+
+func TestExplainFileReportsIndexedMarkdownDoc(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := repoRoot(t)
+	cfg, err := config.Load(filepath.Join(repoRoot, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := ExplainFile(cfg, filepath.Join(repoRoot, "docs", "guides", "api-rate-limits.md"))
+	if err != nil {
+		t.Fatalf("ExplainFile() error = %v", err)
+	}
+	if got, want := result.Summary.Status, "indexed"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	if got, want := result.Sources[1].Reason, explainReasonIndexedMarkdownDoc; got != want {
+		t.Fatalf("docs source reason = %q, want %q", got, want)
+	}
+	if !result.Sources[1].Selected || result.Sources[1].ArtifactKind != "doc" {
+		t.Fatalf("docs source = %+v, want selected doc explanation", result.Sources[1])
+	}
+}
+
+func TestExplainFileReportsBundleMemberNotIndexedDirectly(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := repoRoot(t)
+	cfg, err := config.Load(filepath.Join(repoRoot, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := ExplainFile(cfg, filepath.Join(repoRoot, "specs", "rate-limit-v2", "body.md"))
+	if err != nil {
+		t.Fatalf("ExplainFile() error = %v", err)
+	}
+	if got, want := result.Summary.Status, "not_indexed"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	if got, want := result.Sources[0].Reason, explainReasonBundleMemberNotIndexed; got != want {
+		t.Fatalf("spec source reason = %q, want %q", got, want)
+	}
+	if got, want := result.Sources[0].BundlePath, "specs/rate-limit-v2/spec.toml"; got != want {
+		t.Fatalf("bundle path = %q, want %q", got, want)
+	}
+}
+
 func TestLoadFromConfigReadsOversizedSpecArrayValues(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add `pituitary explain-file` to explain how one file is treated across configured sources
- reuse selector-aware source logic so markdown docs and spec bundles report inclusion, exclusion, and nested-bundle conflicts consistently
- document the command and cover the CLI plus source-level behavior with tests

## Testing
- go test ./cmd -run 'TestRun(ExplainFileJSON|ExplainFileRejectsMissingPath|KnownCommandsStayCallable|HelpIncludesCommandSurface)$'
- go test ./internal/source -run 'Test(ExplainFileReportsExcludedMarkdownDoc|ExplainFileReportsIndexedMarkdownDoc|ExplainFileReportsBundleMemberNotIndexedDirectly|LoadAndPreviewAllowExcludedNestedBundle)$'
- go test ./...

Closes #24