### PR TITLE
Complete source selectors for arbitrary repo layouts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -319,9 +319,15 @@ The adapter contract keeps that variability out of the analysis engine.
 **V1 filesystem enumeration rules:**
 
 - For `kind = "spec_bundle"`, recursively walk the configured source root and treat each directory containing a `spec.toml` file as one bundle.
+- Selector matching for spec bundles is done against the source-relative `spec.toml` path.
 - A valid bundle must contain exactly one `spec.toml`; its `body` field must resolve to exactly one file relative to the bundle directory.
 - Nested bundles inside another bundle directory are invalid and should fail with a clear path-specific error.
-- For `kind = "markdown_docs"`, recursively index `*.md` files under the configured source root, then apply optional `include` / `exclude` selectors against source-relative paths.
+- For `kind = "markdown_docs"`, recursively index `*.md` files under the configured source root, then apply selectors against source-relative paths.
+- `files` is an optional exact allowlist of source-relative files.
+- `include` and `exclude` are optional glob filters over those same source-relative paths.
+- If `files` is present, it narrows the candidate set before `include` / `exclude` are applied.
+- For `kind = "spec_bundle"`, `files` entries must point to `spec.toml`.
+- For `kind = "markdown_docs"`, `files` entries must point to `.md` files.
 - A doc title should come from the first H1 heading when present; otherwise it should fall back to the filename stem.
 - A doc `ref` should be derived from the Markdown path relative to the configured doc source root, without the `.md` suffix.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,37 @@ path = "docs"
 include = ["guides/*.md", "runbooks/*.md"]
 ```
 
+Selectors are always evaluated relative to the configured source `path`:
+
+- `files` is an exact allowlist of source-relative files.
+- `include` and `exclude` are glob filters over those same source-relative paths.
+- If `files` is present, a path must be listed there before `include` / `exclude` are applied.
+- For `spec_bundle`, `files` entries must point to `spec.toml`.
+- For `markdown_docs`, `files` entries must point to `.md` files.
+
+Example for a mixed-layout repo without changing source roots:
+
+```toml
+[[sources]]
+name = "contracts"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "."
+files = [
+  "docs/guides/api-rate-limits.md",
+  "docs/runbooks/rate-limit-rollout.md",
+]
+
+[[sources]]
+name = "accepted-specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+files = ["rate-limit-v2/spec.toml", "burst-handling/spec.toml"]
+```
+
+Selectors narrow what gets indexed; they do not rewrite refs. For example, a docs source rooted at `.` still produces refs like `doc://docs/guides/api-rate-limits` even when `files` narrows the selection to one file.
+
 ## Commands
 
 Every command supports `--format json` for machine-readable output.

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -55,6 +55,9 @@ func renderPreviewSourcesResult(w io.Writer, result *source.PreviewResult) {
 
 	for i, preview := range result.Sources {
 		fmt.Fprintf(w, "source: %s | %s | root: %s | items: %d\n", preview.Name, preview.Kind, preview.Path, preview.ItemCount)
+		if len(preview.Files) > 0 {
+			fmt.Fprintf(w, "files: %s\n", strings.Join(preview.Files, ", "))
+		}
 		if len(preview.Include) > 0 {
 			fmt.Fprintf(w, "include: %s\n", strings.Join(preview.Include, ", "))
 		}

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+func TestRenderPreviewSourcesResultIncludesFiles(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	renderPreviewSourcesResult(&stdout, &source.PreviewResult{
+		Sources: []source.SourcePreview{
+			{
+				Name:      "docs",
+				Kind:      "markdown_docs",
+				Path:      ".",
+				Files:     []string{"docs/guides/api-rate-limits.md"},
+				ItemCount: 1,
+				Items: []source.PreviewItem{
+					{
+						ArtifactKind: "doc",
+						Path:         "docs/guides/api-rate-limits.md",
+					},
+				},
+			},
+		},
+	})
+
+	output := stdout.String()
+	if !strings.Contains(output, "files: docs/guides/api-rate-limits.md") {
+		t.Fatalf("renderPreviewSourcesResult() output %q does not contain files selector", output)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type Source struct {
 	Adapter      string
 	Kind         string
 	Path         string
+	Files        []string
 	Include      []string
 	Exclude      []string
 	ResolvedPath string
@@ -78,6 +79,7 @@ type rawSource struct {
 	adapter string
 	kind    string
 	paths   string
+	files   []string
 	include []string
 	exclude []string
 }
@@ -157,6 +159,7 @@ func Load(path string) (*Config, error) {
 			Adapter: source.adapter,
 			Kind:    source.kind,
 			Path:    source.paths,
+			Files:   append([]string(nil), source.files...),
 			Include: append([]string(nil), source.include...),
 			Exclude: append([]string(nil), source.exclude...),
 		})
@@ -336,7 +339,7 @@ func parseSourceField(source *rawSource, key, value string, lineNo int) error {
 
 func isSourceArrayField(key string) bool {
 	switch key {
-	case "include", "exclude":
+	case "files", "include", "exclude":
 		return true
 	default:
 		return false
@@ -345,6 +348,8 @@ func isSourceArrayField(key string) bool {
 
 func assignSourceArrayField(source *rawSource, key string, values []string) error {
 	switch key {
+	case "files":
+		source.files = append(source.files, values...)
 	case "include":
 		source.include = append(source.include, values...)
 	case "exclude":
@@ -515,6 +520,29 @@ func validate(cfg *Config) error {
 			errs.add("%s.path: value is required", label)
 			continue
 		}
+		files := make([]string, 0, len(source.Files))
+		seenFiles := make(map[string]struct{}, len(source.Files))
+		for i, value := range source.Files {
+			normalized, err := normalizeSourceFileSelector(value)
+			if err != nil {
+				errs.add("%s.files[%d]: %v", label, i, err)
+				continue
+			}
+			if source.Kind == SourceKindSpecBundle && pathpkg.Base(normalized) != "spec.toml" {
+				errs.add("%s.files[%d]: %q must point to a spec.toml file for kind %q", label, i, value, source.Kind)
+				continue
+			}
+			if source.Kind == SourceKindMarkdownDocs && pathpkg.Ext(normalized) != ".md" {
+				errs.add("%s.files[%d]: %q must point to a markdown file for kind %q", label, i, value, source.Kind)
+				continue
+			}
+			if _, exists := seenFiles[normalized]; exists {
+				continue
+			}
+			seenFiles[normalized] = struct{}{}
+			files = append(files, normalized)
+		}
+		source.Files = files
 		for _, pattern := range source.Include {
 			if strings.TrimSpace(pattern) == "" {
 				errs.add("%s.include: patterns must not be empty", label)
@@ -544,6 +572,16 @@ func validate(cfg *Config) error {
 		case err != nil:
 			errs.add("%s.path: %q does not exist", label, source.Path)
 		}
+		for i, relFile := range source.Files {
+			resolvedFile := resolvePath(source.ResolvedPath, filepath.FromSlash(relFile))
+			info, err := os.Stat(resolvedFile)
+			switch {
+			case err == nil && info.IsDir():
+				errs.add("%s.files[%d]: %q is a directory", label, i, relFile)
+			case err != nil:
+				errs.add("%s.files[%d]: %q does not exist", label, i, relFile)
+			}
+		}
 	}
 
 	if err := validateRuntime(cfg.Runtime); err != nil {
@@ -551,6 +589,25 @@ func validate(cfg *Config) error {
 	}
 
 	return errs.err()
+}
+
+func normalizeSourceFileSelector(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("value must not be empty")
+	}
+	if filepath.IsAbs(value) {
+		return "", fmt.Errorf("%q must be relative to the source root", value)
+	}
+
+	normalized := pathpkg.Clean(filepath.ToSlash(value))
+	if normalized == "." {
+		return "", fmt.Errorf("%q must point to a file under the source root", value)
+	}
+	if normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return "", fmt.Errorf("%q escapes the source root", value)
+	}
+	return normalized, nil
 }
 
 func validateRuntime(runtime Runtime) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -139,7 +139,7 @@ func TestLoadPreservesSourceSelectors(t *testing.T) {
 	t.Parallel()
 
 	repo := t.TempDir()
-	mustMkdirAll(t, filepath.Join(repo, "docs"))
+	mustMkdirAll(t, filepath.Join(repo, "docs", "guides"))
 	configPath := filepath.Join(repo, "pituitary.toml")
 	writeFile(t, configPath, `
 [workspace]
@@ -151,15 +151,20 @@ name = "docs"
 adapter = "filesystem"
 kind = "markdown_docs"
 path = "docs"
+files = ["guides/api-rate-limits.md"]
 include = ["guides/*.md", "runbooks/*.md"]
 exclude = ["runbooks/draft-*.md"]
 `)
+	writeFile(t, filepath.Join(repo, "docs", "guides", "api-rate-limits.md"), "# API Rate Limits\n")
 
 	cfg, err := Load(configPath)
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
 
+	if got, want := cfg.Sources[0].Files, []string{"guides/api-rate-limits.md"}; !equalStringSlices(got, want) {
+		t.Fatalf("files = %#v, want %#v", got, want)
+	}
 	if got, want := cfg.Sources[0].Include, []string{"guides/*.md", "runbooks/*.md"}; !equalStringSlices(got, want) {
 		t.Fatalf("include = %#v, want %#v", got, want)
 	}
@@ -193,6 +198,63 @@ include = ["["]
 	}
 	if !strings.Contains(err.Error(), `source "docs".include: invalid pattern "["`) {
 		t.Fatalf("Load() error = %q, want selector validation details", err)
+	}
+}
+
+func TestLoadRejectsInvalidSourceFileSelector(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "docs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+files = ["../guide.md"]
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want invalid file selector error")
+	}
+	if !strings.Contains(err.Error(), `source "docs".files[0]: "../guide.md" escapes the source root`) {
+		t.Fatalf("Load() error = %q, want invalid source-file selector detail", err)
+	}
+}
+
+func TestLoadRejectsSourceFileKindMismatch(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs", "rate-limit-v2"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+files = ["rate-limit-v2/body.md"]
+`)
+	writeFile(t, filepath.Join(repo, "specs", "rate-limit-v2", "body.md"), "Body\n")
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want selector kind mismatch error")
+	}
+	if !strings.Contains(err.Error(), `must point to a spec.toml file`) {
+		t.Fatalf("Load() error = %q, want selector kind mismatch detail", err)
 	}
 }
 

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -357,6 +357,18 @@ func loadMarkdownDocs(workspaceRoot string, source config.Source) ([]model.DocRe
 
 func sourcePathAllowed(source config.Source, relPath string) (bool, error) {
 	relPath = filepath.ToSlash(relPath)
+	if len(source.Files) > 0 {
+		matched := false
+		for _, file := range source.Files {
+			if file == relPath {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false, nil
+		}
+	}
 	if len(source.Include) > 0 {
 		matched := false
 		for _, pattern := range source.Include {

--- a/internal/source/filesystem_test.go
+++ b/internal/source/filesystem_test.go
@@ -499,6 +499,86 @@ exclude = ["runbooks/draft-*.md"]
 	}
 }
 
+func TestLoadFromConfigFiltersMarkdownDocsByExplicitFilesAndKeepsStableRefs(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "pituitary.toml"), `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "."
+files = ["docs/guides/api-rate-limits.md", "docs/runbooks/rate-limit-rollout.md"]
+`)
+	mustWriteFile(t, filepath.Join(repo, "docs", "guides", "api-rate-limits.md"), "# API Rate Limits\n")
+	mustWriteFile(t, filepath.Join(repo, "docs", "runbooks", "rate-limit-rollout.md"), "# Rollout\n")
+	mustWriteFile(t, filepath.Join(repo, "docs", "development", "testing-guide.md"), "# Testing Guide\n")
+
+	cfg, err := config.Load(filepath.Join(repo, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("LoadFromConfig() error = %v", err)
+	}
+	if got, want := len(result.Docs), 2; got != want {
+		t.Fatalf("doc count = %d, want %d", got, want)
+	}
+
+	refs := []string{result.Docs[0].Ref, result.Docs[1].Ref}
+	sort.Strings(refs)
+	wantRefs := []string{"doc://docs/guides/api-rate-limits", "doc://docs/runbooks/rate-limit-rollout"}
+	if !equalStrings(refs, wantRefs) {
+		t.Fatalf("doc refs = %#v, want %#v", refs, wantRefs)
+	}
+}
+
+func TestLoadFromConfigFiltersSpecBundlesByExplicitFiles(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := repoRoot(t)
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "pituitary.toml"), `
+[workspace]
+root = "`+filepath.ToSlash(repoRoot)+`"
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+files = ["rate-limit-v2/spec.toml", "burst-handling/spec.toml"]
+`)
+
+	cfg, err := config.Load(filepath.Join(repo, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("LoadFromConfig() error = %v", err)
+	}
+	if got, want := len(result.Specs), 2; got != want {
+		t.Fatalf("spec count = %d, want %d", got, want)
+	}
+
+	refs := []string{result.Specs[0].Ref, result.Specs[1].Ref}
+	sort.Strings(refs)
+	wantRefs := []string{"SPEC-042", "SPEC-055"}
+	if !equalStrings(refs, wantRefs) {
+		t.Fatalf("spec refs = %#v, want %#v", refs, wantRefs)
+	}
+}
+
 func TestPreviewFromConfigUsesSelectors(t *testing.T) {
 	t.Parallel()
 
@@ -531,6 +611,47 @@ func TestPreviewFromConfigUsesSelectors(t *testing.T) {
 	wantPaths := []string{"docs/guides/api-rate-limits.md", "docs/runbooks/rate-limit-rollout.md"}
 	if !equalStrings(paths, wantPaths) {
 		t.Fatalf("doc preview paths = %#v, want %#v", paths, wantPaths)
+	}
+}
+
+func TestPreviewFromConfigUsesExplicitFiles(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := repoRoot(t)
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "pituitary.toml"), `
+[workspace]
+root = "`+filepath.ToSlash(repoRoot)+`"
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+files = ["guides/api-rate-limits.md"]
+`)
+
+	cfg, err := config.Load(filepath.Join(repo, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := PreviewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("PreviewFromConfig() error = %v", err)
+	}
+	if got, want := len(result.Sources), 1; got != want {
+		t.Fatalf("source count = %d, want %d", got, want)
+	}
+	if got, want := result.Sources[0].Files, []string{"guides/api-rate-limits.md"}; !equalStrings(got, want) {
+		t.Fatalf("preview files = %#v, want %#v", got, want)
+	}
+	if got, want := result.Sources[0].ItemCount, 1; got != want {
+		t.Fatalf("item count = %d, want %d", got, want)
+	}
+	if got, want := result.Sources[0].Items[0].Path, "docs/guides/api-rate-limits.md"; got != want {
+		t.Fatalf("preview path = %q, want %q", got, want)
 	}
 }
 

--- a/internal/source/preview.go
+++ b/internal/source/preview.go
@@ -19,6 +19,7 @@ type SourcePreview struct {
 	Adapter   string        `json:"adapter"`
 	Kind      string        `json:"kind"`
 	Path      string        `json:"path"`
+	Files     []string      `json:"files,omitempty"`
 	Include   []string      `json:"include,omitempty"`
 	Exclude   []string      `json:"exclude,omitempty"`
 	ItemCount int           `json:"item_count"`
@@ -54,6 +55,7 @@ func previewSource(workspaceRoot string, source config.Source) (SourcePreview, e
 		Adapter: source.Adapter,
 		Kind:    source.Kind,
 		Path:    source.Path,
+		Files:   append([]string(nil), source.Files...),
 		Include: append([]string(nil), source.Include...),
 		Exclude: append([]string(nil), source.Exclude...),
 	}


### PR DESCRIPTION
## Summary
- add explicit `files` selectors to source config and validate them against the source kind
- apply `files` before `include` and `exclude` for both markdown docs and spec bundles while preserving stable refs
- document selector semantics and cover the new preview/render behavior with tests

## Testing
- go test ./...

Closes #23