### PR TITLE
[feature] Explain compliance traceability gaps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -709,8 +709,12 @@ Process:
   3. Deterministically classify findings into:
      - compliant
      - conflicting
-     - unspecified / no-governing-spec
-  4. Cite spec refs, section headings, and changed paths
+     - unspecified with explicit traceability reasons:
+       - no_governing_spec
+       - weak_traceability
+       - traceability_gap
+       - insufficient_evidence
+  4. Cite spec refs, section headings, changed paths, and applies_to guidance when traceability is the limiting factor
 
 Output:
   compliant[]

--- a/README.md
+++ b/README.md
@@ -264,6 +264,30 @@ $ ./pituitary check-terminology \
 #   - canonical spec evidence that reflects the replacement language
 ```
 
+### Example: compliance traceability
+
+`check-compliance` is strongest when accepted specs declare the governed code or config surfaces explicitly through `applies_to`.
+
+```toml
+id = "SPEC-042"
+title = "Per-Tenant Rate Limiting for Public API Endpoints"
+status = "accepted"
+body = "body.md"
+
+applies_to = [
+  "code://src/api/middleware/ratelimiter.go",
+  "config://src/api/config/limits.yaml",
+]
+```
+
+If a changed path has no explicit governance yet, `check-compliance` now distinguishes:
+
+- missing `applies_to` coverage with no strong accepted spec match
+- a likely traceability gap where a nearby accepted spec exists but does not govern the path explicitly
+- explicitly governed paths where deterministic evidence is still too weak to confirm or deny compliance
+
+Each `unspecified` finding includes traceability guidance plus a concrete `applies_to` suggestion so you can tighten the accepted spec and rebuild the index.
+
 ## MCP Server
 
 Pituitary ships an optional MCP server over stdio, exposing the same analysis tools to any MCP-compatible client (Claude Code, Cursor, Cowork, etc.):

--- a/cmd/check_compliance_test.go
+++ b/cmd/check_compliance_test.go
@@ -149,12 +149,11 @@ func buildLimiter() {}
 	}
 }
 
-func TestRunCheckCompliancePathJSONNoGoverningSpec(t *testing.T) {
+func TestRunCheckCompliancePathJSONWeakTraceability(t *testing.T) {
 	repo := writeSearchWorkspace(t)
-	writeComplianceSourceFile(t, repo, "src/worker/jobs/reconciler.go", `
-package jobs
-
-func Run() {}
+	writeComplianceSourceFile(t, repo, "notes/ungoverned.txt", `
+zxqv aurora lattice
+plinth ember quartz
 `)
 
 	var stdout bytes.Buffer
@@ -163,7 +162,7 @@ func Run() {}
 	exitCode := withWorkingDir(t, repo, func() int {
 		rebuildSearchWorkspaceIndex(t)
 		return runCheckCompliance([]string{
-			"--path", "src/worker/jobs/reconciler.go",
+			"--path", "notes/ungoverned.txt",
 			"--format", "json",
 		}, &stdout, &stderr)
 	})
@@ -179,9 +178,11 @@ func Run() {}
 			Compliant   []any `json:"compliant"`
 			Conflicts   []any `json:"conflicts"`
 			Unspecified []struct {
-				Path    string `json:"path"`
-				Code    string `json:"code"`
-				Message string `json:"message"`
+				Path         string `json:"path"`
+				Code         string `json:"code"`
+				Message      string `json:"message"`
+				Traceability string `json:"traceability"`
+				Suggestion   string `json:"suggestion"`
 			} `json:"unspecified"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
@@ -198,11 +199,138 @@ func Run() {}
 	if len(payload.Result.Unspecified) != 1 {
 		t.Fatalf("result.unspecified = %+v, want one no-spec finding", payload.Result.Unspecified)
 	}
-	if payload.Result.Unspecified[0].Code != "no_governing_spec" {
-		t.Fatalf("unspecified finding = %+v, want no_governing_spec", payload.Result.Unspecified[0])
+	if payload.Result.Unspecified[0].Code != "weak_traceability" {
+		t.Fatalf("unspecified finding = %+v, want weak_traceability", payload.Result.Unspecified[0])
 	}
-	if payload.Result.Unspecified[0].Path != "src/worker/jobs/reconciler.go" {
-		t.Fatalf("unspecified finding = %+v, want reconciler path", payload.Result.Unspecified[0])
+	if payload.Result.Unspecified[0].Path != "notes/ungoverned.txt" {
+		t.Fatalf("unspecified finding = %+v, want ungoverned path", payload.Result.Unspecified[0])
+	}
+	if payload.Result.Unspecified[0].Traceability != "weak_semantic_retrieval" {
+		t.Fatalf("unspecified finding = %+v, want weak_semantic_retrieval traceability", payload.Result.Unspecified[0])
+	}
+	if !strings.Contains(payload.Result.Unspecified[0].Suggestion, `applies_to = ["code://notes/ungoverned.txt"]`) {
+		t.Fatalf("unspecified finding = %+v, want applies_to suggestion", payload.Result.Unspecified[0])
+	}
+}
+
+func TestRunCheckCompliancePathJSONTraceabilityGap(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	writeComplianceSourceFile(t, repo, "src/api/middleware/tenant_limiter.go", `
+package middleware
+
+// Apply limits per tenant rather than per API key.
+// Enforce a default limit of 200 requests per minute.
+// Allow short bursts above the steady-state tenant limit.
+func buildTenantLimiter() {}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		rebuildSearchWorkspaceIndex(t)
+		return runCheckCompliance([]string{
+			"--path", "src/api/middleware/tenant_limiter.go",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckCompliance() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckCompliance() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Unspecified []struct {
+				Path         string `json:"path"`
+				SpecRef      string `json:"spec_ref"`
+				Code         string `json:"code"`
+				Traceability string `json:"traceability"`
+				Suggestion   string `json:"suggestion"`
+			} `json:"unspecified"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal traceability-gap payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("payload errors = %+v, want none", payload.Errors)
+	}
+	if len(payload.Result.Unspecified) != 1 {
+		t.Fatalf("result.unspecified = %+v, want one traceability gap finding", payload.Result.Unspecified)
+	}
+	if payload.Result.Unspecified[0].Code != "traceability_gap" {
+		t.Fatalf("unspecified finding = %+v, want traceability_gap", payload.Result.Unspecified[0])
+	}
+	if payload.Result.Unspecified[0].SpecRef == "" {
+		t.Fatalf("unspecified finding = %+v, want nearest accepted spec ref", payload.Result.Unspecified[0])
+	}
+	if payload.Result.Unspecified[0].Traceability != "semantic_neighbor_without_applies_to" {
+		t.Fatalf("unspecified finding = %+v, want semantic_neighbor_without_applies_to", payload.Result.Unspecified[0])
+	}
+	if !strings.Contains(payload.Result.Unspecified[0].Suggestion, `applies_to = ["code://src/api/middleware/tenant_limiter.go"]`) {
+		t.Fatalf("unspecified finding = %+v, want applies_to suggestion for tenant_limiter", payload.Result.Unspecified[0])
+	}
+}
+
+func TestRunCheckCompliancePathJSONInsufficientEvidenceExplainsTraceability(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	writeComplianceSourceFile(t, repo, "src/api/middleware/ratelimiter.go", `
+package middleware
+
+func buildLimiter() {}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		rebuildSearchWorkspaceIndex(t)
+		return runCheckCompliance([]string{
+			"--path", "src/api/middleware/ratelimiter.go",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckCompliance() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckCompliance() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Unspecified []struct {
+				SpecRef      string `json:"spec_ref"`
+				Code         string `json:"code"`
+				Traceability string `json:"traceability"`
+				Suggestion   string `json:"suggestion"`
+			} `json:"unspecified"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal insufficient-evidence payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("payload errors = %+v, want none", payload.Errors)
+	}
+	if len(payload.Result.Unspecified) == 0 {
+		t.Fatal("result.unspecified is empty, want insufficient_evidence findings")
+	}
+	for _, item := range payload.Result.Unspecified {
+		if item.Code != "insufficient_evidence" {
+			t.Fatalf("unspecified finding = %+v, want insufficient_evidence", item)
+		}
+		if item.Traceability != "explicit_applies_to" {
+			t.Fatalf("unspecified finding = %+v, want explicit_applies_to", item)
+		}
+		if !strings.Contains(item.Suggestion, "already governs") {
+			t.Fatalf("unspecified finding = %+v, want explicit guidance", item)
+		}
 	}
 }
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -469,6 +469,12 @@ func renderComplianceFindingGroup(w io.Writer, label string, findings []analysis
 			fmt.Fprintf(w, " | %s", item.SectionHeading)
 		}
 		fmt.Fprintf(w, " | %s\n", item.Message)
+		if item.Traceability != "" {
+			fmt.Fprintf(w, "  traceability: %s\n", item.Traceability)
+		}
+		if item.Suggestion != "" {
+			fmt.Fprintf(w, "  suggestion: %s\n", item.Suggestion)
+		}
 	}
 }
 

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -259,6 +259,37 @@ func TestRenderTerminologyAuditResultIncludesEvidence(t *testing.T) {
 	}
 }
 
+func TestRenderComplianceResultIncludesTraceabilityGuidance(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	renderComplianceResult(&stdout, &analysis.ComplianceResult{
+		Paths: []string{"src/api/middleware/tenant_limiter.go"},
+		Unspecified: []analysis.ComplianceFinding{
+			{
+				Path:         "src/api/middleware/tenant_limiter.go",
+				SpecRef:      "SPEC-042",
+				Code:         "traceability_gap",
+				Message:      "src/api/middleware/tenant_limiter.go is not explicitly governed by any accepted applies_to ref; nearest accepted match is SPEC-042",
+				Traceability: "semantic_neighbor_without_applies_to",
+				Suggestion:   `If SPEC-042 governs src/api/middleware/tenant_limiter.go, add applies_to = ["code://src/api/middleware/tenant_limiter.go"] to that accepted spec and rebuild the index.`,
+			},
+		},
+	})
+
+	output := stdout.String()
+	for _, want := range []string{
+		"paths: src/api/middleware/tenant_limiter.go",
+		"unspecified: 1",
+		"traceability: semantic_neighbor_without_applies_to",
+		`suggestion: If SPEC-042 governs src/api/middleware/tenant_limiter.go, add applies_to = ["code://src/api/middleware/tenant_limiter.go"] to that accepted spec and rebuild the index.`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("renderComplianceResult() output %q does not contain %q", output, want)
+		}
+	}
+}
+
 func TestRenderDocDriftResultIncludesEvidenceAndConfidence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -19,6 +19,7 @@ import (
 const (
 	complianceSemanticSuggestionLimit     = 4
 	complianceSemanticSuggestionThreshold = 0.45
+	complianceWeakSuggestionThreshold     = 0.25
 )
 
 var complianceRequestsPerMinutePattern = regexp.MustCompile(`(?i)\b(\d+)\s+requests?\s+per\s+minute\b`)
@@ -103,6 +104,8 @@ type ComplianceFinding struct {
 	SectionHeading string `json:"section_heading,omitempty"`
 	Code           string `json:"code"`
 	Message        string `json:"message"`
+	Traceability   string `json:"traceability,omitempty"`
+	Suggestion     string `json:"suggestion,omitempty"`
 	Expected       string `json:"expected,omitempty"`
 	Observed       string `json:"observed,omitempty"`
 }
@@ -562,11 +565,14 @@ func (r *analysisRepository) complianceSemanticSuggestions(embedding []float64) 
 
 func complianceNoSpecFinding(repo *analysisRepository, target complianceTarget, suggestions []scoredArtifactRef) (ComplianceFinding, string, string, string) {
 	finding := ComplianceFinding{
-		Path:    target.Path,
-		Code:    "no_governing_spec",
-		Message: fmt.Sprintf("%s is not governed by any accepted applies_to ref in the current index", target.Path),
+		Path:         target.Path,
+		Code:         "no_governing_spec",
+		Traceability: "missing_applies_to",
+		Message:      fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref in the current index", target.Path),
+		Suggestion:   complianceAppliesToSuggestion(target.Path, ""),
 	}
 	if len(suggestions) == 0 {
+		finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref, and semantic retrieval did not find a strong accepted spec match", target.Path)
 		return finding, "", "", ""
 	}
 
@@ -584,28 +590,48 @@ func complianceNoSpecFinding(repo *analysisRepository, target complianceTarget, 
 		bestTitle   string
 		bestHeading string
 		bestScore   float64
+		bestSection embeddedSection
 	)
 	for _, suggestion := range suggestions {
 		spec, ok := specs[suggestion.Ref]
 		if !ok {
 			continue
 		}
-		heading, score := strongestComplianceSection(spec, target)
+		section, score, ok := strongestComplianceSectionDetail(spec, target)
+		if !ok {
+			continue
+		}
+		heading := section.Heading
 		if score > bestScore {
 			bestRef = spec.Record.Ref
 			bestTitle = spec.Record.Title
 			bestHeading = heading
 			bestScore = score
+			bestSection = section
 		}
 	}
-	if bestRef == "" || bestScore < complianceSemanticSuggestionThreshold {
+	if bestRef == "" || bestScore < complianceSemanticSuggestionThreshold || !complianceSupportsTraceability(bestSection.Content, target.Content) {
+		if bestRef != "" && bestScore >= complianceWeakSuggestionThreshold {
+			finding.Code = "weak_traceability"
+			finding.Traceability = "weak_semantic_retrieval"
+			finding.SpecRef = bestRef
+			finding.Title = bestTitle
+			finding.SectionHeading = bestHeading
+			finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref; nearest accepted match %s was too weak to trust as the governing spec", target.Path, bestRef)
+			finding.Suggestion = complianceAppliesToSuggestion(target.Path, bestRef)
+			return finding, bestRef, bestTitle, "semantic"
+		}
+		finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref, and semantic retrieval only found low-confidence accepted matches", target.Path)
 		return finding, "", "", ""
 	}
 
 	finding.SpecRef = bestRef
 	finding.Title = bestTitle
 	finding.SectionHeading = bestHeading
-	finding.Message = fmt.Sprintf("%s is not explicitly governed by an accepted spec; nearest accepted match is %s", target.Path, bestRef)
+	finding.Code = "traceability_gap"
+	finding.Traceability = "semantic_neighbor_without_applies_to"
+	finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref; nearest accepted match is %s", target.Path, bestRef)
+	finding.Suggestion = complianceAppliesToSuggestion(target.Path, bestRef)
 	return finding, bestRef, bestTitle, "semantic"
 }
 
@@ -621,6 +647,8 @@ func assessComplianceSpec(spec specDocument, target complianceTarget) compliance
 				SectionHeading: heading,
 				Code:           "removed_content",
 				Message:        fmt.Sprintf("%s removes code governed by %s; deleted lines are not treated as active evidence, so compliance cannot be confirmed from the diff alone", target.Path, spec.Record.Ref),
+				Traceability:   "explicit_applies_to",
+				Suggestion:     fmt.Sprintf("%s already governs %s via applies_to. Review the surrounding spec change with analyze-impact or review-spec before treating the deletion as compliant.", spec.Record.Ref, target.Path),
 			},
 			Score: score,
 		}
@@ -674,24 +702,52 @@ func assessComplianceSpec(spec specDocument, target complianceTarget) compliance
 			SectionHeading: heading,
 			Code:           "insufficient_evidence",
 			Message:        fmt.Sprintf("%s governs %s but the provided code or diff does not contain enough deterministic evidence to confirm compliance", spec.Record.Ref, target.Path),
+			Traceability:   "explicit_applies_to",
+			Suggestion:     fmt.Sprintf("%s already governs %s via applies_to. Strengthen the accepted requirement wording or the changed code surface with more literal evidence, then rerun check-compliance.", spec.Record.Ref, target.Path),
 		},
 		Score: score,
 	}
 }
 
 func strongestComplianceSection(spec specDocument, target complianceTarget) (string, float64) {
+	section, score, ok := strongestComplianceSectionDetail(spec, target)
+	if !ok {
+		return "", 0
+	}
+	return section.Heading, score
+}
+
+func strongestComplianceSectionDetail(spec specDocument, target complianceTarget) (embeddedSection, float64, bool) {
 	var (
-		bestHeading string
+		bestSection embeddedSection
 		bestScore   float64
+		found       bool
 	)
 	for _, section := range spec.Sections {
 		score := cosineSimilarity(target.Embedding, section.Embedding)
-		if score > bestScore {
+		if !found || score > bestScore {
 			bestScore = score
-			bestHeading = section.Heading
+			bestSection = section
+			found = true
 		}
 	}
-	return bestHeading, bestScore
+	return bestSection, bestScore, found
+}
+
+func complianceSupportsTraceability(specContent, targetContent string) bool {
+	for _, statement := range complianceStatements(specContent) {
+		if _, _, ok := complianceRequestsPerMinuteMatch(statement, targetContent); ok {
+			return true
+		}
+		if _, _, ok := compliancePhraseMatch(statement, targetContent); ok {
+			return true
+		}
+		shared, ratio := complianceLexicalOverlap(statement, targetContent)
+		if ratio >= 0.55 && len(shared) >= 3 {
+			return true
+		}
+	}
+	return false
 }
 
 func complianceStatements(content string) []string {
@@ -719,6 +775,7 @@ func conflictingComplianceFinding(spec specDocument, target complianceTarget, se
 			SectionHeading: section.Heading,
 			Code:           "numeric_mismatch",
 			Message:        fmt.Sprintf("%s conflicts with %s: observed %s where %s requires %s", target.Path, spec.Record.Ref, observed, spec.Record.Ref, expected),
+			Traceability:   "explicit_applies_to",
 			Expected:       expected,
 			Observed:       observed,
 		}, true
@@ -733,6 +790,7 @@ func conflictingComplianceFinding(spec specDocument, target complianceTarget, se
 			SectionHeading: section.Heading,
 			Code:           "phrase_mismatch",
 			Message:        fmt.Sprintf("%s conflicts with %s: observed %s where %s expects %s", target.Path, spec.Record.Ref, observed, spec.Record.Ref, expected),
+			Traceability:   "explicit_applies_to",
 			Expected:       expected,
 			Observed:       observed,
 		}, true
@@ -751,6 +809,7 @@ func supportiveComplianceFinding(spec specDocument, target complianceTarget, sec
 			SectionHeading: section.Heading,
 			Code:           "matching_claim",
 			Message:        fmt.Sprintf("%s aligns with %s", target.Path, spec.Record.Ref),
+			Traceability:   "explicit_applies_to",
 			Expected:       expected,
 			Observed:       observed,
 		}, true
@@ -765,6 +824,7 @@ func supportiveComplianceFinding(spec specDocument, target complianceTarget, sec
 			SectionHeading: section.Heading,
 			Code:           "matching_claim",
 			Message:        fmt.Sprintf("%s aligns with %s", target.Path, spec.Record.Ref),
+			Traceability:   "explicit_applies_to",
 			Expected:       expected,
 			Observed:       observed,
 		}, true
@@ -779,11 +839,29 @@ func supportiveComplianceFinding(spec specDocument, target complianceTarget, sec
 			SectionHeading: section.Heading,
 			Code:           "matching_terms",
 			Message:        fmt.Sprintf("%s shares deterministic requirement terms with %s", target.Path, spec.Record.Ref),
+			Traceability:   "explicit_applies_to",
 			Observed:       strings.Join(shared, ", "),
 		}, true
 	}
 
 	return ComplianceFinding{}, false
+}
+
+func complianceAppliesToSuggestion(path, specRef string) string {
+	ref := primaryGovernedRefForPath(path)
+	if specRef != "" {
+		return fmt.Sprintf("If %s governs %s, add applies_to = [\"%s\"] to that accepted spec and rebuild the index.", specRef, path, ref)
+	}
+	return fmt.Sprintf("If an accepted spec governs %s, add applies_to = [\"%s\"] to that spec and rebuild the index.", path, ref)
+}
+
+func primaryGovernedRefForPath(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml", ".json", ".toml", ".ini", ".cfg", ".conf":
+		return "config://" + normalizeCompliancePath(path)
+	default:
+		return "code://" + normalizeCompliancePath(path)
+	}
 }
 
 func complianceRequestsPerMinuteConflict(statement, content string) (string, string, bool) {


### PR DESCRIPTION
## Summary
- distinguish missing governance mappings from weak semantic retrieval in check-compliance
- add explicit applies_to guidance to compliance findings and CLI output
- document spec-to-code traceability expectations in the README and architecture

Closes #87

## Testing
- go test ./cmd
- go test ./...