### PR TITLE
[feature] Explain config precedence and artifact locations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -575,6 +575,9 @@ CLI exit codes should stay simple:
 
 #### V1 JSON command contracts
 
+- `status` (`pituitary status`)
+  - Request: `{ "check_runtime": "none" | "embedder" | "analysis" | "all" }`
+  - Result: `{ "workspace_root": "...", "config_path": "...", "config_resolution": { "selected_by": "command_flag" | "global_flag" | "env" | "discovered_local", "reason": "...", "candidates": [{ "precedence": 1, "source": "...", "path": "...", "status": "selected" | "shadowed" | "not_set" | "missing", "detail": "..." }] }, "index_path": "...", "index_exists": true, "spec_count": N, "doc_count": N, "chunk_count": N, "artifact_locations": { "index_dir": "...", "discover_config_path": "...", "canonicalize_bundle_root": "...", "ignore_patterns": [".pituitary/"], "relocation_hints": ["..."] }, "runtime": { ... } | null }`
 - `index` (`pituitary index --rebuild`)
   - Request: `{ "rebuild": true }`
   - Result: `{ "workspace_root": ".", "index_path": ".pituitary/pituitary.db", "artifact_counts": { "spec": N, "doc": N }, "chunk_count": N, "edge_count": N }`
@@ -595,7 +598,7 @@ CLI exit codes should stay simple:
   - Result: `{ "scope": { "mode": "workspace" | "spec_ref", "artifact_kinds": ["doc", "spec"], "spec_ref": "SPEC-LOCALITY" }, "terms": [...], "canonical_terms": [...], "anchor_specs": [...], "findings": [{ "ref": "...", "kind": "doc" | "spec", "terms": [...], "sections": [{ "section": "...", "terms": [...], "excerpt": "...", "evidence": { "spec_ref": "SPEC-LOCALITY", "section": "...", "score": 0.0 } | null }] }] }`
 - `check_doc_drift` (`pituitary check-doc-drift`)
   - Request: exactly one of `{ "doc_ref": "doc://guides/api-rate-limits" }`, `{ "doc_refs": ["doc://guides/api-rate-limits"] }`, or `{ "scope": "all" }`
-  - Result: `{ "scope": { "mode": "doc_ref" | "doc_refs" | "all", "doc_refs": [...] }, "drift_items": [{ "doc_ref": "...", "findings": [{ "spec_ref": "SPEC-042", "code": "...", "message": "...", "rationale": "...", "evidence": { "spec_ref": "SPEC-042", "spec_section": "...", "doc_section": "..." }, "confidence": { "level": "high" | "medium" | "low", "score": 0.0 } }] }], "assessments": [{ "doc_ref": "...", "status": "drift" | "possible_drift", "rationale": "...", "evidence": { ... }, "confidence": { ... } }], "remediation": { ... } }`
+  - Result: `{ "scope": { "mode": "doc_ref" | "doc_refs" | "all", "doc_refs": [...] }, "drift_items": [{ "doc_ref": "...", "findings": [{ "spec_ref": "SPEC-042", "code": "...", "message": "...", "rationale": "...", "evidence": { "spec_ref": "SPEC-042", "spec_section": "...", "doc_section": "..." }, "confidence": { "level": "high" | "medium" | "low", "score": 0.0 } }] }], "assessments": [{ "doc_ref": "...", "status": "drift" | "aligned" | "possible_drift", "rationale": "...", "evidence": { ... }, "confidence": { ... } }], "remediation": { ... } }`
 - `review_spec` (`pituitary review-spec`)
   - Request: `{ "spec_ref": "SPEC-042" }` or `{ "spec_record": { ... canonical spec record ... } }`
   - Result: `{ "spec_ref": "SPEC-042", "overlap": { ... }, "comparison": { ... } | null, "impact": { ... }, "doc_drift": { ... } }`

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Every command supports `--format json` for machine-readable output. `search-spec
 | `canonicalize --path rfcs/service-sla.md` | Generate a suggested `spec.toml` + `body.md` bundle from one inferred contract |
 | `index --rebuild` | Rebuild the SQLite index from all configured sources |
 | `index --dry-run` | Validate config, sources, and rebuild prerequisites without writing the SQLite index |
-| `status [--check-runtime all]` | Report index counts and optionally probe embedder and analysis runtime readiness |
+| `status [--check-runtime all]` | Report index counts, config resolution, artifact locations, and optionally probe embedder and analysis runtime readiness |
 | `version` | Print Pituitary and Go runtime version information |
 | `search-specs --query "..."` | Semantic search across indexed spec sections |
 | `check-overlap --path specs/rate-limit-v2` | Detect specs that cover overlapping ground without looking up refs first |
@@ -216,6 +216,18 @@ All commands share a consistent JSON envelope:
 ```
 
 Pass `--format json` to any command to get this format, suitable for piping into `jq`, CI scripts, or other tools.
+
+### Config Resolution And Artifact Hygiene
+
+`pituitary status` now explains why the active config won and where Pituitary writes generated state.
+
+- Config precedence is explicit: command-local `--config`, then global `--config`, then `PITUITARY_CONFIG`, then discovered `.pituitary/pituitary.toml` or `pituitary.toml` in the working directory or a parent directory.
+- Artifact locations are surfaced directly: active index path, index directory, `discover --write` default config path, and the default `canonicalize` bundle root.
+- Relocation knobs stay simple:
+  - set `[workspace].index_path` to move the SQLite index
+  - use `pituitary discover --config-path PATH --write` to place generated config elsewhere
+  - use `pituitary canonicalize --bundle-dir PATH` to place generated bundles elsewhere
+- If you keep the defaults, ignore `.pituitary/` in your workspace.
 
 ### Example: terminology audit
 

--- a/cmd/config_path.go
+++ b/cmd/config_path.go
@@ -14,10 +14,35 @@ const (
 	defaultConfigName  = "pituitary.toml"
 	localConfigDirName = ".pituitary"
 	configEnvVar       = "PITUITARY_CONFIG"
+
+	configSourceCommandFlag = "command_flag"
+	configSourceGlobalFlag  = "global_flag"
+	configSourceEnv         = "env"
+	configSourceDiscovery   = "discovered_local"
 )
 
 type cliGlobalOptions struct {
 	ConfigPath string
+}
+
+type configPathOption struct {
+	Source string
+	Path   string
+}
+
+type configResolution struct {
+	WorkingDir string                      `json:"working_dir"`
+	SelectedBy string                      `json:"selected_by,omitempty"`
+	Reason     string                      `json:"reason,omitempty"`
+	Candidates []configResolutionCandidate `json:"candidates"`
+}
+
+type configResolutionCandidate struct {
+	Precedence int    `json:"precedence"`
+	Source     string `json:"source"`
+	Path       string `json:"path,omitempty"`
+	Status     string `json:"status"`
+	Detail     string `json:"detail,omitempty"`
 }
 
 type cliConfigPathContextKey struct{}
@@ -54,38 +79,91 @@ func cliConfigPathFromContext(ctx context.Context) string {
 }
 
 func resolveCommandConfigPath(ctx context.Context, localConfigPath string) (string, error) {
-	return resolveCLIConfigPath(localConfigPath, cliConfigPathFromContext(ctx))
+	resolvedPath, _, err := resolveCommandConfigPathWithResolution(ctx, localConfigPath)
+	return resolvedPath, err
+}
+
+func resolveCommandConfigPathWithResolution(ctx context.Context, localConfigPath string) (string, *configResolution, error) {
+	return resolveCLIConfigPathWithResolution(
+		configPathOption{Source: configSourceCommandFlag, Path: localConfigPath},
+		configPathOption{Source: configSourceGlobalFlag, Path: cliConfigPathFromContext(ctx)},
+	)
 }
 
 func resolveCLIConfigPath(explicitPaths ...string) (string, error) {
-	for _, explicitPath := range explicitPaths {
-		explicitPath = strings.TrimSpace(explicitPath)
-		if explicitPath != "" {
-			return explicitPath, nil
+	options := make([]configPathOption, 0, len(explicitPaths))
+	for i, explicitPath := range explicitPaths {
+		options = append(options, configPathOption{
+			Source: fmt.Sprintf("explicit_%d", i+1),
+			Path:   explicitPath,
+		})
+	}
+	resolvedPath, _, err := resolveCLIConfigPathWithResolution(options...)
+	return resolvedPath, err
+}
+
+func resolveCLIConfigPathWithResolution(explicitOptions ...configPathOption) (string, *configResolution, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve working directory: %w", err)
+	}
+	return resolveCLIConfigPathFromWorkingDir(cwd, explicitOptions...)
+}
+
+func resolveCLIConfigPathFromWorkingDir(cwd string, explicitOptions ...configPathOption) (string, *configResolution, error) {
+	resolution := &configResolution{
+		WorkingDir: filepath.ToSlash(cwd),
+		Candidates: make([]configResolutionCandidate, 0, len(explicitOptions)+4),
+	}
+
+	for _, option := range explicitOptions {
+		resolution.Candidates = append(resolution.Candidates, buildConfigResolutionCandidate(len(resolution.Candidates)+1, option.Source, option.Path))
+	}
+	resolution.Candidates = append(resolution.Candidates, buildConfigResolutionCandidate(len(resolution.Candidates)+1, configSourceEnv, os.Getenv(configEnvVar)))
+	resolution.Candidates = append(resolution.Candidates, discoverCLIConfigCandidates(cwd, len(resolution.Candidates)+1)...)
+
+	selectedIndex := -1
+	for i := range resolution.Candidates {
+		candidate := &resolution.Candidates[i]
+		if candidate.Path == "" || candidate.Status == "missing" {
+			continue
+		}
+		selectedIndex = i
+		resolution.SelectedBy = candidate.Source
+		candidate.Status = "selected"
+		break
+	}
+
+	if selectedIndex == -1 {
+		return "", resolution, fmt.Errorf(
+			"no config found; set --config, set %s, or add %s or %s in %s or a parent directory",
+			configEnvVar,
+			filepath.ToSlash(filepath.Join(localConfigDirName, defaultConfigName)),
+			defaultConfigName,
+			filepath.ToSlash(cwd),
+		)
+	}
+
+	selected := resolution.Candidates[selectedIndex]
+	resolution.Reason = configResolutionReason(selected, resolution.Candidates)
+
+	for i := range resolution.Candidates {
+		if i == selectedIndex {
+			continue
+		}
+		candidate := &resolution.Candidates[i]
+		switch candidate.Status {
+		case "missing", "not_set":
+			continue
+		default:
+			candidate.Status = "shadowed"
+			if candidate.Detail == "" {
+				candidate.Detail = fmt.Sprintf("ignored because %s won first", configSourceLabel(selected.Source))
+			}
 		}
 	}
 
-	envPath := strings.TrimSpace(os.Getenv(configEnvVar))
-	if envPath != "" {
-		return envPath, nil
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("resolve working directory: %w", err)
-	}
-
-	if discoveredPath, ok := discoverCLIConfigPath(cwd); ok {
-		return discoveredPath, nil
-	}
-
-	return "", fmt.Errorf(
-		"no config found; set --config, set %s, or add %s or %s in %s or a parent directory",
-		configEnvVar,
-		filepath.ToSlash(filepath.Join(localConfigDirName, defaultConfigName)),
-		defaultConfigName,
-		filepath.ToSlash(cwd),
-	)
+	return selected.Path, resolution, nil
 }
 
 func discoverCLIConfigPath(startDir string) (string, bool) {
@@ -106,5 +184,149 @@ func discoverCLIConfigPath(startDir string) (string, bool) {
 			return "", false
 		}
 		dir = parent
+	}
+}
+
+func buildConfigResolutionCandidate(precedence int, source, rawPath string) configResolutionCandidate {
+	trimmedPath := strings.TrimSpace(rawPath)
+	candidate := configResolutionCandidate{
+		Precedence: precedence,
+		Source:     source,
+		Path:       trimmedPath,
+	}
+	if trimmedPath == "" {
+		candidate.Status = "not_set"
+		candidate.Detail = configUnsetDetail(source)
+		return candidate
+	}
+	candidate.Status = "available"
+	candidate.Detail = configAvailableDetail(source)
+	return candidate
+}
+
+func configUnsetDetail(source string) string {
+	switch source {
+	case configSourceCommandFlag:
+		return "command-local --config was not provided"
+	case configSourceGlobalFlag:
+		return "global --config was not provided"
+	case configSourceEnv:
+		return fmt.Sprintf("%s is not set", configEnvVar)
+	default:
+		return "not set"
+	}
+}
+
+func configAvailableDetail(source string) string {
+	switch source {
+	case configSourceCommandFlag:
+		return "command-local --config is set"
+	case configSourceGlobalFlag:
+		return "global --config is set"
+	case configSourceEnv:
+		return fmt.Sprintf("%s is set", configEnvVar)
+	default:
+		return "available by precedence"
+	}
+}
+
+func discoverCLIConfigCandidates(startDir string, startPrecedence int) []configResolutionCandidate {
+	dir := filepath.Clean(startDir)
+	candidates := make([]configResolutionCandidate, 0, 4)
+	precedence := startPrecedence
+	foundAny := false
+
+	for {
+		discoveryPaths := []string{
+			filepath.Join(dir, localConfigDirName, defaultConfigName),
+			filepath.Join(dir, defaultConfigName),
+		}
+		for _, candidatePath := range discoveryPaths {
+			info, err := os.Stat(candidatePath)
+			if err == nil && !info.IsDir() {
+				foundAny = true
+				candidates = append(candidates, configResolutionCandidate{
+					Precedence: precedence,
+					Source:     configSourceDiscovery,
+					Path:       candidatePath,
+					Status:     "available",
+					Detail:     fmt.Sprintf("found during working-directory search in %s", filepath.ToSlash(dir)),
+				})
+				precedence++
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	if foundAny {
+		return candidates
+	}
+
+	return []configResolutionCandidate{
+		{
+			Precedence: startPrecedence,
+			Source:     configSourceDiscovery,
+			Path:       filepath.Join(startDir, localConfigDirName, defaultConfigName),
+			Status:     "missing",
+			Detail:     fmt.Sprintf("not present in %s; search continued to parent directories", filepath.ToSlash(startDir)),
+		},
+		{
+			Precedence: startPrecedence + 1,
+			Source:     configSourceDiscovery,
+			Path:       filepath.Join(startDir, defaultConfigName),
+			Status:     "missing",
+			Detail:     fmt.Sprintf("not present in %s; search continued to parent directories", filepath.ToSlash(startDir)),
+		},
+	}
+}
+
+func configResolutionReason(selected configResolutionCandidate, all []configResolutionCandidate) string {
+	switch selected.Source {
+	case configSourceCommandFlag:
+		return "command-local --config won by precedence"
+	case configSourceGlobalFlag:
+		return "global --config won by precedence"
+	case configSourceEnv:
+		return fmt.Sprintf("%s won before working-directory discovery", configEnvVar)
+	case configSourceDiscovery:
+		for _, candidate := range all {
+			if candidate.Source != configSourceDiscovery || candidate.Path == selected.Path {
+				continue
+			}
+			if discoverySearchDir(candidate.Path) == discoverySearchDir(selected.Path) {
+				return fmt.Sprintf("working-directory search found %s before %s in %s", filepath.ToSlash(selected.Path), filepath.ToSlash(candidate.Path), filepath.ToSlash(discoverySearchDir(selected.Path)))
+			}
+		}
+		return fmt.Sprintf("working-directory search found %s", filepath.ToSlash(selected.Path))
+	default:
+		return "selected by precedence"
+	}
+}
+
+func discoverySearchDir(path string) string {
+	dir := filepath.Dir(path)
+	if filepath.Base(dir) == localConfigDirName {
+		return filepath.Dir(dir)
+	}
+	return dir
+}
+
+func configSourceLabel(source string) string {
+	switch source {
+	case configSourceCommandFlag:
+		return "command-local --config"
+	case configSourceGlobalFlag:
+		return "global --config"
+	case configSourceEnv:
+		return configEnvVar
+	case configSourceDiscovery:
+		return "working-directory search"
+	default:
+		return source
 	}
 }

--- a/cmd/config_path_test.go
+++ b/cmd/config_path_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -154,5 +155,109 @@ path = "specs"
 	}
 	if _, err := os.Stat(filepath.Join(repo, ".pituitary", "pituitary.db")); err != nil {
 		t.Fatalf("runIndex() did not create database via discovered local config: %v", err)
+	}
+}
+
+func TestResolveCommandConfigPathPrefersCommandFlagAndExplainsCandidates(t *testing.T) {
+	repo := t.TempDir()
+	commandConfigPath := filepath.Join(repo, "configs", "pituitary.local.toml")
+	globalConfigPath := filepath.Join(repo, "global", "pituitary.toml")
+	envConfigPath := filepath.Join(repo, "env", "pituitary.toml")
+
+	t.Setenv(configEnvVar, envConfigPath)
+
+	var (
+		resolvedPath string
+		resolution   *configResolution
+		err          error
+	)
+	withWorkingDir(t, repo, func() int {
+		resolvedPath, resolution, err = resolveCommandConfigPathWithResolution(
+			withCLIConfigPath(context.Background(), globalConfigPath),
+			commandConfigPath,
+		)
+		return 0
+	})
+	if err != nil {
+		t.Fatalf("resolveCommandConfigPathWithResolution() error = %v", err)
+	}
+	if got, want := resolvedPath, commandConfigPath; got != want {
+		t.Fatalf("resolved path = %q, want %q", got, want)
+	}
+	if resolution == nil {
+		t.Fatal("resolution = nil, want explanation payload")
+	}
+	if got, want := resolution.SelectedBy, configSourceCommandFlag; got != want {
+		t.Fatalf("selected_by = %q, want %q", got, want)
+	}
+	if len(resolution.Candidates) < 5 {
+		t.Fatalf("candidates = %+v, want explicit/env/discovery entries", resolution.Candidates)
+	}
+	if got, want := resolution.Candidates[0].Status, "selected"; got != want {
+		t.Fatalf("command candidate status = %q, want %q", got, want)
+	}
+	if got, want := resolution.Candidates[1].Status, "shadowed"; got != want {
+		t.Fatalf("global candidate status = %q, want %q", got, want)
+	}
+	if got, want := resolution.Candidates[2].Status, "shadowed"; got != want {
+		t.Fatalf("env candidate status = %q, want %q", got, want)
+	}
+	if got, want := resolution.Candidates[3].Status, "missing"; got != want {
+		t.Fatalf("first discovery candidate status = %q, want %q", got, want)
+	}
+	if !strings.Contains(resolution.Reason, "command-local --config") {
+		t.Fatalf("reason = %q, want command precedence detail", resolution.Reason)
+	}
+}
+
+func TestResolveCommandConfigPathExplainsDiscoveredShadowedConfig(t *testing.T) {
+	repo := t.TempDir()
+	resolvedRepo, resolveErr := filepath.EvalSymlinks(repo)
+	if resolveErr != nil {
+		t.Fatalf("filepath.EvalSymlinks(%q) error = %v", repo, resolveErr)
+	}
+	mustMkdirAllCmd(t, filepath.Join(repo, ".pituitary"))
+	mustWriteFileCmd(t, filepath.Join(repo, ".pituitary", "pituitary.toml"), "[workspace]\nroot = \".\"\nindex_path = \".pituitary/pituitary.db\"\n")
+	mustWriteFileCmd(t, filepath.Join(repo, "pituitary.toml"), "[workspace]\nroot = \".\"\nindex_path = \".pituitary/pituitary.db\"\n")
+
+	nested := filepath.Join(repo, "pkg", "nested")
+	mustMkdirAllCmd(t, nested)
+
+	var (
+		resolvedPath string
+		resolution   *configResolution
+		err          error
+	)
+	withWorkingDir(t, nested, func() int {
+		resolvedPath, resolution, err = resolveCommandConfigPathWithResolution(context.Background(), "")
+		return 0
+	})
+	if err != nil {
+		t.Fatalf("resolveCommandConfigPathWithResolution() error = %v", err)
+	}
+	if got, want := resolvedPath, filepath.Join(resolvedRepo, ".pituitary", "pituitary.toml"); got != want {
+		t.Fatalf("resolved path = %q, want %q", got, want)
+	}
+	if resolution == nil {
+		t.Fatal("resolution = nil, want explanation payload")
+	}
+	if got, want := resolution.SelectedBy, configSourceDiscovery; got != want {
+		t.Fatalf("selected_by = %q, want %q", got, want)
+	}
+	var foundSelected, foundShadowed bool
+	for _, candidate := range resolution.Candidates {
+		switch {
+		case candidate.Path == filepath.Join(resolvedRepo, ".pituitary", "pituitary.toml") && candidate.Status == "selected":
+			foundSelected = true
+		case candidate.Path == filepath.Join(resolvedRepo, "pituitary.toml") && candidate.Status == "shadowed":
+			foundShadowed = true
+		}
+	}
+	if !foundSelected || !foundShadowed {
+		t.Fatalf("candidates = %+v, want selected local config and shadowed root config", resolution.Candidates)
+	}
+	if !strings.Contains(resolution.Reason, filepath.ToSlash(filepath.Join(resolvedRepo, ".pituitary", "pituitary.toml"))) ||
+		!strings.Contains(resolution.Reason, filepath.ToSlash(filepath.Join(resolvedRepo, "pituitary.toml"))) {
+		t.Fatalf("reason = %q, want selected and shadowed discovered paths", resolution.Reason)
 	}
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -11,8 +11,9 @@ import (
 )
 
 type discoverRequest struct {
-	Path  string `json:"path"`
-	Write bool   `json:"write,omitempty"`
+	Path       string `json:"path"`
+	ConfigPath string `json:"config_path,omitempty"`
+	Write      bool   `json:"write,omitempty"`
 }
 
 func runDiscover(args []string, stdout, stderr io.Writer) int {
@@ -22,15 +23,17 @@ func runDiscover(args []string, stdout, stderr io.Writer) int {
 func runDiscoverContext(_ context.Context, args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("discover", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	help := newStandaloneCommandHelp("discover", "pituitary discover [--path PATH] [--write] [--format FORMAT]")
+	help := newStandaloneCommandHelp("discover", "pituitary discover [--path PATH] [--config-path PATH] [--write] [--format FORMAT]")
 
 	var (
-		path   string
-		write  bool
-		format string
+		path       string
+		configPath string
+		write      bool
+		format     string
 	)
 	fs.StringVar(&path, "path", ".", "workspace path to scan")
-	fs.BoolVar(&write, "write", false, "write .pituitary/pituitary.toml")
+	fs.StringVar(&configPath, "config-path", "", "where discover --write should place the generated config")
+	fs.BoolVar(&write, "write", false, "write the generated config")
 	fs.StringVar(&format, "format", "text", "output format")
 
 	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
@@ -48,19 +51,21 @@ func runDiscoverContext(_ context.Context, args []string, stdout, stderr io.Writ
 		}, 2)
 	}
 	if err := validateCLIFormat("discover", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "discover", discoverRequest{Path: path, Write: write}, cliIssue{
+		return writeCLIError(stdout, stderr, format, "discover", discoverRequest{Path: path, ConfigPath: strings.TrimSpace(configPath), Write: write}, cliIssue{
 			Code:    "validation_error",
 			Message: err.Error(),
 		}, 2)
 	}
 
 	request := discoverRequest{
-		Path:  path,
-		Write: write,
+		Path:       path,
+		ConfigPath: strings.TrimSpace(configPath),
+		Write:      write,
 	}
 	result, err := source.DiscoverWorkspace(source.DiscoverOptions{
-		RootPath: path,
-		Write:    write,
+		RootPath:   path,
+		ConfigPath: request.ConfigPath,
+		Write:      write,
 	})
 	if err != nil {
 		return writeCLIError(stdout, stderr, format, "discover", request, cliIssue{

--- a/cmd/discover_test.go
+++ b/cmd/discover_test.go
@@ -105,6 +105,35 @@ func TestRunDiscoverWriteProducesUsableLocalConfig(t *testing.T) {
 	}
 }
 
+func TestRunDiscoverWriteSupportsCustomConfigPath(t *testing.T) {
+	repo := writeDiscoveryWorkspace(t)
+	configPath := filepath.Join(repo, "tools", "pituitary.local.toml")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runDiscover([]string{"--path", ".", "--write", "--config-path", filepath.ToSlash(filepath.Join("tools", "pituitary.local.toml"))}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runDiscover(--write, --config-path) exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("custom discovered config %s missing: %v", configPath, err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = withWorkingDir(t, repo, func() int {
+		return Run([]string{"--config", configPath, "index", "--rebuild"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("Run(--config, index --rebuild) exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".pituitary", "pituitary.db")); err != nil {
+		t.Fatalf("rebuilt index missing after custom config: %v", err)
+	}
+}
+
 func TestRunDiscoverHelpDoesNotAdvertiseConfigResolution(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -120,8 +149,11 @@ func TestRunDiscoverHelpDoesNotAdvertiseConfigResolution(t *testing.T) {
 	if strings.Contains(out, "shared config resolution:") {
 		t.Fatalf("discover help %q unexpectedly advertises config resolution", out)
 	}
-	if !strings.Contains(out, "usage: pituitary discover [--path PATH] [--write] [--format FORMAT]") {
+	if !strings.Contains(out, "usage: pituitary discover [--path PATH] [--config-path PATH] [--write] [--format FORMAT]") {
 		t.Fatalf("discover help %q missing usage line", out)
+	}
+	if !strings.Contains(out, "--config-path VALUE") {
+		t.Fatalf("discover help %q missing --config-path flag", out)
 	}
 }
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -48,8 +48,8 @@ func printCommandHelp(w io.Writer, fs *flag.FlagSet, help commandHelp) {
 func printSharedConfigResolution(w io.Writer) {
 	fmt.Fprintln(w, "shared config resolution:")
 	fmt.Fprintln(w, "  the first match wins:")
-	fmt.Fprintln(w, "  - global --config PATH before the command")
 	fmt.Fprintln(w, "  - command-local --config PATH")
+	fmt.Fprintln(w, "  - global --config PATH before the command")
 	fmt.Fprintf(w, "  - %s\n", configEnvVar)
 	fmt.Fprintf(w, "  - %s or %s in the working directory or a parent directory\n", pathpkg.Join(localConfigDirName, defaultConfigName), defaultConfigName)
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -165,7 +165,28 @@ func renderIndexSourceSummaries(w io.Writer, sources []source.LoadSourceSummary)
 }
 
 func renderStatusResult(w io.Writer, result *statusResult) {
+	if result.WorkspaceRoot != "" {
+		fmt.Fprintf(w, "workspace: %s\n", result.WorkspaceRoot)
+	}
 	fmt.Fprintf(w, "config: %s\n", result.ConfigPath)
+	if result.ConfigResolution != nil {
+		if result.ConfigResolution.Reason != "" {
+			fmt.Fprintf(w, "config resolution: %s\n", result.ConfigResolution.Reason)
+		}
+		if len(result.ConfigResolution.Candidates) > 0 {
+			fmt.Fprintln(w, "config candidates:")
+			for _, candidate := range result.ConfigResolution.Candidates {
+				fmt.Fprintf(w, "  %d. %s | %s", candidate.Precedence, configSourceLabel(candidate.Source), candidate.Status)
+				if candidate.Path != "" {
+					fmt.Fprintf(w, " | %s", candidate.Path)
+				}
+				fmt.Fprintln(w)
+				if candidate.Detail != "" {
+					fmt.Fprintf(w, "     %s\n", candidate.Detail)
+				}
+			}
+		}
+	}
 	fmt.Fprintf(w, "index path: %s\n", result.IndexPath)
 	if result.IndexExists {
 		fmt.Fprintln(w, "index: present")
@@ -175,6 +196,17 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 	fmt.Fprintf(w, "indexed specs: %d\n", result.SpecCount)
 	fmt.Fprintf(w, "indexed docs: %d\n", result.DocCount)
 	fmt.Fprintf(w, "indexed chunks: %d\n", result.ChunkCount)
+	if result.ArtifactLocations != nil {
+		fmt.Fprintf(w, "artifact index dir: %s\n", result.ArtifactLocations.IndexDir)
+		fmt.Fprintf(w, "artifact discover --write default: %s\n", result.ArtifactLocations.DiscoverConfigPath)
+		fmt.Fprintf(w, "artifact canonicalize default: %s\n", result.ArtifactLocations.CanonicalizeBundleRoot)
+		if len(result.ArtifactLocations.IgnorePatterns) > 0 {
+			fmt.Fprintf(w, "artifact ignore patterns: %s\n", strings.Join(result.ArtifactLocations.IgnorePatterns, ", "))
+		}
+		for _, hint := range result.ArtifactLocations.RelocationHints {
+			fmt.Fprintf(w, "artifact relocation: %s\n", hint)
+		}
+	}
 	if result.Runtime != nil {
 		fmt.Fprintf(w, "runtime probe: %s\n", result.Runtime.Scope)
 		for _, check := range result.Runtime.Checks {

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -88,12 +88,34 @@ func TestRenderStatusResultIncludesRuntimeProbe(t *testing.T) {
 
 	var stdout bytes.Buffer
 	renderStatusResult(&stdout, &statusResult{
-		ConfigPath:  "/tmp/repo/pituitary.toml",
+		WorkspaceRoot: "/tmp/repo",
+		ConfigPath:    "/tmp/repo/pituitary.toml",
+		ConfigResolution: &configResolution{
+			SelectedBy: configSourceDiscovery,
+			Reason:     "working-directory search found /tmp/repo/pituitary.toml",
+			Candidates: []configResolutionCandidate{
+				{Precedence: 1, Source: configSourceCommandFlag, Status: "not_set", Detail: "command-local --config was not provided"},
+				{Precedence: 2, Source: configSourceGlobalFlag, Status: "not_set", Detail: "global --config was not provided"},
+				{Precedence: 3, Source: configSourceEnv, Status: "not_set", Detail: "PITUITARY_CONFIG is not set"},
+				{Precedence: 4, Source: configSourceDiscovery, Status: "selected", Path: "/tmp/repo/pituitary.toml", Detail: "found during working-directory search in /tmp/repo"},
+			},
+		},
 		IndexPath:   "/tmp/repo/.pituitary/pituitary.db",
 		IndexExists: true,
 		SpecCount:   3,
 		DocCount:    2,
 		ChunkCount:  17,
+		ArtifactLocations: &statusArtifactLocation{
+			IndexDir:               "/tmp/repo/.pituitary",
+			DiscoverConfigPath:     "/tmp/repo/.pituitary/pituitary.toml",
+			CanonicalizeBundleRoot: "/tmp/repo/.pituitary/canonicalized",
+			IgnorePatterns:         []string{".pituitary/"},
+			RelocationHints: []string{
+				"set [workspace].index_path to move the SQLite index",
+				"use `pituitary discover --config-path PATH --write` to place generated config elsewhere",
+				"use `pituitary canonicalize --bundle-dir PATH` to place generated bundles elsewhere",
+			},
+		},
 		Runtime: &runtimeprobe.Result{
 			Scope: "all",
 			Checks: []runtimeprobe.Check{
@@ -116,7 +138,17 @@ func TestRenderStatusResultIncludesRuntimeProbe(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
+		"workspace: /tmp/repo",
+		"config resolution: working-directory search found /tmp/repo/pituitary.toml",
+		"config candidates:",
+		"1. command-local --config | not_set",
+		"4. working-directory search | selected | /tmp/repo/pituitary.toml",
 		"index: present",
+		"artifact index dir: /tmp/repo/.pituitary",
+		"artifact discover --write default: /tmp/repo/.pituitary/pituitary.toml",
+		"artifact canonicalize default: /tmp/repo/.pituitary/canonicalized",
+		"artifact ignore patterns: .pituitary/",
+		"artifact relocation: set [workspace].index_path to move the SQLite index",
 		"runtime probe: all",
 		"runtime: runtime.embedder | ready | provider: openai_compatible | model: pituitary-embed | endpoint: http://localhost:1234/v1",
 		"runtime: runtime.analysis | disabled | provider: disabled",

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/app"
@@ -18,13 +20,24 @@ type statusRequest struct {
 }
 
 type statusResult struct {
-	ConfigPath  string               `json:"config_path"`
-	IndexPath   string               `json:"index_path"`
-	IndexExists bool                 `json:"index_exists"`
-	SpecCount   int                  `json:"spec_count"`
-	DocCount    int                  `json:"doc_count"`
-	ChunkCount  int                  `json:"chunk_count"`
-	Runtime     *runtimeprobe.Result `json:"runtime,omitempty"`
+	WorkspaceRoot     string                  `json:"workspace_root"`
+	ConfigPath        string                  `json:"config_path"`
+	ConfigResolution  *configResolution       `json:"config_resolution,omitempty"`
+	IndexPath         string                  `json:"index_path"`
+	IndexExists       bool                    `json:"index_exists"`
+	SpecCount         int                     `json:"spec_count"`
+	DocCount          int                     `json:"doc_count"`
+	ChunkCount        int                     `json:"chunk_count"`
+	ArtifactLocations *statusArtifactLocation `json:"artifact_locations,omitempty"`
+	Runtime           *runtimeprobe.Result    `json:"runtime,omitempty"`
+}
+
+type statusArtifactLocation struct {
+	IndexDir               string   `json:"index_dir"`
+	DiscoverConfigPath     string   `json:"discover_config_path"`
+	CanonicalizeBundleRoot string   `json:"canonicalize_bundle_root"`
+	IgnorePatterns         []string `json:"ignore_patterns,omitempty"`
+	RelocationHints        []string `json:"relocation_hints,omitempty"`
 }
 
 func runStatus(args []string, stdout, stderr io.Writer) int {
@@ -79,7 +92,7 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 		request.CheckRuntime = string(scope)
 	}
 
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	resolvedConfigPath, resolution, err := resolveCommandConfigPathWithResolution(ctx, configPath)
 	if err != nil {
 		return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
 			Code:    "config_error",
@@ -123,12 +136,62 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "status", request, &statusResult{
-		ConfigPath:  cfg.ConfigPath,
-		IndexPath:   status.IndexPath,
-		IndexExists: status.Exists,
-		SpecCount:   status.SpecCount,
-		DocCount:    status.DocCount,
-		ChunkCount:  status.ChunkCount,
-		Runtime:     runtimeResult,
+		WorkspaceRoot:     cfg.Workspace.RootPath,
+		ConfigPath:        cfg.ConfigPath,
+		ConfigResolution:  resolution,
+		IndexPath:         status.IndexPath,
+		IndexExists:       status.Exists,
+		SpecCount:         status.SpecCount,
+		DocCount:          status.DocCount,
+		ChunkCount:        status.ChunkCount,
+		ArtifactLocations: buildStatusArtifactLocations(cfg),
+		Runtime:           runtimeResult,
 	}, nil)
+}
+
+func buildStatusArtifactLocations(cfg *config.Config) *statusArtifactLocation {
+	if cfg == nil {
+		return nil
+	}
+
+	workspaceRoot := cfg.Workspace.RootPath
+	indexDir := filepath.Dir(cfg.Workspace.ResolvedIndexPath)
+	discoverConfigPath := filepath.Join(workspaceRoot, localConfigDirName, defaultConfigName)
+	canonicalizeBundleRoot := filepath.Join(workspaceRoot, localConfigDirName, "canonicalized")
+
+	ignoreSet := map[string]struct{}{
+		filepath.ToSlash(localConfigDirName) + "/": {},
+	}
+	indexPattern := relativeStatusPath(workspaceRoot, cfg.Workspace.ResolvedIndexPath)
+	if indexPattern != "" && indexPattern != "." && !strings.HasPrefix(indexPattern, filepath.ToSlash(localConfigDirName)+"/") {
+		ignoreSet[indexPattern] = struct{}{}
+	}
+	ignorePatterns := make([]string, 0, len(ignoreSet))
+	for pattern := range ignoreSet {
+		ignorePatterns = append(ignorePatterns, pattern)
+	}
+	sort.Strings(ignorePatterns)
+
+	return &statusArtifactLocation{
+		IndexDir:               indexDir,
+		DiscoverConfigPath:     discoverConfigPath,
+		CanonicalizeBundleRoot: canonicalizeBundleRoot,
+		IgnorePatterns:         ignorePatterns,
+		RelocationHints: []string{
+			"set [workspace].index_path to move the SQLite index",
+			"use `pituitary discover --config-path PATH --write` to place generated config elsewhere",
+			"use `pituitary canonicalize --bundle-dir PATH` to place generated bundles elsewhere",
+		},
+	}
+}
+
+func relativeStatusPath(root, path string) string {
+	if strings.TrimSpace(root) == "" || strings.TrimSpace(path) == "" {
+		return ""
+	}
+	relativePath, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(relativePath)
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -31,6 +31,12 @@ func TestRunStatusReportsMissingIndex(t *testing.T) {
 	if !strings.Contains(out, "index: missing") {
 		t.Fatalf("runStatus() output %q does not report missing index", out)
 	}
+	if !strings.Contains(out, "config resolution:") {
+		t.Fatalf("runStatus() output %q does not explain config resolution", out)
+	}
+	if !strings.Contains(out, "artifact ignore patterns: .pituitary/") {
+		t.Fatalf("runStatus() output %q does not contain artifact ignore guidance", out)
+	}
 	if !strings.Contains(out, filepath.Join(repo, ".pituitary", "pituitary.db")) {
 		t.Fatalf("runStatus() output %q does not contain resolved index path", out)
 	}
@@ -63,12 +69,29 @@ func TestRunStatusJSON(t *testing.T) {
 	var payload struct {
 		Request struct{} `json:"request"`
 		Result  struct {
-			ConfigPath  string `json:"config_path"`
-			IndexPath   string `json:"index_path"`
-			IndexExists bool   `json:"index_exists"`
-			SpecCount   int    `json:"spec_count"`
-			DocCount    int    `json:"doc_count"`
-			ChunkCount  int    `json:"chunk_count"`
+			WorkspaceRoot    string `json:"workspace_root"`
+			ConfigPath       string `json:"config_path"`
+			ConfigResolution struct {
+				SelectedBy string `json:"selected_by"`
+				Reason     string `json:"reason"`
+				Candidates []struct {
+					Source string `json:"source"`
+					Status string `json:"status"`
+					Path   string `json:"path"`
+				} `json:"candidates"`
+			} `json:"config_resolution"`
+			IndexPath         string `json:"index_path"`
+			IndexExists       bool   `json:"index_exists"`
+			SpecCount         int    `json:"spec_count"`
+			DocCount          int    `json:"doc_count"`
+			ChunkCount        int    `json:"chunk_count"`
+			ArtifactLocations struct {
+				IndexDir               string   `json:"index_dir"`
+				DiscoverConfigPath     string   `json:"discover_config_path"`
+				CanonicalizeBundleRoot string   `json:"canonicalize_bundle_root"`
+				IgnorePatterns         []string `json:"ignore_patterns"`
+				RelocationHints        []string `json:"relocation_hints"`
+			} `json:"artifact_locations"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
 	}
@@ -78,11 +101,28 @@ func TestRunStatusJSON(t *testing.T) {
 	if len(payload.Errors) != 0 {
 		t.Fatalf("errors = %+v, want none", payload.Errors)
 	}
-	if payload.Result.ConfigPath == "" || payload.Result.IndexPath == "" {
-		t.Fatalf("result = %+v, want non-empty config and index paths", payload.Result)
+	if payload.Result.WorkspaceRoot == "" || payload.Result.ConfigPath == "" || payload.Result.IndexPath == "" {
+		t.Fatalf("result = %+v, want non-empty workspace, config, and index paths", payload.Result)
 	}
 	if !payload.Result.IndexExists {
 		t.Fatalf("result = %+v, want index_exists=true", payload.Result)
+	}
+	if got, want := payload.Result.ConfigResolution.SelectedBy, configSourceDiscovery; got != want {
+		t.Fatalf("config_resolution.selected_by = %q, want %q", got, want)
+	}
+	if payload.Result.ConfigResolution.Reason == "" || len(payload.Result.ConfigResolution.Candidates) < 4 {
+		t.Fatalf("config_resolution = %+v, want reason and candidates", payload.Result.ConfigResolution)
+	}
+	if payload.Result.ArtifactLocations.IndexDir == "" ||
+		payload.Result.ArtifactLocations.DiscoverConfigPath == "" ||
+		payload.Result.ArtifactLocations.CanonicalizeBundleRoot == "" {
+		t.Fatalf("artifact_locations = %+v, want explicit artifact paths", payload.Result.ArtifactLocations)
+	}
+	if len(payload.Result.ArtifactLocations.IgnorePatterns) == 0 || payload.Result.ArtifactLocations.IgnorePatterns[0] != ".pituitary/" {
+		t.Fatalf("artifact_locations.ignore_patterns = %v, want .pituitary/", payload.Result.ArtifactLocations.IgnorePatterns)
+	}
+	if len(payload.Result.ArtifactLocations.RelocationHints) < 3 {
+		t.Fatalf("artifact_locations.relocation_hints = %v, want relocation guidance", payload.Result.ArtifactLocations.RelocationHints)
 	}
 	if payload.Result.SpecCount != 3 || payload.Result.DocCount != 2 || payload.Result.ChunkCount != 17 {
 		t.Fatalf("result = %+v, want 3 specs, 2 docs, 17 chunks", payload.Result)
@@ -236,5 +276,85 @@ func TestRunStatusReportsConfigError(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "pituitary status: no config found") {
 		t.Fatalf("runStatus() stderr %q does not contain config discovery error", stderr.String())
+	}
+}
+
+func TestRunStatusJSONExplainsShadowedDiscoveredConfig(t *testing.T) {
+	repo := t.TempDir()
+	resolvedRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks(%q) error = %v", repo, err)
+	}
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+	mustMkdirAllCmd(t, filepath.Join(repo, ".pituitary"))
+	mustWriteIndexFixture(t, filepath.Join(repo, ".pituitary"), `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus([]string{"--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runStatus() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			ConfigPath       string `json:"config_path"`
+			ConfigResolution struct {
+				SelectedBy string `json:"selected_by"`
+				Reason     string `json:"reason"`
+				Candidates []struct {
+					Path   string `json:"path"`
+					Status string `json:"status"`
+				} `json:"candidates"`
+			} `json:"config_resolution"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status payload: %v", err)
+	}
+	if got, want := payload.Result.ConfigPath, filepath.Join(resolvedRepo, ".pituitary", "pituitary.toml"); got != want {
+		t.Fatalf("config_path = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.ConfigResolution.SelectedBy, configSourceDiscovery; got != want {
+		t.Fatalf("selected_by = %q, want %q", got, want)
+	}
+	var foundShadowed bool
+	for _, candidate := range payload.Result.ConfigResolution.Candidates {
+		if candidate.Path == filepath.Join(resolvedRepo, "pituitary.toml") && candidate.Status == "shadowed" {
+			foundShadowed = true
+			break
+		}
+	}
+	if !foundShadowed {
+		t.Fatalf("candidates = %+v, want shadowed root config", payload.Result.ConfigResolution.Candidates)
+	}
+	if !strings.Contains(payload.Result.ConfigResolution.Reason, filepath.ToSlash(filepath.Join(resolvedRepo, "pituitary.toml"))) {
+		t.Fatalf("reason = %q, want shadowed root config path", payload.Result.ConfigResolution.Reason)
 	}
 }

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -11,10 +11,16 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 )
 
+const (
+	discoverDefaultConfigName = "pituitary.toml"
+	discoverLocalConfigDir    = ".pituitary"
+)
+
 // DiscoverOptions controls how workspace discovery runs.
 type DiscoverOptions struct {
-	RootPath string
-	Write    bool
+	RootPath   string
+	ConfigPath string
+	Write      bool
 }
 
 // DiscoverResult reports a conservative source proposal for one workspace.
@@ -88,7 +94,7 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 		return nil, fmt.Errorf("no likely sources discovered under %s", filepath.ToSlash(workspaceRoot))
 	}
 
-	cfg, err := buildDiscoveredConfig(workspaceRoot, sources)
+	cfg, err := buildDiscoveredConfig(workspaceRoot, strings.TrimSpace(options.ConfigPath), sources)
 	if err != nil {
 		return nil, err
 	}
@@ -423,13 +429,16 @@ func buildDiscoveredSource(workspaceRoot, fallbackName, kind string, candidates 
 	}, true
 }
 
-func buildDiscoveredConfig(workspaceRoot string, sources []DiscoveredSource) (*config.Config, error) {
-	configPath := filepath.Join(workspaceRoot, ".pituitary", "pituitary.toml")
+func buildDiscoveredConfig(workspaceRoot, requestedConfigPath string, sources []DiscoveredSource) (*config.Config, error) {
+	configPath, configDir, workspaceSetting, err := resolveDiscoveredConfigPath(workspaceRoot, requestedConfigPath)
+	if err != nil {
+		return nil, err
+	}
 	cfg := &config.Config{
 		ConfigPath: configPath,
-		ConfigDir:  workspaceRoot,
+		ConfigDir:  configDir,
 		Workspace: config.Workspace{
-			Root:      ".",
+			Root:      workspaceSetting,
 			RootPath:  workspaceRoot,
 			IndexPath: filepath.ToSlash(filepath.Join(".pituitary", "pituitary.db")),
 		},
@@ -462,6 +471,42 @@ func buildDiscoveredConfig(workspaceRoot string, sources []DiscoveredSource) (*c
 		return nil, fmt.Errorf("validate discovered config: %w", err)
 	}
 	return cfg, nil
+}
+
+func resolveDiscoveredConfigPath(workspaceRoot, requestedConfigPath string) (string, string, string, error) {
+	configPath := strings.TrimSpace(requestedConfigPath)
+	if configPath == "" {
+		configPath = filepath.Join(workspaceRoot, discoverLocalConfigDir, discoverDefaultConfigName)
+	} else if !filepath.IsAbs(configPath) {
+		configPath = filepath.Join(workspaceRoot, configPath)
+	}
+
+	absoluteConfigPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve discovered config path %q: %w", configPath, err)
+	}
+	if !pathWithinRoot(workspaceRoot, absoluteConfigPath) {
+		return "", "", "", fmt.Errorf("discover config path %q resolves outside workspace root %q", requestedConfigPath, filepath.ToSlash(workspaceRoot))
+	}
+
+	configDir := discoveredConfigBaseDir(absoluteConfigPath)
+	workspaceSetting, err := filepath.Rel(configDir, workspaceRoot)
+	if err != nil {
+		return "", "", "", fmt.Errorf("relativize workspace root against config path: %w", err)
+	}
+	workspaceSetting = filepath.ToSlash(workspaceSetting)
+	if workspaceSetting == "" {
+		workspaceSetting = "."
+	}
+	return absoluteConfigPath, configDir, workspaceSetting, nil
+}
+
+func discoveredConfigBaseDir(configPath string) string {
+	configDir := filepath.Dir(configPath)
+	if filepath.Base(configPath) == discoverDefaultConfigName && filepath.Base(configDir) == discoverLocalConfigDir {
+		return filepath.Dir(configDir)
+	}
+	return configDir
 }
 
 func writeDiscoveredConfig(path, content string) error {

--- a/internal/source/discover_test.go
+++ b/internal/source/discover_test.go
@@ -74,3 +74,45 @@ Applies To:
 		t.Fatal("generated config = empty, want TOML")
 	}
 }
+
+func TestDiscoverWorkspaceSupportsCustomConfigPath(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "specs", "rate-limit-v2", "spec.toml"), `
+id = "SPEC-042"
+title = "Per-Tenant API Rate Limits"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(t, filepath.Join(repo, "specs", "rate-limit-v2", "body.md"), `
+# Per-Tenant API Rate Limits
+`)
+	customConfigPath := filepath.Join(repo, "tools", "pituitary.local.toml")
+
+	result, err := DiscoverWorkspace(DiscoverOptions{
+		RootPath:   repo,
+		ConfigPath: filepath.ToSlash(filepath.Join("tools", "pituitary.local.toml")),
+		Write:      true,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverWorkspace() error = %v", err)
+	}
+
+	if got, want := result.ConfigPath, customConfigPath; got != want {
+		t.Fatalf("config path = %q, want %q", got, want)
+	}
+	if !result.WroteConfig {
+		t.Fatalf("result = %+v, want wrote_config=true", result)
+	}
+
+	cfg, err := config.Load(result.ConfigPath)
+	if err != nil {
+		t.Fatalf("config.Load(custom discovered config) error = %v", err)
+	}
+	if got, want := cfg.Workspace.RootPath, repo; got != want {
+		t.Fatalf("workspace root path = %q, want %q", got, want)
+	}
+	if got, want := cfg.Workspace.ResolvedIndexPath, filepath.Join(repo, ".pituitary", "pituitary.db"); got != want {
+		t.Fatalf("resolved index path = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- explain config precedence and shadowed candidates in pituitary status
- surface artifact locations and relocation hints, and support pituitary discover --config-path
- document the new status/discovery behavior and cover it with CLI/source tests

## Validation
- go test ./cmd ./internal/source

Closes #70
Closes #71
