### PR TITLE
[feature] Add config schema versioning and migration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,6 +79,8 @@ The first ship should use one repo-local config file:
 `pituitary.toml`
 
 ```toml
+schema_version = 2
+
 [workspace]
 root = "."
 index_path = ".pituitary/pituitary.db"
@@ -105,6 +107,8 @@ include = ["**/*.md"]
 ```
 
 This keeps the first ship explicit and easy to reason about. The indexed config remains explicit even as the repo grows into inferred-contract sources: `pituitary discover` may propose a local `.pituitary/pituitary.toml`, but it must stay conservative, inspectable before write, and never introduce hidden indexing behavior behind the user's back.
+
+When the config schema changes, Pituitary should detect older known shapes explicitly and provide a migration path instead of failing with a generic unsupported-section error. The current schema is versioned with `schema_version = 2`, and legacy `[project]` configs should be rewritten through `pituitary migrate-config`.
 
 Inferred `markdown_contract` records must preserve confidence metadata alongside the normalized artifact so result surfaces can distinguish strong explicit extraction from weaker path/default fallbacks. Search should expose those confidence signals inline, while higher-stakes outputs such as impact and doc-drift should elevate weak inference as warnings instead of silently treating it as equally strong.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ When you run `pituitary index --rebuild`, Pituitary:
 The workspace is configured with a `pituitary.toml` at your project root:
 
 ```toml
+schema_version = 2
+
 [workspace]
 root = "."
 index_path = ".pituitary/pituitary.db"
@@ -162,6 +164,12 @@ For an existing repo without a hand-written config yet, the default onboarding f
 ./pituitary index --rebuild
 ```
 
+If you still have a legacy config shaped like `[project]` with `specs_dir = "specs"`, migrate it with:
+
+```sh
+./pituitary migrate-config --path pituitary.toml --write
+```
+
 ## Commands
 
 Every command supports `--format json` for machine-readable output. `search-specs` also supports `--format table` for compact terminal summaries, and `review-spec` also supports `--format markdown` for shareable review reports.
@@ -169,6 +177,7 @@ Every command supports `--format json` for machine-readable output. `search-spec
 | Command | What it does |
 |---|---|
 | `discover --path .` | Scan a repo, propose conservative sources for specs, contracts, guides, runbooks, and reference docs, and show the generated local config |
+| `migrate-config --path pituitary.toml --write` | Rewrite a legacy or unversioned config into the current schema |
 | `preview-sources` | Show which files each configured source will index |
 | `explain-file docs/guides/api-rate-limits.md` | Explain how one file is classified by configured sources |
 | `canonicalize --path rfcs/service-sla.md` | Generate a suggested `spec.toml` + `body.md` bundle from one inferred contract |

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -11,6 +11,7 @@ func TestRunCommandHelpAcrossSurface(t *testing.T) {
 
 	testCases := map[string][]string{
 		"index":             {"usage: pituitary [--config PATH] index (--rebuild | --dry-run) [--format FORMAT]", "shared config resolution:", "PITUITARY_CONFIG", "--rebuild", "--dry-run", "--verbose"},
+		"migrate-config":    {"usage: pituitary migrate-config [--path PATH] [--write] [--format FORMAT]", "--path VALUE", "--write"},
 		"status":            {"usage: pituitary [--config PATH] status [--format FORMAT] [--check-runtime SCOPE]", "shared config resolution:", "--format VALUE", "--check-runtime VALUE"},
 		"preview-sources":   {"usage: pituitary [--config PATH] preview-sources", "shared config resolution:", "--format VALUE"},
 		"explain-file":      {"usage: pituitary [--config PATH] explain-file PATH [--format FORMAT]", "shared config resolution:", "--format VALUE"},

--- a/cmd/migrate_config.go
+++ b/cmd/migrate_config.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+type migrateConfigRequest struct {
+	Path  string `json:"path"`
+	Write bool   `json:"write,omitempty"`
+}
+
+type migrateConfigResult struct {
+	ConfigPath          string   `json:"config_path"`
+	DetectedSchema      string   `json:"detected_schema"`
+	TargetSchemaVersion int      `json:"target_schema_version"`
+	WroteConfig         bool     `json:"wrote_config"`
+	Notes               []string `json:"notes,omitempty"`
+	Config              string   `json:"config"`
+}
+
+func runMigrateConfig(args []string, stdout, stderr io.Writer) int {
+	return runMigrateConfigContext(context.Background(), args, stdout, stderr)
+}
+
+func runMigrateConfigContext(_ context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("migrate-config", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	help := newStandaloneCommandHelp("migrate-config", "pituitary migrate-config [--path PATH] [--write] [--format FORMAT]")
+
+	var (
+		path   string
+		write  bool
+		format string
+	)
+	fs.StringVar(&path, "path", defaultConfigName, "path to the config file to migrate")
+	fs.BoolVar(&write, "write", false, "rewrite the config in place")
+	fs.StringVar(&format, "format", "text", "output format")
+
+	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
+		return writeCLIError(stdout, stderr, format, "migrate-config", nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	} else if handled {
+		return 0
+	}
+	if fs.NArg() != 0 {
+		return writeCLIError(stdout, stderr, format, "migrate-config", nil, cliIssue{
+			Code:    "validation_error",
+			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
+		}, 2)
+	}
+	if err := validateCLIFormat("migrate-config", format); err != nil {
+		return writeCLIError(stdout, stderr, format, "migrate-config", migrateConfigRequest{Path: path, Write: write}, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	request := migrateConfigRequest{
+		Path:  strings.TrimSpace(path),
+		Write: write,
+	}
+	if request.Path == "" {
+		request.Path = defaultConfigName
+	}
+
+	migration, err := config.MigrateFile(request.Path)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "migrate-config", request, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+	rendered, err := config.Render(migration.Config)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "migrate-config", request, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	if write {
+		if err := os.WriteFile(migration.Config.ConfigPath, []byte(rendered), 0o644); err != nil {
+			return writeCLIError(stdout, stderr, format, "migrate-config", request, cliIssue{
+				Code:    "config_error",
+				Message: fmt.Sprintf("write migrated config: %v", err),
+			}, 2)
+		}
+	}
+
+	return writeCLISuccess(stdout, stderr, format, "migrate-config", request, &migrateConfigResult{
+		ConfigPath:          migration.Config.ConfigPath,
+		DetectedSchema:      migration.DetectedSchema,
+		TargetSchemaVersion: config.CurrentSchemaVersion,
+		WroteConfig:         write,
+		Notes:               migration.Notes,
+		Config:              rendered,
+	}, nil)
+}

--- a/cmd/migrate_config_test.go
+++ b/cmd/migrate_config_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunMigrateConfigJSONPreview(t *testing.T) {
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, "pituitary.toml")
+	mustWriteFileCmd(t, configPath, `
+[project]
+id = "ccd"
+name = "Continuous Context Development"
+specs_dir = "specs"
+`)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runMigrateConfig([]string{"--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runMigrateConfig() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runMigrateConfig() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request migrateConfigRequest `json:"request"`
+		Result  struct {
+			ConfigPath          string   `json:"config_path"`
+			DetectedSchema      string   `json:"detected_schema"`
+			TargetSchemaVersion int      `json:"target_schema_version"`
+			WroteConfig         bool     `json:"wrote_config"`
+			Notes               []string `json:"notes"`
+			Config              string   `json:"config"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal migrate-config payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if got, want := payload.Request.Path, defaultConfigName; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	if payload.Result.WroteConfig {
+		t.Fatalf("result = %+v, want preview without write", payload.Result)
+	}
+	if got, want := payload.Result.DetectedSchema, "project.v1"; got != want {
+		t.Fatalf("detected schema = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.TargetSchemaVersion, 2; got != want {
+		t.Fatalf("target schema version = %d, want %d", got, want)
+	}
+	if !strings.Contains(payload.Result.Config, "schema_version = 2") {
+		t.Fatalf("migrated config %q does not contain schema_version", payload.Result.Config)
+	}
+}
+
+func TestRunMigrateConfigWriteOverwritesFile(t *testing.T) {
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, "pituitary.toml")
+	mustWriteFileCmd(t, configPath, `
+[project]
+id = "ccd"
+name = "Continuous Context Development"
+specs_dir = "specs"
+`)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runMigrateConfig([]string{"--write"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runMigrateConfig(--write) exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runMigrateConfig(--write) wrote unexpected stderr: %q", stderr.String())
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	if !strings.Contains(string(content), "schema_version = 2") {
+		t.Fatalf("written config %q does not contain schema_version", string(content))
+	}
+	if strings.Contains(string(content), "[project]") {
+		t.Fatalf("written config %q still contains legacy project section", string(content))
+	}
+}
+
+func TestRunMigrateConfigHelpDoesNotAdvertiseConfigResolution(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"migrate-config", "--help"}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("Run(migrate-config, --help) exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run(migrate-config, --help) wrote unexpected stderr: %q", stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "shared config resolution:") {
+		t.Fatalf("migrate-config help %q unexpectedly advertises config resolution", out)
+	}
+	if !strings.Contains(out, "usage: pituitary migrate-config [--path PATH] [--write] [--format FORMAT]") {
+		t.Fatalf("migrate-config help %q missing usage line", out)
+	}
+}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -24,6 +24,8 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 		renderCanonicalizeResult(w, typed)
 	case *source.DiscoverResult:
 		renderDiscoverResult(w, typed)
+	case *migrateConfigResult:
+		renderMigrateConfigResult(w, typed)
 	case *index.RebuildResult:
 		renderIndexResult(w, typed)
 	case *statusResult:
@@ -149,6 +151,22 @@ func renderCanonicalizeResult(w io.Writer, result *source.CanonicalizeResult) {
 			fmt.Fprintln(w)
 		}
 	}
+}
+
+func renderMigrateConfigResult(w io.Writer, result *migrateConfigResult) {
+	fmt.Fprintf(w, "config path: %s\n", result.ConfigPath)
+	fmt.Fprintf(w, "detected schema: %s\n", result.DetectedSchema)
+	fmt.Fprintf(w, "target schema_version: %d\n", result.TargetSchemaVersion)
+	if result.WroteConfig {
+		fmt.Fprintln(w, "config write: wrote migrated config")
+	} else {
+		fmt.Fprintln(w, "config write: skipped")
+	}
+	for _, note := range result.Notes {
+		fmt.Fprintf(w, "note: %s\n", note)
+	}
+	fmt.Fprintln(w, "migrated config:")
+	fmt.Fprint(w, result.Config)
 }
 
 func renderIndexSourceSummaries(w io.Writer, sources []source.LoadSourceSummary) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 var commands = map[string]string{
 	"canonicalize":      "promote an inferred contract into a spec bundle",
 	"discover":          "scan a repo and propose a local config",
+	"migrate-config":    "rewrite a legacy config into the current schema",
 	"index":             "rebuild or validate the local Pituitary index",
 	"status":            "show current index status",
 	"version":           "show Pituitary and Go runtime versions",
@@ -71,6 +72,9 @@ func RunContext(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	}
 	if name == "canonicalize" {
 		return runCanonicalizeContext(ctx, remainingArgs[1:], stdout, stderr)
+	}
+	if name == "migrate-config" {
+		return runMigrateConfigContext(ctx, remainingArgs[1:], stdout, stderr)
 	}
 	if name == "status" {
 		return runStatusContext(ctx, remainingArgs[1:], stdout, stderr)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -31,7 +32,7 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 				return
 			}
 
-			if name == "canonicalize" || name == "discover" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "review-spec" {
+			if name == "canonicalize" || name == "discover" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "review-spec" {
 				repoRoot := writeSearchWorkspace(t)
 				if name == "discover" || name == "canonicalize" {
 					repoRoot = writeDiscoveryWorkspace(t)
@@ -45,6 +46,21 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 				}
 				if name == "discover" {
 					args = []string{name, "--path", "."}
+					expectBootstrapStatus = false
+					exitCode := withWorkingDir(t, repoRoot, run)
+					assertKnownCommandResult(t, name, description, exitCode, stdout.String(), stderr.String(), expectBootstrapStatus)
+					return
+				}
+				if name == "migrate-config" {
+					repoRoot = t.TempDir()
+					mustWriteFileCmd(t, filepath.Join(repoRoot, "pituitary.toml"), `
+[project]
+id = "ccd"
+name = "Continuous Context Development"
+specs_dir = "specs"
+`)
+					mustMkdirAllCmd(t, filepath.Join(repoRoot, "specs"))
+					args = []string{name}
 					expectBootstrapStatus = false
 					exitCode := withWorkingDir(t, repoRoot, run)
 					assertKnownCommandResult(t, name, description, exitCode, stdout.String(), stderr.String(), expectBootstrapStatus)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	pathpkg "path"
@@ -13,6 +15,7 @@ import (
 )
 
 const (
+	CurrentSchemaVersion       = 2
 	AdapterFilesystem          = "filesystem"
 	SourceKindSpecBundle       = "spec_bundle"
 	SourceKindMarkdownDocs     = "markdown_docs"
@@ -24,11 +27,12 @@ const (
 
 // Config is the validated workspace configuration resolved from pituitary.toml.
 type Config struct {
-	ConfigPath string
-	ConfigDir  string
-	Workspace  Workspace
-	Runtime    Runtime
-	Sources    []Source
+	SchemaVersion int
+	ConfigPath    string
+	ConfigDir     string
+	Workspace     Workspace
+	Runtime       Runtime
+	Sources       []Source
 }
 
 // Workspace describes the configured workspace root and index path.
@@ -68,6 +72,7 @@ type RuntimeProvider struct {
 }
 
 type rawConfig struct {
+	schemaVersion   int
 	workspace       rawWorkspace
 	runtimeEmbedder rawRuntimeProvider
 	runtimeAnalysis rawRuntimeProvider
@@ -120,20 +125,34 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("resolve config path: %w", err)
 	}
 
-	file, err := os.Open(configPath)
+	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", configPath, err)
 	}
-	defer file.Close()
 
-	raw, err := parse(file)
+	if legacy, ok, err := detectLegacyProjectConfig(bytes.NewReader(data)); err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
+	} else if ok {
+		return nil, fmt.Errorf("%s: %s", configPath, legacyConfigLoadMessage(configPath, legacy))
+	}
+
+	raw, err := parse(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", configPath, err)
 	}
 
+	cfg, err := buildFromRaw(configPath, raw, true)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
+	}
+	return cfg, nil
+}
+
+func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (*Config, error) {
 	cfg := &Config{
-		ConfigPath: configPath,
-		ConfigDir:  configBaseDir(configPath),
+		SchemaVersion: raw.schemaVersion,
+		ConfigPath:    configPath,
+		ConfigDir:     configBaseDir(configPath),
 		Workspace: Workspace{
 			Root:      raw.workspace.root,
 			IndexPath: raw.workspace.indexPath,
@@ -172,10 +191,21 @@ func Load(path string) (*Config, error) {
 	if cfg.Runtime.Embedder.Provider == RuntimeProviderFixture && strings.TrimSpace(cfg.Runtime.Embedder.Model) == "" {
 		cfg.Runtime.Embedder.Model = "fixture-8d"
 	}
+	if cfg.SchemaVersion == 0 {
+		cfg.SchemaVersion = CurrentSchemaVersion
+	} else if enforceSchemaVersion && cfg.SchemaVersion != CurrentSchemaVersion {
+		return nil, fmt.Errorf(
+			"unsupported schema_version %d (supported: %d); run `pituitary migrate-config --path %s --write` if this is an older config",
+			cfg.SchemaVersion,
+			CurrentSchemaVersion,
+			filepath.ToSlash(configPath),
+		)
+	}
 
 	if err := validate(cfg); err != nil {
-		return nil, fmt.Errorf("%s: %w", configPath, err)
+		return nil, err
 	}
+	cfg.SchemaVersion = CurrentSchemaVersion
 	return cfg, nil
 }
 
@@ -187,7 +217,7 @@ func configBaseDir(configPath string) string {
 	return configDir
 }
 
-func parse(file *os.File) (rawConfig, error) {
+func parse(file io.Reader) (rawConfig, error) {
 	var cfg rawConfig
 	var section string
 	var currentSource *rawSource
@@ -258,6 +288,15 @@ func parse(file *os.File) (rawConfig, error) {
 		value = strings.TrimSpace(value)
 
 		switch section {
+		case "":
+			if key != "schema_version" {
+				return rawConfig{}, fmt.Errorf("line %d: key %q is outside a supported section", lineNo, key)
+			}
+			parsed, err := strconv.Atoi(value)
+			if err != nil {
+				return rawConfig{}, fmt.Errorf("line %d: schema_version: expected integer", lineNo)
+			}
+			cfg.schemaVersion = parsed
 		case "workspace":
 			if err := parseWorkspaceField(&cfg.workspace, key, value, lineNo); err != nil {
 				return rawConfig{}, err
@@ -301,8 +340,6 @@ func parse(file *os.File) (rawConfig, error) {
 			if err := parseSourceField(currentSource, key, value, lineNo); err != nil {
 				return rawConfig{}, err
 			}
-		default:
-			return rawConfig{}, fmt.Errorf("line %d: key %q is outside a supported section", lineNo, key)
 		}
 	}
 

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,0 +1,228 @@
+package config
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const legacyProjectSchemaName = "project.v1"
+
+type legacyProjectConfig struct {
+	projectID   string
+	projectName string
+	specsDir    string
+	docsDir     string
+}
+
+type MigrationResult struct {
+	Config         *Config
+	DetectedSchema string
+	Notes          []string
+}
+
+func MigrateFile(path string) (*MigrationResult, error) {
+	configPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config path: %w", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", configPath, err)
+	}
+
+	if legacy, ok, err := detectLegacyProjectConfig(bytes.NewReader(data)); err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
+	} else if ok {
+		cfg, notes, err := migrateLegacyProjectConfig(configPath, legacy)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", configPath, err)
+		}
+		return &MigrationResult{
+			Config:         cfg,
+			DetectedSchema: legacyProjectSchemaName,
+			Notes:          notes,
+		}, nil
+	}
+
+	raw, err := parse(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
+	}
+	cfg, err := buildFromRaw(configPath, raw, false)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
+	}
+
+	detectedSchema := fmt.Sprintf("current.v%d", CurrentSchemaVersion)
+	var notes []string
+	switch raw.schemaVersion {
+	case 0:
+		detectedSchema = "current.unversioned"
+		notes = append(notes, fmt.Sprintf("added explicit schema_version = %d", CurrentSchemaVersion))
+	case CurrentSchemaVersion:
+		notes = append(notes, fmt.Sprintf("config already uses schema_version = %d; output is normalized", CurrentSchemaVersion))
+	default:
+		return nil, fmt.Errorf("cannot migrate unsupported schema_version %d automatically", raw.schemaVersion)
+	}
+
+	return &MigrationResult{
+		Config:         cfg,
+		DetectedSchema: detectedSchema,
+		Notes:          notes,
+	}, nil
+}
+
+func detectLegacyProjectConfig(reader io.Reader) (*legacyProjectConfig, bool, error) {
+	var (
+		legacy           legacyProjectConfig
+		section          string
+		sawProject       bool
+		sawCurrentSchema bool
+	)
+
+	scanner := bufio.NewScanner(reader)
+	for lineNo := 1; scanner.Scan(); lineNo++ {
+		line := strings.TrimSpace(stripComment(scanner.Text()))
+		if line == "" {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]"):
+			if sawProject {
+				return nil, false, fmt.Errorf("line %d: unsupported array section %q in legacy [project] config", lineNo, strings.TrimSpace(line[2:len(line)-2]))
+			}
+			sawCurrentSchema = true
+			continue
+		case strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]"):
+			section = strings.TrimSpace(line[1 : len(line)-1])
+			switch section {
+			case "project":
+				sawProject = true
+			case "workspace", "runtime.embedder", "runtime.analysis":
+				sawCurrentSchema = true
+			}
+			continue
+		}
+
+		if section == "" && strings.HasPrefix(line, "schema_version") {
+			sawCurrentSchema = true
+			continue
+		}
+
+		if section != "project" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, false, fmt.Errorf("line %d: expected key = value", lineNo)
+		}
+		key = strings.TrimSpace(key)
+		parsed, err := parseQuotedString(strings.TrimSpace(value))
+		if err != nil {
+			return nil, false, fmt.Errorf("line %d: project.%s: %w", lineNo, key, err)
+		}
+		switch key {
+		case "id":
+			legacy.projectID = parsed
+		case "name":
+			legacy.projectName = parsed
+		case "specs_dir":
+			legacy.specsDir = parsed
+		case "docs_dir":
+			legacy.docsDir = parsed
+		default:
+			return nil, false, fmt.Errorf("line %d: unsupported project field %q", lineNo, key)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, false, fmt.Errorf("read config: %w", err)
+	}
+	if sawProject && sawCurrentSchema {
+		return nil, false, fmt.Errorf("cannot mix legacy [project] config with current schema sections")
+	}
+	if !sawProject {
+		return nil, false, nil
+	}
+	if strings.TrimSpace(legacy.specsDir) == "" {
+		return nil, false, fmt.Errorf("legacy [project] config is missing required field \"specs_dir\"")
+	}
+	return &legacy, true, nil
+}
+
+func migrateLegacyProjectConfig(configPath string, legacy *legacyProjectConfig) (*Config, []string, error) {
+	if legacy == nil {
+		return nil, nil, fmt.Errorf("legacy config is required")
+	}
+
+	cfg := &Config{
+		SchemaVersion: CurrentSchemaVersion,
+		ConfigPath:    configPath,
+		ConfigDir:     configBaseDir(configPath),
+		Workspace: Workspace{
+			Root:      ".",
+			IndexPath: filepath.ToSlash(filepath.Join(".pituitary", "pituitary.db")),
+		},
+		Runtime: Runtime{
+			Embedder: RuntimeProvider{
+				Provider:   RuntimeProviderFixture,
+				Model:      "fixture-8d",
+				TimeoutMS:  1000,
+				MaxRetries: 0,
+			},
+			Analysis: RuntimeProvider{
+				Provider:   RuntimeProviderDisabled,
+				TimeoutMS:  1000,
+				MaxRetries: 0,
+			},
+		},
+		Sources: []Source{
+			{
+				Name:    "specs",
+				Adapter: AdapterFilesystem,
+				Kind:    SourceKindSpecBundle,
+				Path:    legacy.specsDir,
+			},
+		},
+	}
+	if strings.TrimSpace(legacy.docsDir) != "" {
+		cfg.Sources = append(cfg.Sources, Source{
+			Name:    "docs",
+			Adapter: AdapterFilesystem,
+			Kind:    SourceKindMarkdownDocs,
+			Path:    legacy.docsDir,
+		})
+	}
+
+	if err := validate(cfg); err != nil {
+		return nil, nil, err
+	}
+
+	notes := []string{
+		fmt.Sprintf("migrated legacy [project] config to schema_version = %d", CurrentSchemaVersion),
+	}
+	if strings.TrimSpace(legacy.projectID) != "" || strings.TrimSpace(legacy.projectName) != "" {
+		notes = append(notes, "legacy project.id and project.name are informational only and are not represented in the current schema")
+	}
+	if strings.TrimSpace(legacy.docsDir) == "" {
+		notes = append(notes, "legacy config did not declare docs; add markdown docs sources manually or run `pituitary discover` if needed")
+	}
+	return cfg, notes, nil
+}
+
+func legacyConfigLoadMessage(configPath string, legacy *legacyProjectConfig) string {
+	if legacy == nil {
+		return fmt.Sprintf("legacy config schema detected; run `pituitary migrate-config --path %s --write`", filepath.ToSlash(configPath))
+	}
+	return fmt.Sprintf(
+		"legacy config schema detected: [project] with specs_dir = %q; run `pituitary migrate-config --path %s --write`",
+		legacy.specsDir,
+		filepath.ToSlash(configPath),
+	)
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadAcceptsExplicitSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+schema_version = 2
+
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got, want := cfg.SchemaVersion, CurrentSchemaVersion; got != want {
+		t.Fatalf("schema version = %d, want %d", got, want)
+	}
+}
+
+func TestLoadRejectsUnsupportedSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+schema_version = 9
+
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want schema-version failure")
+	}
+	if !strings.Contains(err.Error(), "unsupported schema_version 9") {
+		t.Fatalf("Load() error = %q, want schema-version detail", err)
+	}
+	if !strings.Contains(err.Error(), "migrate-config") {
+		t.Fatalf("Load() error = %q, want migrate-config hint", err)
+	}
+}
+
+func TestLoadRejectsLegacyProjectConfigWithMigrationHint(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[project]
+id = "ccd"
+name = "Continuous Context Development"
+specs_dir = "specs"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want legacy-config failure")
+	}
+	if !strings.Contains(err.Error(), "legacy config schema detected") {
+		t.Fatalf("Load() error = %q, want legacy-config detail", err)
+	}
+	if !strings.Contains(err.Error(), "migrate-config") {
+		t.Fatalf("Load() error = %q, want migrate-config hint", err)
+	}
+}
+
+func TestMigrateFileRewritesLegacyProjectConfig(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[project]
+id = "ccd"
+name = "Continuous Context Development"
+specs_dir = "specs"
+`)
+
+	result, err := MigrateFile(configPath)
+	if err != nil {
+		t.Fatalf("MigrateFile() error = %v", err)
+	}
+	if got, want := result.DetectedSchema, legacyProjectSchemaName; got != want {
+		t.Fatalf("detected schema = %q, want %q", got, want)
+	}
+	if got, want := result.Config.SchemaVersion, CurrentSchemaVersion; got != want {
+		t.Fatalf("schema version = %d, want %d", got, want)
+	}
+	if got, want := result.Config.Workspace.Root, "."; got != want {
+		t.Fatalf("workspace root = %q, want %q", got, want)
+	}
+	if got, want := result.Config.Sources[0].Path, "specs"; got != want {
+		t.Fatalf("spec source path = %q, want %q", got, want)
+	}
+
+	rendered, err := Render(result.Config)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if !strings.Contains(rendered, "schema_version = 2") {
+		t.Fatalf("rendered config %q does not contain schema_version", rendered)
+	}
+	if !strings.Contains(rendered, "kind = \"spec_bundle\"") {
+		t.Fatalf("rendered config %q does not contain spec source", rendered)
+	}
+}
+
+func TestMigrateFileNormalizesCurrentUnversionedConfig(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	result, err := MigrateFile(configPath)
+	if err != nil {
+		t.Fatalf("MigrateFile() error = %v", err)
+	}
+	if got, want := result.DetectedSchema, "current.unversioned"; got != want {
+		t.Fatalf("detected schema = %q, want %q", got, want)
+	}
+	if len(result.Notes) == 0 || !strings.Contains(result.Notes[0], "added explicit schema_version") {
+		t.Fatalf("notes = %#v, want explicit schema-version note", result.Notes)
+	}
+}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -14,6 +14,7 @@ func Render(cfg *Config) (string, error) {
 	}
 
 	var builder strings.Builder
+	fmt.Fprintf(&builder, "schema_version = %d\n\n", CurrentSchemaVersion)
 	fmt.Fprintf(&builder, "[workspace]\n")
 	fmt.Fprintf(&builder, "root = %s\n", strconv.Quote(cfg.Workspace.Root))
 	fmt.Fprintf(&builder, "index_path = %s\n", strconv.Quote(cfg.Workspace.IndexPath))


### PR DESCRIPTION
## Summary
- add explicit `schema_version = 2` support to the current config format
- detect legacy `[project]` configs with a targeted migration hint instead of a generic unsupported-section error
- add `pituitary migrate-config` to preview or rewrite known legacy and unversioned configs into the current schema

Closes #79

## Validation
- `go test ./...`
