### PR TITLE
Reduce whole-table scans in targeted analysis loads

### DIFF
--- a/internal/analysis/benchmark_test.go
+++ b/internal/analysis/benchmark_test.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dusk-network/pituitary/internal/config"
@@ -170,6 +171,44 @@ func BenchmarkReviewSpec(b *testing.B) {
 			}
 			if result.Overlap == nil || result.Impact == nil {
 				b.Fatalf("ReviewSpec() draft result = %+v, want composed output", result)
+			}
+		}
+	})
+}
+
+func BenchmarkLoadIndexedTargets(b *testing.B) {
+	fixture := prepareBenchmarkFixture(b)
+
+	db, err := index.OpenReadOnlyContext(context.Background(), fixture.cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		b.Fatalf("index.OpenReadOnlyContext() error = %v", err)
+	}
+	defer db.Close()
+
+	b.Run("specs_selected", func(b *testing.B) {
+		refs := []string{"SPEC-042", "SPEC-055"}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			specs, err := loadIndexedSpecsContext(context.Background(), db, refs)
+			if err != nil {
+				b.Fatalf("loadIndexedSpecsContext() error = %v", err)
+			}
+			if len(specs) != 2 {
+				b.Fatalf("loadIndexedSpecsContext() returned %d specs, want 2", len(specs))
+			}
+		}
+	})
+
+	b.Run("docs_selected", func(b *testing.B) {
+		refs := []string{"doc://guides/api-rate-limits", "doc://runbooks/rate-limit-rollout"}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			docs, err := loadIndexedDocsContext(context.Background(), db, refs)
+			if err != nil {
+				b.Fatalf("loadIndexedDocsContext() error = %v", err)
+			}
+			if len(docs) != 2 {
+				b.Fatalf("loadIndexedDocsContext() returned %d docs, want 2", len(docs))
 			}
 		}
 	})

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -288,13 +288,25 @@ func loadDocSections(db *sql.DB, docs map[string]docDocument) error {
 }
 
 func loadDocSectionsContext(ctx context.Context, db *sql.DB, docs map[string]docDocument) error {
-	rows, err := db.QueryContext(ctx, `
+	refs := sortedDocRefs(docs)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	var builder strings.Builder
+	args := make([]any, 0, 1+len(refs))
+	builder.WriteString(`
 SELECT c.artifact_ref, c.section, c.content, cv.embedding
 FROM chunks c
 JOIN chunks_vec cv ON cv.chunk_id = c.id
 JOIN artifacts a ON a.ref = c.artifact_ref
-WHERE a.kind = ?
-ORDER BY c.id`, model.ArtifactKindDoc)
+WHERE a.kind = ?`)
+	args = append(args, model.ArtifactKindDoc)
+	appendRefFilterClause(&builder, &args, "c.artifact_ref", refs)
+	builder.WriteString(`
+ORDER BY c.id`)
+
+	rows, err := db.QueryContext(ctx, builder.String(), args...)
 	if err != nil {
 		return fmt.Errorf("query doc sections: %w", err)
 	}

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -351,10 +351,22 @@ func loadSpecEdges(db *sql.DB, specs map[string]specDocument) error {
 }
 
 func loadSpecEdgesContext(ctx context.Context, db *sql.DB, specs map[string]specDocument) error {
-	rows, err := db.QueryContext(ctx, `
+	refs := sortedSpecRefs(specs)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	var builder strings.Builder
+	args := make([]any, 0, len(refs))
+	builder.WriteString(`
 SELECT from_ref, to_ref, edge_type
 FROM edges
 WHERE edge_type IN ('depends_on', 'supersedes', 'applies_to')`)
+	appendRefFilterClause(&builder, &args, "from_ref", refs)
+	builder.WriteString(`
+ORDER BY from_ref ASC, edge_type ASC, to_ref ASC`)
+
+	rows, err := db.QueryContext(ctx, builder.String(), args...)
 	if err != nil {
 		return fmt.Errorf("query spec edges: %w", err)
 	}
@@ -397,13 +409,25 @@ func loadSpecSections(db *sql.DB, specs map[string]specDocument) error {
 }
 
 func loadSpecSectionsContext(ctx context.Context, db *sql.DB, specs map[string]specDocument) error {
-	rows, err := db.QueryContext(ctx, `
+	refs := sortedSpecRefs(specs)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	var builder strings.Builder
+	args := make([]any, 0, 1+len(refs))
+	builder.WriteString(`
 SELECT c.artifact_ref, c.section, c.content, cv.embedding
 FROM chunks c
 JOIN chunks_vec cv ON cv.chunk_id = c.id
 JOIN artifacts a ON a.ref = c.artifact_ref
-WHERE a.kind = ?
-ORDER BY c.id`, model.ArtifactKindSpec)
+WHERE a.kind = ?`)
+	args = append(args, model.ArtifactKindSpec)
+	appendRefFilterClause(&builder, &args, "c.artifact_ref", refs)
+	builder.WriteString(`
+ORDER BY c.id`)
+
+	rows, err := db.QueryContext(ctx, builder.String(), args...)
 	if err != nil {
 		return fmt.Errorf("query spec sections: %w", err)
 	}
@@ -464,6 +488,33 @@ func overlapScore(candidate, target specDocument) float64 {
 		score = 0
 	}
 	return score
+}
+
+func sortedSpecRefs(specs map[string]specDocument) []string {
+	refs := make([]string, 0, len(specs))
+	for ref := range specs {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+func appendRefFilterClause(builder *strings.Builder, args *[]any, column string, refs []string) {
+	refs = uniqueStrings(refs)
+	if len(refs) == 0 {
+		return
+	}
+	builder.WriteString(" AND ")
+	builder.WriteString(column)
+	builder.WriteString(" IN (")
+	for i, ref := range refs {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString("?")
+		*args = append(*args, ref)
+	}
+	builder.WriteString(")")
 }
 
 func bestSectionOverlap(left, right []embeddedSection) float64 {

--- a/internal/analysis/repository_targeted_test.go
+++ b/internal/analysis/repository_targeted_test.go
@@ -1,0 +1,88 @@
+package analysis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+func TestLoadIndexedSpecsContextSelectedRefsLoadsOnlyRequestedSpec(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	db, err := index.OpenReadOnlyContext(context.Background(), cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("index.OpenReadOnlyContext() error = %v", err)
+	}
+	defer db.Close()
+
+	specs, err := loadIndexedSpecsContext(context.Background(), db, []string{"SPEC-042"})
+	if err != nil {
+		t.Fatalf("loadIndexedSpecsContext() error = %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("loadIndexedSpecsContext() returned %d specs, want 1", len(specs))
+	}
+
+	spec, ok := specs["SPEC-042"]
+	if !ok {
+		t.Fatalf("loaded specs = %+v, want SPEC-042", specs)
+	}
+	if len(spec.Record.AppliesTo) == 0 {
+		t.Fatalf("SPEC-042 applies_to = %v, want hydrated edges", spec.Record.AppliesTo)
+	}
+	if len(spec.Sections) == 0 {
+		t.Fatalf("SPEC-042 sections = %v, want hydrated sections", spec.Sections)
+	}
+	if _, ok := specs["SPEC-055"]; ok {
+		t.Fatalf("loaded specs = %+v, did not expect unrelated SPEC-055", specs)
+	}
+}
+
+func TestLoadIndexedDocsContextSelectedRefsLoadsOnlyRequestedDoc(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	db, err := index.OpenReadOnlyContext(context.Background(), cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("index.OpenReadOnlyContext() error = %v", err)
+	}
+	defer db.Close()
+
+	docs, err := loadIndexedDocsContext(context.Background(), db, []string{"doc://guides/api-rate-limits"})
+	if err != nil {
+		t.Fatalf("loadIndexedDocsContext() error = %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("loadIndexedDocsContext() returned %d docs, want 1", len(docs))
+	}
+
+	doc, ok := docs["doc://guides/api-rate-limits"]
+	if !ok {
+		t.Fatalf("loaded docs = %+v, want guides/api-rate-limits", docs)
+	}
+	if len(doc.Sections) == 0 {
+		t.Fatalf("doc sections = %v, want hydrated sections", doc.Sections)
+	}
+	if _, ok := docs["doc://runbooks/rate-limit-rollout"]; ok {
+		t.Fatalf("loaded docs = %+v, did not expect unrelated runbook", docs)
+	}
+}


### PR DESCRIPTION
## Summary
- filter targeted spec edge and section loads by the selected refs instead of scanning whole tables
- filter targeted doc section loads by the selected refs instead of scanning whole tables
- add focused loader tests for selected-ref hydration
- add a benchmark for the targeted spec/doc loader hot paths

## Validation
- `go test ./...`
- `go test ./internal/analysis -run 'TestLoadIndexed(Specs|Docs)ContextSelectedRefsLoadsOnlyRequested|TestCheckDocDriftSupportsTargetedDocRefs|TestAnalyzeImpactFindsDependentSpecsRefsAndDocs|TestCheckOverlapDetectsKnownFixtureOverlap' -bench 'BenchmarkLoadIndexedTargets' -benchtime=1x`

Closes #28