### PR TITLE
[feature] Reduce overlap noise for mature specs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -586,7 +586,7 @@ CLI exit codes should stay simple:
   - Result: `{ "matches": [{ "ref": "SPEC-042", "title": "...", "section_heading": "...", "score": 0.0, "excerpt": "...", "source_ref": "file://..." }] }`
 - `check_overlap` (`pituitary check-overlap`)
   - Request: `{ "spec_ref": "SPEC-042" }` or `{ "spec_record": { ... canonical spec record ... } }`
-  - Result: `{ "candidate": { "ref": "SPEC-042", "title": "..." }, "overlaps": [{ "ref": "SPEC-008", "score": 0.0, "overlap_degree": "high", "relationship": "extends" }], "recommendation": "proceed_with_supersedes" }`
+  - Result: `{ "candidate": { "ref": "SPEC-042", "title": "..." }, "overlaps": [{ "ref": "SPEC-008", "score": 0.0, "overlap_degree": "high", "relationship": "extends", "guidance": "merge_candidate" }], "recommendation": "proceed_with_supersedes" }`
 - `compare_specs` (`pituitary compare-specs`)
   - Request: `{ "spec_refs": ["SPEC-008", "SPEC-042"] }`
   - Result: `{ "spec_refs": ["SPEC-008", "SPEC-042"], "comparison": { "shared_scope": [...], "differences": [...], "tradeoffs": [...], "recommendation": "..." } }`
@@ -647,7 +647,8 @@ Process:
 
 Output:
   overlaps[]
-  recommendation = proceed_with_supersedes | merge_into_existing | no_overlap
+  overlaps[].guidance = merge_candidate | boundary_review
+  recommendation = proceed_with_supersedes | merge_into_existing | review_boundaries | no_overlap
 ```
 
 #### Tool: `compare_specs`

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Every command supports `--format json` for machine-readable output. `search-spec
 
 By default, `search-specs` down-ranks sections that look like historical provenance or history so active normative content wins first. If your query explicitly asks for historical context, those sections stay fully accessible.
 
+`check-overlap` keeps weaker structural matches visible, but it now reserves `merge_into_existing` for strong merge candidates. Mature accepted specs usually surface `review_boundaries` instead, so overlap stays visible without implying that every adjacency should collapse into one spec.
+
 ### Example: full spec review
 
 Path-first commands accept workspace-relative paths, absolute paths, bundle directories, `spec.toml` files, `body.md` files, and inferred `markdown_contract` files. Internally they still normalize to canonical indexed refs.

--- a/cmd/check_overlap_test.go
+++ b/cmd/check_overlap_test.go
@@ -110,6 +110,58 @@ func TestRunCheckOverlapWithPathJSON(t *testing.T) {
 	}
 }
 
+func TestRunCheckOverlapReportsBoundaryReviewForMatureAcceptedSpecs(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runCheckOverlap([]string{"--path", "specs/burst-handling", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckOverlap() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckOverlap() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Candidate struct {
+				Ref string `json:"ref"`
+			} `json:"candidate"`
+			Overlaps []struct {
+				Ref          string `json:"ref"`
+				Relationship string `json:"relationship"`
+				Guidance     string `json:"guidance"`
+			} `json:"overlaps"`
+			Recommendation string `json:"recommendation"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal overlap payload: %v", err)
+	}
+	if got, want := payload.Result.Candidate.Ref, "SPEC-055"; got != want {
+		t.Fatalf("candidate ref = %q, want %q", got, want)
+	}
+	if len(payload.Result.Overlaps) == 0 || payload.Result.Overlaps[0].Ref != "SPEC-042" {
+		t.Fatalf("overlaps = %+v, want SPEC-042 first", payload.Result.Overlaps)
+	}
+	if got, want := payload.Result.Overlaps[0].Relationship, "adjacent"; got != want {
+		t.Fatalf("relationship = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.Overlaps[0].Guidance, "boundary_review"; got != want {
+		t.Fatalf("guidance = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.Recommendation, "review_boundaries"; got != want {
+		t.Fatalf("recommendation = %q, want %q", got, want)
+	}
+}
+
 func TestRunCheckOverlapWithSpecRecordFileJSON(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -394,13 +394,13 @@ func renderOverlapResult(w io.Writer, result *analysis.OverlapResult) {
 	fmt.Fprintf(w, "candidate: %s | %s\n", result.Candidate.Ref, result.Candidate.Title)
 	if len(result.Overlaps) == 0 {
 		fmt.Fprintln(w, "no overlaps")
-		fmt.Fprintf(w, "recommendation: %s\n", result.Recommendation)
+		renderOverlapRecommendation(w, result.Recommendation)
 		return
 	}
 	for i, overlap := range result.Overlaps {
-		fmt.Fprintf(w, "%d. %s | %s | %.3f | %s | %s\n", i+1, overlap.Ref, overlap.Title, overlap.Score, overlap.OverlapDegree, overlap.Relationship)
+		fmt.Fprintf(w, "%d. %s | %s | %.3f | %s | %s | %s\n", i+1, overlap.Ref, overlap.Title, overlap.Score, overlap.OverlapDegree, overlap.Relationship, humanizeOverlapGuidance(overlap.Guidance))
 	}
-	fmt.Fprintf(w, "recommendation: %s\n", result.Recommendation)
+	renderOverlapRecommendation(w, result.Recommendation)
 }
 
 func renderCompareResult(w io.Writer, result *analysis.CompareResult) {
@@ -588,10 +588,14 @@ func renderReviewResult(w io.Writer, result *analysis.ReviewResult) {
 	fmt.Fprintf(w, "spec: %s\n", result.SpecRef)
 
 	if result.Overlap != nil {
-		fmt.Fprintf(w, "overlaps: %d | recommendation: %s\n", len(result.Overlap.Overlaps), result.Overlap.Recommendation)
+		fmt.Fprintf(w, "overlaps: %d | recommendation: %s", len(result.Overlap.Overlaps), result.Overlap.Recommendation)
+		if detail := humanizeOverlapRecommendation(result.Overlap.Recommendation); detail != "" {
+			fmt.Fprintf(w, " | %s", detail)
+		}
+		fmt.Fprintln(w)
 		if len(result.Overlap.Overlaps) > 0 {
 			top := result.Overlap.Overlaps[0]
-			fmt.Fprintf(w, "top overlap: %s | %s | %.3f\n", top.Ref, top.Relationship, top.Score)
+			fmt.Fprintf(w, "top overlap: %s | %s | %.3f | %s\n", top.Ref, top.Relationship, top.Score, humanizeOverlapGuidance(top.Guidance))
 		}
 	}
 	if result.Comparison != nil {
@@ -626,12 +630,16 @@ func renderReviewMarkdown(w io.Writer, result *analysis.ReviewResult) {
 	if result.Overlap == nil {
 		fmt.Fprintln(w, "No overlap analysis.")
 	} else {
-		fmt.Fprintf(w, "- Recommendation: `%s`\n", result.Overlap.Recommendation)
+		fmt.Fprintf(w, "- Recommendation: `%s`", result.Overlap.Recommendation)
+		if detail := humanizeOverlapRecommendation(result.Overlap.Recommendation); detail != "" {
+			fmt.Fprintf(w, " (%s)", detail)
+		}
+		fmt.Fprintln(w)
 		if len(result.Overlap.Overlaps) == 0 {
 			fmt.Fprintln(w, "- No overlapping specs detected.")
 		} else {
 			for _, item := range result.Overlap.Overlaps {
-				fmt.Fprintf(w, "- `%s` %s (%s, %.3f)\n", item.Ref, item.Title, item.Relationship, item.Score)
+				fmt.Fprintf(w, "- `%s` %s (%s, %.3f, %s)\n", item.Ref, item.Title, item.Relationship, item.Score, humanizeOverlapGuidance(item.Guidance))
 			}
 		}
 	}
@@ -723,6 +731,38 @@ func renderReviewMarkdown(w io.Writer, result *analysis.ReviewResult) {
 			}
 		}
 		fmt.Fprintln(w)
+	}
+}
+
+func renderOverlapRecommendation(w io.Writer, recommendation string) {
+	fmt.Fprintf(w, "recommendation: %s", recommendation)
+	if detail := humanizeOverlapRecommendation(recommendation); detail != "" {
+		fmt.Fprintf(w, " | %s", detail)
+	}
+	fmt.Fprintln(w)
+}
+
+func humanizeOverlapRecommendation(recommendation string) string {
+	switch recommendation {
+	case "review_boundaries":
+		return "real overlap, but clarify boundaries before merging"
+	case "merge_into_existing":
+		return "strong merge candidate"
+	case "proceed_with_supersedes":
+		return "candidate already declares the replacement path"
+	default:
+		return ""
+	}
+}
+
+func humanizeOverlapGuidance(guidance string) string {
+	switch guidance {
+	case "merge_candidate":
+		return "merge candidate"
+	case "boundary_review":
+		return "boundary review"
+	default:
+		return guidance
 	}
 }
 

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -403,6 +403,62 @@ func TestRenderReviewResultIncludesTopImpactSummaries(t *testing.T) {
 	}
 }
 
+func TestRenderOverlapResultShowsBoundaryReviewGuidance(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	renderOverlapResult(&stdout, &analysis.OverlapResult{
+		Candidate: analysis.OverlapCandidate{Ref: "SPEC-055", Title: "Burst Handling"},
+		Overlaps: []analysis.OverlapItem{
+			{
+				Ref:           "SPEC-042",
+				Title:         "Per-Tenant Rate Limiting",
+				Score:         0.811,
+				OverlapDegree: "high",
+				Relationship:  "adjacent",
+				Guidance:      "boundary_review",
+			},
+		},
+		Recommendation: "review_boundaries",
+	})
+
+	output := stdout.String()
+	for _, want := range []string{
+		"candidate: SPEC-055 | Burst Handling",
+		"SPEC-042 | Per-Tenant Rate Limiting | 0.811 | high | adjacent | boundary review",
+		"recommendation: review_boundaries | real overlap, but clarify boundaries before merging",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("renderOverlapResult() output %q does not contain %q", output, want)
+		}
+	}
+}
+
+func TestRenderReviewResultShowsOverlapGuidance(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	renderReviewResult(&stdout, &analysis.ReviewResult{
+		SpecRef: "SPEC-055",
+		Overlap: &analysis.OverlapResult{
+			Recommendation: "review_boundaries",
+			Overlaps: []analysis.OverlapItem{
+				{Ref: "SPEC-042", Relationship: "adjacent", Score: 0.811, Guidance: "boundary_review"},
+			},
+		},
+	})
+
+	output := stdout.String()
+	for _, want := range []string{
+		"overlaps: 1 | recommendation: review_boundaries | real overlap, but clarify boundaries before merging",
+		"top overlap: SPEC-042 | adjacent | 0.811 | boundary review",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("renderReviewResult() output %q does not contain %q", output, want)
+		}
+	}
+}
+
 func TestRenderCommandMarkdownReviewSpec(t *testing.T) {
 	t.Parallel()
 
@@ -413,7 +469,7 @@ func TestRenderCommandMarkdownReviewSpec(t *testing.T) {
 		Overlap: &analysis.OverlapResult{
 			Recommendation: "proceed_with_supersedes",
 			Overlaps: []analysis.OverlapItem{
-				{Ref: "SPEC-008", Title: "Legacy Rate Limiting", Relationship: "extends", Score: 0.922},
+				{Ref: "SPEC-008", Title: "Legacy Rate Limiting", Relationship: "extends", Score: 0.922, Guidance: "merge_candidate"},
 			},
 		},
 		Comparison: &analysis.CompareResult{
@@ -470,7 +526,7 @@ func TestRenderCommandMarkdownReviewSpec(t *testing.T) {
 	for _, want := range []string{
 		"# Review Spec Report",
 		"## Overlap",
-		"`SPEC-008`",
+		"`SPEC-008` Legacy Rate Limiting (extends, 0.922, merge candidate)",
 		"## Comparison",
 		"## Impact",
 		"Top impacted specs",

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -15,7 +15,11 @@ import (
 	"github.com/dusk-network/pituitary/internal/model"
 )
 
-const overlapThreshold = 0.45
+const (
+	overlapThreshold           = 0.45
+	overlapDraftMergeThreshold = 0.8
+	overlapDuplicateThreshold  = 0.82
+)
 
 // OverlapRequest is the normalized input for overlap detection.
 type OverlapRequest struct {
@@ -41,6 +45,7 @@ type OverlapItem struct {
 	Score           float64                    `json:"score"`
 	OverlapDegree   string                     `json:"overlap_degree"`
 	Relationship    string                     `json:"relationship"`
+	Guidance        string                     `json:"guidance"`
 	SharedAppliesTo []string                   `json:"shared_applies_to,omitempty"`
 	Inference       *model.InferenceConfidence `json:"inference,omitempty"`
 }
@@ -125,6 +130,7 @@ func buildOverlapResult(candidate *specDocument, targets map[string]specDocument
 		}
 
 		sharedAppliesTo := sharedStrings(candidate.Record.AppliesTo, target.Record.AppliesTo)
+		relationship := overlapRelationship(candidate.Record, target.Record, score)
 		overlaps = append(overlaps, OverlapItem{
 			Ref:             target.Record.Ref,
 			Title:           target.Record.Title,
@@ -132,7 +138,8 @@ func buildOverlapResult(candidate *specDocument, targets map[string]specDocument
 			Domain:          target.Record.Domain,
 			Score:           roundScore(score),
 			OverlapDegree:   overlapDegree(score),
-			Relationship:    overlapRelationship(candidate.Record, target.Record, score),
+			Relationship:    relationship,
+			Guidance:        overlapGuidance(candidate.Record, score, relationship),
 			SharedAppliesTo: sharedAppliesTo,
 			Inference:       target.Record.Inference,
 		})
@@ -142,6 +149,8 @@ func buildOverlapResult(candidate *specDocument, targets map[string]specDocument
 		switch {
 		case overlaps[i].Score != overlaps[j].Score:
 			return overlaps[i].Score > overlaps[j].Score
+		case overlaps[i].Guidance != overlaps[j].Guidance:
+			return overlapGuidancePriority(overlaps[i].Guidance) < overlapGuidancePriority(overlaps[j].Guidance)
 		default:
 			return overlaps[i].Ref < overlaps[j].Ref
 		}
@@ -611,10 +620,44 @@ func overlapRelationship(candidate, target model.SpecRecord, score float64) stri
 	case relationExists(candidate.Relations, model.RelationSupersedes, target.Ref),
 		relationExists(target.Relations, model.RelationSupersedes, candidate.Ref):
 		return "extends"
-	case sharedSet(candidate.AppliesTo, target.AppliesTo) && score >= 0.82:
+	case relationExists(candidate.Relations, model.RelationDependsOn, target.Ref),
+		relationExists(target.Relations, model.RelationDependsOn, candidate.Ref):
+		return "adjacent"
+	case sharedSet(candidate.AppliesTo, target.AppliesTo) && score >= overlapDuplicateThreshold:
 		return "duplicates"
 	default:
-		return "extends"
+		return "adjacent"
+	}
+}
+
+func overlapGuidance(candidate model.SpecRecord, score float64, relationship string) string {
+	switch {
+	case relationship == "duplicates" && score >= overlapDuplicateThreshold:
+		return "merge_candidate"
+	case overlapCandidateStillMutable(candidate) && relationship == "extends" && score >= overlapDraftMergeThreshold:
+		return "merge_candidate"
+	default:
+		return "boundary_review"
+	}
+}
+
+func overlapCandidateStillMutable(candidate model.SpecRecord) bool {
+	switch candidate.Status {
+	case model.StatusDraft, model.StatusReview:
+		return true
+	default:
+		return false
+	}
+}
+
+func overlapGuidancePriority(guidance string) int {
+	switch guidance {
+	case "merge_candidate":
+		return 0
+	case "boundary_review":
+		return 1
+	default:
+		return 2
 	}
 }
 
@@ -627,10 +670,10 @@ func overlapRecommendation(candidate model.SpecRecord, overlaps []OverlapItem) s
 			return "proceed_with_supersedes"
 		}
 	}
-	if overlaps[0].OverlapDegree == "high" {
+	if overlaps[0].Guidance == "merge_candidate" {
 		return "merge_into_existing"
 	}
-	return "merge_into_existing"
+	return "review_boundaries"
 }
 
 func roundScore(score float64) float64 {

--- a/internal/analysis/overlap_test.go
+++ b/internal/analysis/overlap_test.go
@@ -69,6 +69,7 @@ func TestCheckOverlapSupportsDraftSpecRecord(t *testing.T) {
 	base.Ref = "SPEC-900"
 	base.Title = "Draft Rate Limiting Update"
 	base.Status = model.StatusDraft
+	base.Relations = nil
 
 	result, err := CheckOverlap(cfg, OverlapRequest{SpecRecord: &base})
 	if err != nil {
@@ -79,6 +80,45 @@ func TestCheckOverlapSupportsDraftSpecRecord(t *testing.T) {
 	}
 	if result.Overlaps[0].Ref != "SPEC-042" {
 		t.Fatalf("top draft overlap = %+v, want SPEC-042", result.Overlaps[0])
+	}
+	if got, want := result.Overlaps[0].Guidance, "merge_candidate"; got != want {
+		t.Fatalf("top draft guidance = %q, want %q", got, want)
+	}
+	if got, want := result.Recommendation, "merge_into_existing"; got != want {
+		t.Fatalf("draft recommendation = %q, want %q", got, want)
+	}
+}
+
+func TestCheckOverlapTreatsDependentAcceptedSpecsAsBoundaryReview(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := CheckOverlap(cfg, OverlapRequest{SpecRef: "SPEC-055"})
+	if err != nil {
+		t.Fatalf("CheckOverlap() error = %v", err)
+	}
+	if len(result.Overlaps) == 0 {
+		t.Fatal("CheckOverlap() returned no overlaps")
+	}
+	if got, want := result.Overlaps[0].Ref, "SPEC-042"; got != want {
+		t.Fatalf("top overlap ref = %q, want %q", got, want)
+	}
+	if got, want := result.Overlaps[0].Relationship, "adjacent"; got != want {
+		t.Fatalf("top overlap relationship = %q, want %q", got, want)
+	}
+	if got, want := result.Overlaps[0].Guidance, "boundary_review"; got != want {
+		t.Fatalf("top overlap guidance = %q, want %q", got, want)
+	}
+	if got, want := result.Recommendation, "review_boundaries"; got != want {
+		t.Fatalf("recommendation = %q, want %q", got, want)
 	}
 }
 

--- a/internal/analysis/review_test.go
+++ b/internal/analysis/review_test.go
@@ -95,6 +95,36 @@ func TestReviewSpecSupportsDraftSpecRecord(t *testing.T) {
 	}
 }
 
+func TestReviewSpecCarriesBoundaryReviewOverlapGuidance(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := ReviewSpec(cfg, ReviewRequest{SpecRef: "SPEC-055"})
+	if err != nil {
+		t.Fatalf("ReviewSpec() error = %v", err)
+	}
+	if result.Overlap == nil || len(result.Overlap.Overlaps) == 0 {
+		t.Fatalf("overlap = %+v, want composed overlap", result.Overlap)
+	}
+	if got, want := result.Overlap.Overlaps[0].Ref, "SPEC-042"; got != want {
+		t.Fatalf("top overlap ref = %q, want %q", got, want)
+	}
+	if got, want := result.Overlap.Overlaps[0].Guidance, "boundary_review"; got != want {
+		t.Fatalf("top overlap guidance = %q, want %q", got, want)
+	}
+	if got, want := result.Overlap.Recommendation, "review_boundaries"; got != want {
+		t.Fatalf("recommendation = %q, want %q", got, want)
+	}
+}
+
 func TestReviewSpecSurfacesStaleNamedArtifacts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add overlap guidance so weak structural matches stay visible without defaulting to merge advice
- reserve merge_into_existing for strong merge candidates and use review_boundaries for mature adjacent specs
- update overlap and review rendering, docs, and regression coverage around accepted dependent specs

## Validation
- go test ./...

Closes #69