### PR TITLE
[feature] Add OpenAI-compatible embedder support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -393,34 +393,36 @@ Step 6: Atomic Swap
 
 **Bootstrap runtime contract (current implementation):**
 
-- The current bootstrap supports one embedder provider: `fixture`.
+- The current runtime supports two embedder providers: `fixture` and `openai_compatible`.
 - `runtime.analysis` is part of the config shape for forward compatibility, but it must currently be `disabled`.
 - Shipped analysis commands are deterministic today and do not call an external qualitative-analysis provider.
 - Tests and CI should use the deterministic fixture embedder and require no live model credentials.
 - Unsupported runtime providers should fail during config validation with clear, intentional errors.
-- A richer provider boundary remains a future design goal, but it is not part of the current runtime contract.
+- Provider-backed embeddings are now part of the runtime contract; provider-backed analysis remains a future design goal.
 
 V1 runtime configuration should be explicit in `pituitary.toml` under `[runtime.embedder]` and `[runtime.analysis]`:
 
 | Field | Embedder | Analysis | Notes |
 |---|---|---|---|
-| `provider` | optional, defaults to `fixture` | optional, defaults to `disabled` | Any other value is rejected in the bootstrap |
-| `model` | optional, defaults to `fixture-8d` | ignored when analysis is disabled | Kept in the config shape for forward compatibility |
-| `endpoint` | optional | optional | Parsed but unused in the bootstrap runtime |
-| `api_key_env` | optional | optional | Parsed but unused in the bootstrap runtime |
-| `timeout_ms` | optional, defaults to `1000` | optional, defaults to `1000` | Reserved for later provider-backed runtime work |
-| `max_retries` | optional, defaults to `0` | optional, defaults to `0` | Reserved for later provider-backed runtime work |
+| `provider` | optional, defaults to `fixture` | optional, defaults to `disabled` | Embedder currently supports `fixture` and `openai_compatible` |
+| `model` | defaults to `fixture-8d` for `fixture`; required for `openai_compatible` | ignored when analysis is disabled | Part of the embedder fingerprint stored in index metadata |
+| `endpoint` | required for `openai_compatible`, ignored for `fixture` | optional | Expected to point at an OpenAI-compatible API root such as `http://host:1234/v1` |
+| `api_key_env` | optional | optional | Optional so local servers such as LM Studio can run without credentials |
+| `timeout_ms` | optional, defaults to `1000` | optional, defaults to `1000` | Active for `openai_compatible` embedding requests |
+| `max_retries` | optional, defaults to `0` | optional, defaults to `0` | Active for retryable `openai_compatible` embedding failures |
 
 Degraded behavior rules:
 
 - The `fixture` embedder must be deterministic, require no network access, and be the default mode for CI and local tests.
 - Unsupported embedder or analysis providers must fail during config validation rather than degrading silently.
+- Indexed metadata must store both embedder dimension and embedder fingerprint so provider/model changes fail clearly and require a rebuild.
 - Future provider-backed analysis work should preserve the current storage and transport contracts rather than widening them implicitly.
 
 Retry and timeout rules:
 
-- `timeout_ms` and `max_retries` are parsed today so the config shape does not need a second contract change when richer providers are added.
-- The bootstrap runtime itself does not issue network requests, so those fields are currently inert.
+- `timeout_ms` and `max_retries` remain parsed for both runtime blocks so the config shape does not need a second contract change later.
+- For `openai_compatible` embeddings, those fields control the HTTP client timeout and retry behavior.
+- For `fixture` embeddings and `disabled` analysis, those fields remain inert.
 
 **Chunking strategy:** The current implementation uses a lightweight internal Markdown scanner that splits on ATX headings, preserves the nested heading path in each section title, and falls back to one title-scoped chunk when a document has no headings. For non-Markdown inputs, adapters should either provide text with lightweight structural markers or let the chunker fall back to paragraph-based splitting.
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Add to your MCP client config (e.g., Claude Code `settings.json`):
 
 Pituitary's current bootstrap runtime is intentionally narrow and deterministic:
 
-- **Embedder** — `fixture` only. This deterministic embedder is the only supported runtime provider today.
+- **Embedder** — `fixture` by default, with optional `openai_compatible` support for real embeddings.
 - **Analysis** — `disabled` only. The shipped analysis commands are deterministic and do not call an external qualitative-analysis provider yet.
 
 The runtime blocks are optional. If omitted, Pituitary defaults to:
@@ -261,9 +261,27 @@ model = "fixture-8d"
 provider = "disabled"
 ```
 
-Fields such as `endpoint`, `api_key_env`, `timeout_ms`, and `max_retries` remain in the config shape for future runtime work, but non-bootstrap providers are currently rejected during config validation.
+For `fixture`, `endpoint`, `api_key_env`, `timeout_ms`, and `max_retries` remain inert bootstrap fields. For `openai_compatible`, Pituitary uses them for the embeddings API call path.
 
-This means the repo works out of the box with no model credentials. If you configure any provider other than `fixture` for `runtime.embedder` or `disabled` for `runtime.analysis`, Pituitary fails fast with a clear unsupported-provider error.
+This means the repo still works out of the box with no model credentials. Today:
+
+- `runtime.embedder.provider` supports `fixture` and `openai_compatible`
+- `runtime.analysis.provider` supports only `disabled`
+
+For `openai_compatible` embeddings, `model` and `endpoint` are required. `api_key_env` is optional so local servers such as LM Studio can work without a token. Pituitary stores an embedder fingerprint in the index and requires `pituitary index --rebuild` when the configured embedder changes.
+
+Example local embedding setup against LM Studio:
+
+```toml
+[runtime.embedder]
+provider = "openai_compatible"
+model = "pituitary-embed"
+endpoint = "http://100.92.91.40:1234/v1"
+timeout_ms = 30000
+max_retries = 1
+```
+
+For Nomic-compatible models such as `nomic-embed-text-v1.5`, Pituitary automatically applies the required `search_document:` and `search_query:` prefixes when calling the embeddings endpoint.
 
 ## Architecture
 

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -230,7 +230,7 @@ provider = "fixture"
 	}
 }
 
-func TestRunIndexRejectsUnsupportedEmbedderProvider(t *testing.T) {
+func TestRunIndexRejectsOpenAICompatibleEmbedderWithoutEndpoint(t *testing.T) {
 	repo := t.TempDir()
 	mustWriteIndexFixture(t, repo, `
 [workspace]
@@ -264,8 +264,8 @@ path = "specs"
 	if !strings.Contains(stderr.String(), `pituitary index: invalid config:`) {
 		t.Fatalf("runIndex() stderr %q does not contain config-error prefix", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), `runtime.embedder.provider: unsupported provider "openai_compatible"`) {
-		t.Fatalf("runIndex() stderr %q does not contain unsupported-provider detail", stderr.String())
+	if !strings.Contains(stderr.String(), `runtime.embedder.endpoint: value is required for provider "openai_compatible"`) {
+		t.Fatalf("runIndex() stderr %q does not contain missing-endpoint detail", stderr.String())
 	}
 }
 

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -294,7 +294,7 @@ func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, p
 		texts = append(texts, textForEmbedding(relPath, relPath, string(data)))
 	}
 
-	vectors, err := embedder.EmbedTexts(ctx, texts)
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
 		return nil, fmt.Errorf("embed code paths: %w", err)
 	}
@@ -329,7 +329,7 @@ func loadDiffComplianceTargetsContext(ctx context.Context, diffText string, embe
 		return nil, fmt.Errorf("diff_text does not contain any changed paths with readable content")
 	}
 
-	vectors, err := embedder.EmbedTexts(ctx, texts)
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
 		return nil, fmt.Errorf("embed diff paths: %w", err)
 	}

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -208,7 +208,7 @@ func loadCandidate(repo *analysisRepository, request OverlapRequest, specs map[s
 	for _, section := range sections {
 		texts = append(texts, textForEmbedding(record.Title, section.Heading, section.Body))
 	}
-	vectors, err := embedder.EmbedTexts(repo.ctx, texts)
+	vectors, err := embedder.EmbedDocuments(repo.ctx, texts)
 	if err != nil {
 		return nil, fmt.Errorf("embed draft spec %s: %w", record.Ref, err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	pathpkg "path"
 	"path/filepath"
@@ -16,6 +17,9 @@ const (
 	SourceKindSpecBundle       = "spec_bundle"
 	SourceKindMarkdownDocs     = "markdown_docs"
 	SourceKindMarkdownContract = "markdown_contract"
+	RuntimeProviderFixture     = "fixture"
+	RuntimeProviderOpenAI      = "openai_compatible"
+	RuntimeProviderDisabled    = "disabled"
 )
 
 // Config is the validated workspace configuration resolved from pituitary.toml.
@@ -136,15 +140,15 @@ func Load(path string) (*Config, error) {
 		},
 		Runtime: Runtime{
 			Embedder: RuntimeProvider{
-				Provider:   defaultString(raw.runtimeEmbedder.provider, "fixture"),
-				Model:      defaultString(raw.runtimeEmbedder.model, "fixture-8d"),
+				Provider:   defaultString(raw.runtimeEmbedder.provider, RuntimeProviderFixture),
+				Model:      raw.runtimeEmbedder.model,
 				Endpoint:   raw.runtimeEmbedder.endpoint,
 				APIKeyEnv:  raw.runtimeEmbedder.apiKeyEnv,
 				TimeoutMS:  defaultInt(raw.runtimeEmbedder.timeoutMS, 1000),
 				MaxRetries: raw.runtimeEmbedder.maxRetries,
 			},
 			Analysis: RuntimeProvider{
-				Provider:   defaultString(raw.runtimeAnalysis.provider, "disabled"),
+				Provider:   defaultString(raw.runtimeAnalysis.provider, RuntimeProviderDisabled),
 				Model:      raw.runtimeAnalysis.model,
 				Endpoint:   raw.runtimeAnalysis.endpoint,
 				APIKeyEnv:  raw.runtimeAnalysis.apiKeyEnv,
@@ -164,6 +168,9 @@ func Load(path string) (*Config, error) {
 			Include: append([]string(nil), source.include...),
 			Exclude: append([]string(nil), source.exclude...),
 		})
+	}
+	if cfg.Runtime.Embedder.Provider == RuntimeProviderFixture && strings.TrimSpace(cfg.Runtime.Embedder.Model) == "" {
+		cfg.Runtime.Embedder.Model = "fixture-8d"
 	}
 
 	if err := validate(cfg); err != nil {
@@ -636,12 +643,34 @@ func validateRuntime(runtime Runtime) error {
 		errs.add("runtime.embedder.provider: value is required")
 	} else {
 		switch runtime.Embedder.Provider {
-		case "fixture":
+		case RuntimeProviderFixture:
 			if runtime.Embedder.Model == "" {
 				errs.add("runtime.embedder.model: value is required for provider %q", runtime.Embedder.Provider)
 			}
+		case RuntimeProviderOpenAI:
+			if runtime.Embedder.Model == "" {
+				errs.add("runtime.embedder.model: value is required for provider %q", runtime.Embedder.Provider)
+			}
+			if endpoint := strings.TrimSpace(runtime.Embedder.Endpoint); endpoint == "" {
+				errs.add("runtime.embedder.endpoint: value is required for provider %q", runtime.Embedder.Provider)
+			} else {
+				parsed, err := url.Parse(endpoint)
+				switch {
+				case err != nil:
+					errs.add("runtime.embedder.endpoint: invalid URL %q: %v", runtime.Embedder.Endpoint, err)
+				case !parsed.IsAbs() || parsed.Host == "":
+					errs.add("runtime.embedder.endpoint: %q must be an absolute URL", runtime.Embedder.Endpoint)
+				case parsed.Scheme != "http" && parsed.Scheme != "https":
+					errs.add("runtime.embedder.endpoint: %q must use http or https", runtime.Embedder.Endpoint)
+				}
+			}
 		default:
-			errs.add("runtime.embedder.provider: unsupported provider %q (the bootstrap currently supports only %q)", runtime.Embedder.Provider, "fixture")
+			errs.add(
+				"runtime.embedder.provider: unsupported provider %q (supported providers: %q, %q)",
+				runtime.Embedder.Provider,
+				RuntimeProviderFixture,
+				RuntimeProviderOpenAI,
+			)
 		}
 	}
 	if runtime.Embedder.TimeoutMS < 0 {
@@ -653,8 +682,8 @@ func validateRuntime(runtime Runtime) error {
 
 	if runtime.Analysis.Provider == "" {
 		errs.add("runtime.analysis.provider: value is required")
-	} else if runtime.Analysis.Provider != "disabled" {
-		errs.add("runtime.analysis.provider: unsupported provider %q (the bootstrap currently supports only %q)", runtime.Analysis.Provider, "disabled")
+	} else if runtime.Analysis.Provider != RuntimeProviderDisabled {
+		errs.add("runtime.analysis.provider: unsupported provider %q (the bootstrap currently supports only %q)", runtime.Analysis.Provider, RuntimeProviderDisabled)
 	}
 	if runtime.Analysis.TimeoutMS < 0 {
 		errs.add("runtime.analysis.timeout_ms: must be >= 0")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -387,7 +387,7 @@ provider = "fixture"
 	}
 }
 
-func TestLoadRejectsUnsupportedEmbedderProvider(t *testing.T) {
+func TestLoadAcceptsOpenAICompatibleEmbedderProvider(t *testing.T) {
 	t.Parallel()
 
 	repo := t.TempDir()
@@ -400,6 +400,72 @@ index_path = ".pituitary/pituitary.db"
 
 [runtime.embedder]
 provider = "openai_compatible"
+model = "pituitary-embed"
+endpoint = "http://100.92.91.40:1234/v1"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+	if got, want := cfg.Runtime.Embedder.Provider, RuntimeProviderOpenAI; got != want {
+		t.Fatalf("runtime.embedder.provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Runtime.Embedder.Endpoint, "http://100.92.91.40:1234/v1"; got != want {
+		t.Fatalf("runtime.embedder.endpoint = %q, want %q", got, want)
+	}
+}
+
+func TestLoadRejectsOpenAICompatibleEmbedderWithoutEndpoint(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "openai_compatible"
+model = "pituitary-embed"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want runtime validation error")
+	}
+	if !strings.Contains(err.Error(), `runtime.embedder.endpoint: value is required for provider "openai_compatible"`) {
+		t.Fatalf("Load() error = %q, want embedder endpoint detail", err)
+	}
+}
+
+func TestLoadRejectsUnsupportedEmbedderProvider(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "anthropic"
 model = "text-embedding-3-small"
 
 [[sources]]
@@ -413,11 +479,11 @@ path = "specs"
 	if err == nil {
 		t.Fatal("Load() error = nil, want runtime validation error")
 	}
-	if !strings.Contains(err.Error(), `runtime.embedder.provider: unsupported provider "openai_compatible"`) {
+	if !strings.Contains(err.Error(), `runtime.embedder.provider: unsupported provider "anthropic"`) {
 		t.Fatalf("Load() error = %q, want embedder provider detail", err)
 	}
-	if !strings.Contains(err.Error(), `supports only "fixture"`) {
-		t.Fatalf("Load() error = %q, want bootstrap support detail", err)
+	if !strings.Contains(err.Error(), `supported providers: "fixture", "openai_compatible"`) {
+		t.Fatalf("Load() error = %q, want provider list", err)
 	}
 }
 

--- a/internal/index/embedder.go
+++ b/internal/index/embedder.go
@@ -30,21 +30,30 @@ func IsDependencyUnavailable(err error) bool {
 
 // Embedder generates embeddings for rebuild and query-time retrieval.
 type Embedder interface {
-	Dimension() int
-	EmbedTexts(ctx context.Context, texts []string) ([][]float64, error)
+	Fingerprint() string
+	Dimension(ctx context.Context) (int, error)
+	EmbedDocuments(ctx context.Context, texts []string) ([][]float64, error)
+	EmbedQueries(ctx context.Context, texts []string) ([][]float64, error)
 }
 
 // NewEmbedder resolves the configured embedder runtime.
 func NewEmbedder(provider config.RuntimeProvider) (Embedder, error) {
 	switch provider.Provider {
-	case "", "fixture":
+	case "", config.RuntimeProviderFixture:
 		dimension, err := fixtureDimension(provider.Model)
 		if err != nil {
 			return nil, err
 		}
-		return fixtureEmbedder{dimension: dimension}, nil
+		return fixtureEmbedder{dimension: dimension, model: provider.Model}, nil
+	case config.RuntimeProviderOpenAI:
+		return newOpenAICompatibleEmbedder(provider)
 	default:
-		return nil, fmt.Errorf("runtime.embedder.provider %q is not supported in the bootstrap; use %q", provider.Provider, "fixture")
+		return nil, fmt.Errorf(
+			"runtime.embedder.provider %q is not supported; supported providers are %q and %q",
+			provider.Provider,
+			config.RuntimeProviderFixture,
+			config.RuntimeProviderOpenAI,
+		)
 	}
 }
 
@@ -54,13 +63,26 @@ func newEmbedder(provider config.RuntimeProvider) (Embedder, error) {
 
 type fixtureEmbedder struct {
 	dimension int
+	model     string
 }
 
-func (e fixtureEmbedder) Dimension() int {
-	return e.dimension
+func (e fixtureEmbedder) Fingerprint() string {
+	return embedderFingerprint(config.RuntimeProviderFixture, e.model, "plain_v1")
 }
 
-func (e fixtureEmbedder) EmbedTexts(ctx context.Context, texts []string) ([][]float64, error) {
+func (e fixtureEmbedder) Dimension(ctx context.Context) (int, error) {
+	return e.dimension, nil
+}
+
+func (e fixtureEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float64, error) {
+	return e.embedTexts(ctx, texts)
+}
+
+func (e fixtureEmbedder) EmbedQueries(ctx context.Context, texts []string) ([][]float64, error) {
+	return e.embedTexts(ctx, texts)
+}
+
+func (e fixtureEmbedder) embedTexts(ctx context.Context, texts []string) ([][]float64, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -72,6 +94,10 @@ func (e fixtureEmbedder) EmbedTexts(ctx context.Context, texts []string) ([][]fl
 		vectors = append(vectors, fixtureVector(text, e.dimension))
 	}
 	return vectors, nil
+}
+
+func embedderFingerprint(provider, model, strategy string) string {
+	return fmt.Sprintf("%s|%s|%s", strings.TrimSpace(provider), strings.TrimSpace(model), strings.TrimSpace(strategy))
 }
 
 func fixtureVector(text string, dimension int) []float64 {

--- a/internal/index/openai_embedder.go
+++ b/internal/index/openai_embedder.go
@@ -1,0 +1,314 @@
+package index
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+const (
+	embeddingStrategyPlain             = "plain_v1"
+	embeddingStrategyNomicSearchPrefix = "nomic_search_prefix_v1"
+)
+
+type openAICompatibleEmbedder struct {
+	model      string
+	endpoint   string
+	token      string
+	maxRetries int
+	strategy   string
+	client     *http.Client
+
+	mu        sync.Mutex
+	dimension int
+}
+
+type openAICompatibleEmbeddingsRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type openAICompatibleEmbeddingsResponse struct {
+	Data []openAICompatibleEmbedding `json:"data"`
+	Err  *openAICompatibleErrorBody  `json:"error,omitempty"`
+}
+
+type openAICompatibleEmbedding struct {
+	Embedding []float64 `json:"embedding"`
+	Index     int       `json:"index"`
+}
+
+type openAICompatibleErrorBody struct {
+	Message string `json:"message"`
+}
+
+func newOpenAICompatibleEmbedder(provider config.RuntimeProvider) (Embedder, error) {
+	token := ""
+	if envVar := strings.TrimSpace(provider.APIKeyEnv); envVar != "" {
+		token = strings.TrimSpace(os.Getenv(envVar))
+		if token == "" {
+			return nil, &DependencyUnavailableError{Message: "missing API key for runtime.embedder"}
+		}
+	}
+
+	client := &http.Client{}
+	if provider.TimeoutMS > 0 {
+		client.Timeout = time.Duration(provider.TimeoutMS) * time.Millisecond
+	}
+
+	return &openAICompatibleEmbedder{
+		model:      strings.TrimSpace(provider.Model),
+		endpoint:   strings.TrimRight(strings.TrimSpace(provider.Endpoint), "/"),
+		token:      token,
+		maxRetries: provider.MaxRetries,
+		strategy:   embeddingStrategyForModel(provider.Model),
+		client:     client,
+	}, nil
+}
+
+func (e *openAICompatibleEmbedder) Fingerprint() string {
+	return embedderFingerprint(config.RuntimeProviderOpenAI, e.model, e.strategy)
+}
+
+func (e *openAICompatibleEmbedder) Dimension(ctx context.Context) (int, error) {
+	if dimension := e.cachedDimension(); dimension > 0 {
+		return dimension, nil
+	}
+
+	vectors, err := e.EmbedQueries(ctx, []string{"dimension probe"})
+	if err != nil {
+		return 0, err
+	}
+	if len(vectors) != 1 || len(vectors[0]) == 0 {
+		return 0, &DependencyUnavailableError{Message: "runtime.embedder returned no embedding dimensions"}
+	}
+	return len(vectors[0]), nil
+}
+
+func (e *openAICompatibleEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float64, error) {
+	return e.embedTexts(ctx, "document", texts)
+}
+
+func (e *openAICompatibleEmbedder) EmbedQueries(ctx context.Context, texts []string) ([][]float64, error) {
+	return e.embedTexts(ctx, "query", texts)
+}
+
+func (e *openAICompatibleEmbedder) embedTexts(ctx context.Context, purpose string, texts []string) ([][]float64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if len(texts) == 0 {
+		return [][]float64{}, nil
+	}
+
+	input := make([]string, 0, len(texts))
+	for _, text := range texts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		input = append(input, prepareEmbeddingInput(e.strategy, purpose, text))
+	}
+
+	body, err := json.Marshal(openAICompatibleEmbeddingsRequest{
+		Model: e.model,
+		Input: input,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode runtime.embedder request: %w", err)
+	}
+
+	payload, err := e.requestEmbeddings(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	if len(payload.Data) != len(input) {
+		return nil, &DependencyUnavailableError{
+			Message: fmt.Sprintf("runtime.embedder returned %d embedding(s) for %d input(s)", len(payload.Data), len(input)),
+		}
+	}
+
+	vectors := make([][]float64, len(input))
+	for i, item := range payload.Data {
+		index := item.Index
+		if index < 0 || index >= len(input) {
+			index = i
+		}
+		if len(item.Embedding) == 0 {
+			return nil, &DependencyUnavailableError{
+				Message: fmt.Sprintf("runtime.embedder returned an empty embedding for input %d", index),
+			}
+		}
+		if err := e.cacheDimension(len(item.Embedding)); err != nil {
+			return nil, err
+		}
+		vectors[index] = item.Embedding
+	}
+	for i, vector := range vectors {
+		if len(vector) == 0 {
+			return nil, &DependencyUnavailableError{
+				Message: fmt.Sprintf("runtime.embedder omitted embedding for input %d", i),
+			}
+		}
+	}
+	return vectors, nil
+}
+
+func (e *openAICompatibleEmbedder) requestEmbeddings(ctx context.Context, body []byte) (*openAICompatibleEmbeddingsResponse, error) {
+	var lastErr error
+
+	for attempt := 0; attempt <= e.maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint+"/embeddings", bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("build runtime.embedder request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if e.token != "" {
+			req.Header.Set("Authorization", "Bearer "+e.token)
+		}
+
+		resp, err := e.client.Do(req)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) && ctx.Err() != nil {
+				return nil, err
+			}
+			lastErr = &DependencyUnavailableError{
+				Message: fmt.Sprintf("call runtime.embedder endpoint %s: %v", e.endpoint, err),
+			}
+			if shouldRetryOpenAICompatibleRequest(err, 0) && attempt < e.maxRetries {
+				continue
+			}
+			return nil, lastErr
+		}
+
+		payload, err := readOpenAICompatibleEmbeddingsResponse(resp)
+		resp.Body.Close()
+		if err == nil {
+			return payload, nil
+		}
+		lastErr = err
+		if shouldRetryOpenAICompatibleRequest(err, resp.StatusCode) && attempt < e.maxRetries {
+			continue
+		}
+		return nil, err
+	}
+
+	if lastErr == nil {
+		lastErr = &DependencyUnavailableError{Message: "runtime.embedder request failed"}
+	}
+	return nil, lastErr
+}
+
+func readOpenAICompatibleEmbeddingsResponse(resp *http.Response) (*openAICompatibleEmbeddingsResponse, error) {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, &DependencyUnavailableError{Message: fmt.Sprintf("read runtime.embedder response: %v", err)}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message := extractOpenAICompatibleError(body)
+		if message == "" {
+			message = strings.TrimSpace(string(body))
+		}
+		if message == "" {
+			message = http.StatusText(resp.StatusCode)
+		}
+		return nil, &DependencyUnavailableError{
+			Message: fmt.Sprintf("runtime.embedder endpoint %s returned %s: %s", resp.Request.URL, resp.Status, message),
+		}
+	}
+
+	var payload openAICompatibleEmbeddingsResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, &DependencyUnavailableError{
+			Message: fmt.Sprintf("decode runtime.embedder response: %v", err),
+		}
+	}
+	if payload.Err != nil && strings.TrimSpace(payload.Err.Message) != "" {
+		return nil, &DependencyUnavailableError{
+			Message: fmt.Sprintf("runtime.embedder endpoint %s returned an error: %s", resp.Request.URL, payload.Err.Message),
+		}
+	}
+	return &payload, nil
+}
+
+func extractOpenAICompatibleError(body []byte) string {
+	var payload openAICompatibleEmbeddingsResponse
+	if err := json.Unmarshal(body, &payload); err == nil && payload.Err != nil {
+		return strings.TrimSpace(payload.Err.Message)
+	}
+	return ""
+}
+
+func shouldRetryOpenAICompatibleRequest(err error, statusCode int) bool {
+	if statusCode == http.StatusTooManyRequests || statusCode >= 500 {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout() || netErr.Temporary()
+	}
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "connection refused") ||
+		strings.Contains(strings.ToLower(err.Error()), "connection reset") ||
+		strings.Contains(strings.ToLower(err.Error()), "broken pipe")
+}
+
+func embeddingStrategyForModel(model string) string {
+	if strings.Contains(strings.ToLower(model), "nomic-embed-text") {
+		return embeddingStrategyNomicSearchPrefix
+	}
+	return embeddingStrategyPlain
+}
+
+func prepareEmbeddingInput(strategy, purpose, text string) string {
+	switch strategy {
+	case embeddingStrategyNomicSearchPrefix:
+		switch purpose {
+		case "query":
+			return "search_query: " + text
+		default:
+			return "search_document: " + text
+		}
+	default:
+		return text
+	}
+}
+
+func (e *openAICompatibleEmbedder) cachedDimension() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.dimension
+}
+
+func (e *openAICompatibleEmbedder) cacheDimension(dimension int) error {
+	if dimension <= 0 {
+		return &DependencyUnavailableError{Message: "runtime.embedder returned a non-positive embedding dimension"}
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.dimension == 0 {
+		e.dimension = dimension
+		return nil
+	}
+	if e.dimension != dimension {
+		return &DependencyUnavailableError{
+			Message: fmt.Sprintf("runtime.embedder changed embedding dimension from %d to %d", e.dimension, dimension),
+		}
+	}
+	return nil
+}

--- a/internal/index/openai_embedder_test.go
+++ b/internal/index/openai_embedder_test.go
@@ -1,0 +1,114 @@
+package index
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+func TestOpenAICompatibleEmbedderUsesNomicSearchPrefixes(t *testing.T) {
+	t.Parallel()
+
+	var inputs [][]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, "/v1/embeddings")
+		}
+		var request struct {
+			Model string   `json:"model"`
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		inputs = append(inputs, append([]string(nil), request.Input...))
+
+		response := map[string]any{
+			"data": []map[string]any{},
+		}
+		for i := range request.Input {
+			response["data"] = append(response["data"].([]map[string]any), map[string]any{
+				"index":     i,
+				"embedding": []float64{float64(i + 1), float64(i + 2), float64(i + 3)},
+			})
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	embedder, err := NewEmbedder(config.RuntimeProvider{
+		Provider:  config.RuntimeProviderOpenAI,
+		Model:     "nomic-embed-text-v1.5",
+		Endpoint:  server.URL + "/v1",
+		TimeoutMS: 1000,
+	})
+	if err != nil {
+		t.Fatalf("NewEmbedder() error = %v", err)
+	}
+
+	documentVectors, err := embedder.EmbedDocuments(context.Background(), []string{"alpha"})
+	if err != nil {
+		t.Fatalf("EmbedDocuments() error = %v", err)
+	}
+	queryVectors, err := embedder.EmbedQueries(context.Background(), []string{"beta"})
+	if err != nil {
+		t.Fatalf("EmbedQueries() error = %v", err)
+	}
+	dimension, err := embedder.Dimension(context.Background())
+	if err != nil {
+		t.Fatalf("Dimension() error = %v", err)
+	}
+
+	if len(documentVectors) != 1 || len(documentVectors[0]) != 3 {
+		t.Fatalf("document vectors = %+v, want one 3d vector", documentVectors)
+	}
+	if len(queryVectors) != 1 || len(queryVectors[0]) != 3 {
+		t.Fatalf("query vectors = %+v, want one 3d vector", queryVectors)
+	}
+	if dimension != 3 {
+		t.Fatalf("Dimension() = %d, want 3", dimension)
+	}
+	if !slices.Equal(inputs[0], []string{"search_document: alpha"}) {
+		t.Fatalf("document input = %v, want search_document prefix", inputs[0])
+	}
+	if !slices.Equal(inputs[1], []string{"search_query: beta"}) {
+		t.Fatalf("query input = %v, want search_query prefix", inputs[1])
+	}
+	if got, want := embedder.Fingerprint(), "openai_compatible|nomic-embed-text-v1.5|nomic_search_prefix_v1"; got != want {
+		t.Fatalf("Fingerprint() = %q, want %q", got, want)
+	}
+}
+
+func TestOpenAICompatibleEmbedderRequiresConfiguredAPIKey(t *testing.T) {
+	t.Parallel()
+
+	const envVar = "PITUITARY_TEST_OPENAI_API_KEY"
+	if err := os.Unsetenv(envVar); err != nil {
+		t.Fatalf("Unsetenv(%s): %v", envVar, err)
+	}
+
+	_, err := NewEmbedder(config.RuntimeProvider{
+		Provider:  config.RuntimeProviderOpenAI,
+		Model:     "pituitary-embed",
+		Endpoint:  "http://127.0.0.1:1234/v1",
+		APIKeyEnv: envVar,
+	})
+	if err == nil {
+		t.Fatal("NewEmbedder() error = nil, want missing-API-key failure")
+	}
+	if !IsDependencyUnavailable(err) {
+		t.Fatalf("NewEmbedder() error = %v, want dependency-unavailable classification", err)
+	}
+	if !strings.Contains(err.Error(), "missing API key for runtime.embedder") {
+		t.Fatalf("NewEmbedder() error = %q, want missing-API-key detail", err)
+	}
+}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -19,7 +19,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/source"
 )
 
-const schemaVersion = 2
+const schemaVersion = 3
 
 // RebuildResult reports the staged rebuild outcome.
 type RebuildResult struct {
@@ -70,11 +70,15 @@ func PrepareRebuildContext(ctx context.Context, cfg *config.Config, records *sou
 	if err != nil {
 		return nil, err
 	}
-	if err := prepareDryRunPreflightContext(ctx, cfg.Workspace.ResolvedIndexPath, embedder.Dimension()); err != nil {
+	dimension, err := embedder.Dimension(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := prepareDryRunPreflightContext(ctx, cfg.Workspace.ResolvedIndexPath, dimension); err != nil {
 		return nil, err
 	}
 
-	result := summarizeRebuild(records, embedder.Dimension())
+	result := summarizeRebuild(records, dimension)
 	result.IndexPath = cfg.Workspace.ResolvedIndexPath
 	result.DryRun = true
 	return result, nil
@@ -111,7 +115,10 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 	if err != nil {
 		return nil, err
 	}
-	dimension := embedder.Dimension()
+	dimension, err := embedder.Dimension(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	indexPath := cfg.Workspace.ResolvedIndexPath
 	stagePath, err := prepareStagingPath(indexPath)
@@ -377,6 +384,9 @@ func buildStagingContext(ctx context.Context, db *sql.DB, dimension int, embedde
 	if err := insertMetadataContext(ctx, tx, "embedder_dimension", strconv.Itoa(dimension)); err != nil {
 		return nil, err
 	}
+	if err := insertMetadataContext(ctx, tx, "embedder_fingerprint", embedder.Fingerprint()); err != nil {
+		return nil, err
+	}
 
 	chunkStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunks (artifact_ref, section, content) VALUES (?, ?, ?)`)
 	if err != nil {
@@ -617,7 +627,7 @@ func insertArtifactChunksContext(ctx context.Context, chunkStmt, vectorStmt *sql
 
 	event.Phase = "embedding"
 	reportRebuildProgress(reporter, event)
-	vectors, err := embedder.EmbedTexts(ctx, texts)
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
 		return 0, fmt.Errorf("embed chunks for %s: %w", artifactRef, err)
 	}
@@ -633,7 +643,7 @@ func insertArtifactChunksContext(ctx context.Context, chunkStmt, vectorStmt *sql
 		if err != nil {
 			return 0, err
 		}
-		if err := insertChunkVectorContext(ctx, vectorStmt, chunkID, embedder.Dimension(), vectors[i]); err != nil {
+		if err := insertChunkVectorContext(ctx, vectorStmt, chunkID, len(vectors[i]), vectors[i]); err != nil {
 			return 0, err
 		}
 	}

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -53,7 +53,8 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 	assertCount(t, db, `SELECT COUNT(*) FROM chunks`, 17)
 	assertCount(t, db, `SELECT COUNT(*) FROM edges`, 8)
 	assertCount(t, db, `SELECT COUNT(*) FROM chunks_vec`, 17)
-	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 3)
+	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 4)
+	assertMetadataValue(t, db, "embedder_fingerprint", "fixture|fixture-8d|plain_v1")
 	assertSections(t, db, "SPEC-042", []string{
 		"Overview",
 		"Requirements",
@@ -361,6 +362,17 @@ func assertColumnType(t *testing.T, db *sql.DB, query, want string) {
 	}
 	if got != want {
 		t.Fatalf("query %q = %q, want %q", query, got, want)
+	}
+}
+
+func assertMetadataValue(t *testing.T, db *sql.DB, key, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRow(`SELECT value FROM metadata WHERE key = ?`, key).Scan(&got); err != nil {
+		t.Fatalf("lookup metadata %s: %v", key, err)
+	}
+	if got != want {
+		t.Fatalf("metadata %s = %q, want %q", key, got, want)
 	}
 }
 

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -143,13 +143,15 @@ func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpe
 	}
 	defer db.Close()
 
-	if err := validateStoredDimensionContext(ctx, db, embedder.Dimension()); err != nil {
-		return nil, err
-	}
-
-	vectors, err := embedder.EmbedTexts(ctx, []string{query.Query})
+	vectors, err := embedder.EmbedQueries(ctx, []string{query.Query})
 	if err != nil {
 		return nil, fmt.Errorf("embed query: %w", err)
+	}
+	if len(vectors) != 1 {
+		return nil, fmt.Errorf("embed query: returned %d vector(s) for 1 query", len(vectors))
+	}
+	if err := validateStoredEmbedderContext(ctx, db, embedder.Fingerprint(), len(vectors[0])); err != nil {
+		return nil, err
 	}
 
 	candidates, err := loadRankedCandidatesContext(ctx, db, query, vectors[0])
@@ -229,14 +231,14 @@ func isSupportedSearchStatus(status string) bool {
 }
 
 func validateStoredDimension(db *sql.DB, configured int) error {
-	return validateStoredDimensionContext(context.Background(), db, configured)
+	return validateStoredEmbedderContext(context.Background(), db, "", configured)
 }
 
-func validateStoredDimensionContext(ctx context.Context, db *sql.DB, configured int) error {
+func validateStoredEmbedderContext(ctx context.Context, db *sql.DB, fingerprint string, configured int) error {
 	var raw string
 	err := db.QueryRowContext(ctx, `SELECT value FROM metadata WHERE key = 'embedder_dimension'`).Scan(&raw)
 	if err == sql.ErrNoRows {
-		return nil
+		return fmt.Errorf("index is missing embedder metadata; run `pituitary index --rebuild`")
 	}
 	if err != nil {
 		return fmt.Errorf("read index metadata: %w", err)
@@ -248,6 +250,22 @@ func validateStoredDimensionContext(ctx context.Context, db *sql.DB, configured 
 	}
 	if stored != configured {
 		return fmt.Errorf("index embedder dimension %d does not match configured embedder dimension %d; run `pituitary index --rebuild`", stored, configured)
+	}
+
+	if strings.TrimSpace(fingerprint) == "" {
+		return nil
+	}
+
+	var storedFingerprint string
+	err = db.QueryRowContext(ctx, `SELECT value FROM metadata WHERE key = 'embedder_fingerprint'`).Scan(&storedFingerprint)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("index is missing embedder fingerprint metadata; run `pituitary index --rebuild`")
+	}
+	if err != nil {
+		return fmt.Errorf("read index metadata: %w", err)
+	}
+	if storedFingerprint != fingerprint {
+		return fmt.Errorf("index embedder fingerprint %q does not match configured embedder fingerprint %q; run `pituitary index --rebuild`", storedFingerprint, fingerprint)
 	}
 	return nil
 }

--- a/internal/index/search_test.go
+++ b/internal/index/search_test.go
@@ -2,8 +2,10 @@ package index
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dusk-network/pituitary/internal/config"
@@ -245,5 +247,37 @@ Interactive authentication sessions must use tenant-scoped policy checks and sli
 	}
 	if len(result.Matches[0].Inference.Reasons) == 0 || result.Matches[0].Inference.Reasons[0] != "applies_to missing" {
 		t.Fatalf("top match inference reasons = %+v, want applies_to warning", result.Matches[0].Inference.Reasons)
+	}
+}
+
+func TestSearchSpecsRejectsEmbedderFingerprintMismatch(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE metadata SET value = ? WHERE key = 'embedder_fingerprint'`, "fixture|fixture-16d|plain_v1"); err != nil {
+		t.Fatalf("update embedder_fingerprint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close writable db: %v", err)
+	}
+
+	_, err = SearchSpecs(cfg, SearchSpecQuery{Query: "rate limiting", Limit: 5})
+	if err == nil {
+		t.Fatal("SearchSpecs() error = nil, want fingerprint mismatch")
+	}
+	if got := err.Error(); !strings.Contains(got, "embedder fingerprint") || !strings.Contains(got, "pituitary index --rebuild") {
+		t.Fatalf("SearchSpecs() error = %q, want fingerprint rebuild guidance", got)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,10 +1,12 @@
 package mcp
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
@@ -97,13 +99,17 @@ func validateStartup(options Options) error {
 	}
 	defer db.Close()
 
-	if err := validateIndexReady(db, embedder.Dimension()); err != nil {
+	dimension, err := embedder.Dimension(context.Background())
+	if err != nil {
+		return err
+	}
+	if err := validateIndexReady(db, embedder.Fingerprint(), dimension); err != nil {
 		return err
 	}
 	return nil
 }
 
-func validateIndexReady(db *sql.DB, configuredDimension int) error {
+func validateIndexReady(db *sql.DB, configuredFingerprint string, configuredDimension int) error {
 	var raw string
 	err := db.QueryRow(`SELECT value FROM metadata WHERE key = 'embedder_dimension'`).Scan(&raw)
 	if err == sql.ErrNoRows {
@@ -119,6 +125,22 @@ func validateIndexReady(db *sql.DB, configuredDimension int) error {
 	}
 	if stored != configuredDimension {
 		return fmt.Errorf("index embedder dimension %d does not match configured embedder dimension %d; run `pituitary index --rebuild`", stored, configuredDimension)
+	}
+
+	if strings.TrimSpace(configuredFingerprint) == "" {
+		return nil
+	}
+
+	var storedFingerprint string
+	err = db.QueryRow(`SELECT value FROM metadata WHERE key = 'embedder_fingerprint'`).Scan(&storedFingerprint)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("index metadata is missing embedder_fingerprint; run `pituitary index --rebuild`")
+	}
+	if err != nil {
+		return fmt.Errorf("read index metadata: %w", err)
+	}
+	if storedFingerprint != configuredFingerprint {
+		return fmt.Errorf("index embedder fingerprint %q does not match configured embedder fingerprint %q; run `pituitary index --rebuild`", storedFingerprint, configuredFingerprint)
 	}
 	return nil
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -83,7 +83,7 @@ include = ["guides/*.md", "runbooks/*.md"]
 	}
 }
 
-func TestValidateStartupRejectsUnsupportedEmbedderProvider(t *testing.T) {
+func TestValidateStartupRejectsOpenAICompatibleEmbedderWithoutEndpoint(t *testing.T) {
 	configPath := writeMCPServeWorkspace(t, `
 [workspace]
 root = "."
@@ -113,8 +113,8 @@ include = ["guides/*.md", "runbooks/*.md"]
 	if err == nil {
 		t.Fatal("validateStartup() error = nil, want embedder failure")
 	}
-	if !strings.Contains(err.Error(), `runtime.embedder.provider: unsupported provider "openai_compatible"`) {
-		t.Fatalf("validateStartup() error = %v, want unsupported-provider detail", err)
+	if !strings.Contains(err.Error(), `runtime.embedder.endpoint: value is required for provider "openai_compatible"`) {
+		t.Fatalf("validateStartup() error = %v, want missing-endpoint detail", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR lands the first runtime-provider slice under #53.

It adds optional `openai_compatible` support for `runtime.embedder`, wires it through `index` and `search-specs`, stores an embedder fingerprint in index metadata, and requires `pituitary index --rebuild` when the configured embedder changes.

It keeps the existing product boundaries intact:

- `fixture` remains the default embedder for CI and no-credentials bootstrap usage
- `runtime.analysis` remains `disabled` only
- CLI and MCP response contracts stay unchanged
- Pituitary remains tools-only, not an embedded agent

## What Changed

- allow `runtime.embedder.provider = "openai_compatible"`
- add an OpenAI-compatible embeddings client
- support Nomic `search_document:` / `search_query:` prefixes automatically
- persist and validate `embedder_fingerprint` alongside `embedder_dimension`
- validate runtime/index compatibility in MCP startup too
- update docs and targeted tests for the new runtime path

## Validation

- `go test ./...`

## Issue Links

Closes #54
Closes #55
Part of #53
Follow-up: #56
