### PR TITLE
Add release automation for tagged binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+
+      - name: Validate release configuration
+        run: goreleaser check
+
       - name: Run formatting check
         run: make fmt-check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs_on: ubuntu-latest
+            release_runner_os: linux
+            artifact_name: release-linux
+          - runs_on: macos-14
+            release_runner_os: darwin
+            artifact_name: release-macos
+          - runs_on: windows-latest
+            release_runner_os: windows
+            artifact_name: release-windows
+
+    runs-on: ${{ matrix.runs_on }}
+    env:
+      PITUITARY_RELEASE_RUNNER_OS: ${{ matrix.release_runner_os }}
+    steps:
+      - name: Disable CRLF conversion for MSYS2 builds
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf input
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Windows CGO toolchain
+        id: msys2
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+
+      - name: Run GoReleaser packaging
+        if: runner.os != 'Windows'
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=publish --skip=announce
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser packaging
+        if: runner.os == 'Windows'
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=publish --skip=announce
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CC: ${{ runner.os == 'Windows' && format('{0}/ucrt64/bin/gcc.exe', steps.msys2.outputs.msys2-location) || '' }}
+
+      - name: Upload packaged artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+          if-no-files-found: error
+
+  publish:
+    needs: package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist/release
+
+      - name: Generate release checksums
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          cd dist/release
+          sha256sum *.tar.gz *.zip > "pituitary_${TAG}_checksums.txt"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/release/* --clobber
+          else
+            gh release create "$TAG" --verify-tag --generate-notes dist/release/*
+          fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,71 @@
+version: 2
+
+project_name: pituitary
+
+builds:
+  - id: linux-amd64
+    main: .
+    binary: pituitary
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/dusk-network/pituitary/cmd.Version={{ .Version }} -X github.com/dusk-network/pituitary/cmd.Commit={{ .FullCommit }} -X github.com/dusk-network/pituitary/cmd.BuildDate={{ .Date }} -X github.com/dusk-network/pituitary/internal/mcp.serverVersion={{ .Version }}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    skip: '{{ if index .Env "PITUITARY_RELEASE_RUNNER_OS" }}{{ ne .Env.PITUITARY_RELEASE_RUNNER_OS "linux" }}{{ else }}false{{ end }}'
+
+  - id: darwin-arm64
+    main: .
+    binary: pituitary
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/dusk-network/pituitary/cmd.Version={{ .Version }} -X github.com/dusk-network/pituitary/cmd.Commit={{ .FullCommit }} -X github.com/dusk-network/pituitary/cmd.BuildDate={{ .Date }} -X github.com/dusk-network/pituitary/internal/mcp.serverVersion={{ .Version }}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    skip: '{{ if index .Env "PITUITARY_RELEASE_RUNNER_OS" }}{{ ne .Env.PITUITARY_RELEASE_RUNNER_OS "darwin" }}{{ else }}false{{ end }}'
+
+  - id: windows-amd64
+    main: .
+    binary: pituitary
+    goos:
+      - windows
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/dusk-network/pituitary/cmd.Version={{ .Version }} -X github.com/dusk-network/pituitary/cmd.Commit={{ .FullCommit }} -X github.com/dusk-network/pituitary/cmd.BuildDate={{ .Date }} -X github.com/dusk-network/pituitary/internal/mcp.serverVersion={{ .Version }}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    skip: '{{ if index .Env "PITUITARY_RELEASE_RUNNER_OS" }}{{ ne .Env.PITUITARY_RELEASE_RUNNER_OS "windows" }}{{ else }}false{{ end }}'
+
+archives:
+  - ids:
+      - linux-amd64
+      - darwin-arm64
+      - windows-amd64
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os \"darwin\" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}"
+
+checksum:
+  disable: true
+
+source:
+  enabled: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ Contributor docs:
 - [docs/development/architecture-guide.md](docs/development/architecture-guide.md)
 - [docs/development/testing-guide.md](docs/development/testing-guide.md)
 - [docs/development/adding-a-command.md](docs/development/adding-a-command.md)
+- [docs/development/releasing.md](docs/development/releasing.md)
 
 ## Project Structure
 
@@ -116,6 +117,12 @@ Tests use a **deterministic fixture provider** — no live API keys or network a
 - Run the smallest check that proves your change works.
 
 If a command needs live AI to function, ensure it fails gracefully with `dependency_unavailable` when the provider is absent.
+
+## Release Process
+
+Maintainers cut releases by pushing an annotated `v*` tag from `main`. The tag-driven workflow packages prebuilt archives with GoReleaser and publishes them to GitHub Releases.
+
+See [docs/development/releasing.md](docs/development/releasing.md) for the exact steps and the currently automated platform targets.
 
 ## Submitting a PR
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Pituitary keeps your specifications, code, and documentation from drifting out o
 
 It ships as a single Go binary — no Docker, no external services. Just `pituitary` and one SQLite file.
 
+Prebuilt release archives are published on [GitHub Releases](https://github.com/dusk-network/pituitary/releases) for `linux/amd64`, `darwin/arm64`, and `windows/amd64` if you want to evaluate the CLI without building from source.
+
 ## Why
 
 Specs are easy to write and hard to maintain. As a corpus grows, common problems emerge:

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,0 +1,39 @@
+# Releasing Pituitary
+
+Pituitary releases are tag-driven and produce prebuilt archives so users can evaluate the tool without building it from source.
+
+## Automated Targets
+
+The current release workflow publishes one archive per supported platform:
+
+- `linux/amd64`
+- `darwin/arm64`
+- `windows/amd64`
+
+Each archive is built from the checked-in [/.goreleaser.yaml](../../.goreleaser.yaml) configuration, and the workflow also uploads a combined SHA-256 checksum manifest for the tagged release.
+
+## Release Workflow
+
+1. Make sure the branch you want to release is already merged to `main`.
+2. Pull the latest `main` locally.
+3. Create and push an annotated SemVer tag such as `v0.2.0`.
+
+```sh
+git switch main
+git pull --ff-only origin main
+git tag -a v0.2.0 -m "Release v0.2.0"
+git push origin v0.2.0
+```
+
+Pushing the tag triggers [/.github/workflows/release.yml](../../.github/workflows/release.yml), which:
+
+- runs GoReleaser packaging on Linux, macOS, and Windows runners
+- injects the tag, commit, and build date into the binary metadata
+- uploads the versioned archives to a GitHub release for that tag
+- publishes `pituitary_<tag>_checksums.txt` alongside the archives
+
+## Validation
+
+Pull requests and pushes to `main` validate the checked-in GoReleaser configuration with `goreleaser check` in [/.github/workflows/ci.yml](../../.github/workflows/ci.yml).
+
+That validation is intentionally lighter than a full tagged release: it checks the config shape without requiring a release tag or publishing artifacts.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -14,8 +14,10 @@ import (
 const (
 	defaultConfigPath = "pituitary.toml"
 	serverName        = "Pituitary"
-	serverVersion     = "0.1.0"
 )
+
+// serverVersion defaults to "dev" and can be overridden at build time with -ldflags.
+var serverVersion = "dev"
 
 var sqliteReadyCheck = index.CheckSQLiteReady
 


### PR DESCRIPTION
## Summary
- add a checked-in GoReleaser config for tagged Linux, macOS, and Windows archives
- add a tag-driven release workflow plus CI validation for the release config
- document the release process and align MCP build metadata with release versioning

## Testing
- go test ./internal/mcp -count=1

Closes #22