### PR TITLE
Check out repo before publishing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,11 @@ jobs:
     needs: package
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Download packaged artifacts
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
Fix the release publish job by checking out the repository before running gh release create --verify-tag. This unblocks the v0.1.0 publish step after packaging succeeds.

Validation: git diff --check -- .github/workflows/release.yml