### PR TITLE
[feature] Validate spec relation graphs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,6 +114,8 @@ Inferred `markdown_contract` records must preserve confidence metadata alongside
 
 The index must also carry enough metadata to reject stale reuse. At minimum, rebuilds should persist the configured embedder fingerprint, a normalized source fingerprint, and a content fingerprint of the indexed artifacts. Search and analysis commands should compare those values against the current workspace before returning results and fail fast with `pituitary index --rebuild` guidance when they no longer match.
 
+Before a rebuild or dry run touches SQLite, Pituitary should validate the explicit spec relation graph. Cycles in `depends_on` or `supersedes`, plus contradictory relation combinations, are repository-health failures and should be surfaced with the exact refs involved instead of silently entering the index.
+
 When teams want more rigor, Pituitary may optionally generate an explicit spec bundle from one inferred contract. That canonicalization flow must preserve the stable inferred ref, preserve source provenance, preview the generated `spec.toml` and `body.md` before write, and remain incremental rather than forcing whole-repo migration.
 
 ---

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Every command supports `--format json` for machine-readable output. `search-spec
 | `canonicalize --path rfcs/service-sla.md` | Generate a suggested `spec.toml` + `body.md` bundle from one inferred contract |
 | `index --rebuild` | Rebuild the SQLite index from all configured sources |
 | `index --dry-run` | Validate config, sources, and rebuild prerequisites without writing the SQLite index |
-| `status [--check-runtime all]` | Report index counts, config resolution, freshness, artifact locations, and optionally probe embedder and analysis runtime readiness |
+| `status [--check-runtime all]` | Report index counts, config resolution, freshness, relation-graph health, artifact locations, and optionally probe embedder and analysis runtime readiness |
 | `version` | Print Pituitary and Go runtime version information |
 | `search-specs --query "..."` | Semantic search across indexed spec sections |
 | `check-overlap --path specs/rate-limit-v2` | Detect specs that cover overlapping ground without looking up refs first |
@@ -202,6 +202,8 @@ Every command supports `--format json` for machine-readable output. `search-spec
 By default, `search-specs` down-ranks sections that look like historical provenance or history so active normative content wins first. If your query explicitly asks for historical context, those sections stay fully accessible.
 
 `check-overlap` keeps weaker structural matches visible, but it now reserves `merge_into_existing` for strong merge candidates. Mature accepted specs usually surface `review_boundaries` instead, so overlap stays visible without implying that every adjacency should collapse into one spec.
+
+`index --rebuild` and `index --dry-run` now validate the spec relation graph before touching SQLite. Cycles in `depends_on` or `supersedes`, plus contradictory `depends_on`/`supersedes` combinations, fail fast with the exact refs involved. `pituitary status` reports the same graph-health findings without requiring a rebuild.
 
 ### Example: full spec review
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -99,6 +99,12 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 	if dryRun {
 		result, err := index.PrepareRebuildContext(ctx, cfg, records)
 		if err != nil {
+			if index.IsGraphValidationError(err) {
+				return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
+					Code:    "validation_error",
+					Message: "relation graph invalid:\n" + err.Error(),
+				}, 2)
+			}
 			if index.IsDependencyUnavailable(err) {
 				return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
 					Code:    "dependency_unavailable",
@@ -125,6 +131,12 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 		result, err = index.RebuildContext(ctx, cfg, records)
 	}
 	if err != nil {
+		if index.IsGraphValidationError(err) {
+			return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
+				Code:    "validation_error",
+				Message: "relation graph invalid:\n" + err.Error(),
+			}, 2)
+		}
 		if index.IsDependencyUnavailable(err) {
 			return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
 				Code:    "dependency_unavailable",

--- a/cmd/relation_graph_test.go
+++ b/cmd/relation_graph_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunIndexDryRunRejectsInvalidRelationGraph(t *testing.T) {
+	repo := writeRelationGraphWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--dry-run"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runIndex(--dry-run) exit code = %d, want 2", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("runIndex(--dry-run) wrote unexpected stdout: %q", stdout.String())
+	}
+	for _, want := range []string{
+		"pituitary index: relation graph invalid:",
+		"depends_on cycle detected:",
+		"SPEC-100",
+		"SPEC-101",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("runIndex(--dry-run) stderr %q does not contain %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestRunStatusJSONIncludesRelationGraphFindings(t *testing.T) {
+	repo := writeRelationGraphWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus([]string{"--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runStatus() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			RelationGraph struct {
+				State    string `json:"state"`
+				Findings []struct {
+					Code         string   `json:"code"`
+					RelationType string   `json:"relation_type"`
+					Refs         []string `json:"refs"`
+					Message      string   `json:"message"`
+				} `json:"findings"`
+			} `json:"relation_graph"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if got, want := payload.Result.RelationGraph.State, "invalid"; got != want {
+		t.Fatalf("result.relation_graph.state = %q, want %q", got, want)
+	}
+	if len(payload.Result.RelationGraph.Findings) == 0 {
+		t.Fatal("result.relation_graph.findings is empty, want cycle detail")
+	}
+	if payload.Result.RelationGraph.Findings[0].Code == "" || payload.Result.RelationGraph.Findings[0].Message == "" {
+		t.Fatalf("top relation graph finding = %+v, want stable code and message", payload.Result.RelationGraph.Findings[0])
+	}
+}
+
+func TestRunStatusTextIncludesRelationGraphFindings(t *testing.T) {
+	repo := writeRelationGraphWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus(nil, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runStatus() wrote unexpected stderr: %q", stderr.String())
+	}
+	for _, want := range []string{
+		"relation graph: invalid",
+		"relation issue: depends_on cycle detected:",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("runStatus() output %q does not contain %q", stdout.String(), want)
+		}
+	}
+}
+
+func writeRelationGraphWorkspace(t *testing.T) string {
+	t.Helper()
+
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "alpha", "spec.toml"), `
+id = "SPEC-100"
+title = "Alpha"
+status = "accepted"
+domain = "kernel"
+body = "body.md"
+depends_on = ["SPEC-101"]
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "alpha", "body.md"), `
+# Alpha
+
+## Requirements
+
+- Alpha depends on beta.
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "beta", "spec.toml"), `
+id = "SPEC-101"
+title = "Beta"
+status = "accepted"
+domain = "kernel"
+body = "body.md"
+depends_on = ["SPEC-100"]
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "beta", "body.md"), `
+# Beta
+
+## Requirements
+
+- Beta depends on alpha.
+`)
+	return repo
+}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -223,6 +223,12 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 	fmt.Fprintf(w, "indexed specs: %d\n", result.SpecCount)
 	fmt.Fprintf(w, "indexed docs: %d\n", result.DocCount)
 	fmt.Fprintf(w, "indexed chunks: %d\n", result.ChunkCount)
+	if result.RelationGraph != nil {
+		fmt.Fprintf(w, "relation graph: %s\n", result.RelationGraph.State)
+		for _, finding := range result.RelationGraph.Findings {
+			fmt.Fprintf(w, "relation issue: %s\n", finding.Message)
+		}
+	}
 	if result.ArtifactLocations != nil {
 		fmt.Fprintf(w, "artifact index dir: %s\n", result.ArtifactLocations.IndexDir)
 		fmt.Fprintf(w, "artifact discover --write default: %s\n", result.ArtifactLocations.DiscoverConfigPath)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/runtimeprobe"
+	"github.com/dusk-network/pituitary/internal/source"
 )
 
 type statusRequest struct {
@@ -20,17 +21,18 @@ type statusRequest struct {
 }
 
 type statusResult struct {
-	WorkspaceRoot     string                  `json:"workspace_root"`
-	ConfigPath        string                  `json:"config_path"`
-	ConfigResolution  *configResolution       `json:"config_resolution,omitempty"`
-	IndexPath         string                  `json:"index_path"`
-	IndexExists       bool                    `json:"index_exists"`
-	Freshness         *index.FreshnessStatus  `json:"freshness,omitempty"`
-	SpecCount         int                     `json:"spec_count"`
-	DocCount          int                     `json:"doc_count"`
-	ChunkCount        int                     `json:"chunk_count"`
-	ArtifactLocations *statusArtifactLocation `json:"artifact_locations,omitempty"`
-	Runtime           *runtimeprobe.Result    `json:"runtime,omitempty"`
+	WorkspaceRoot     string                     `json:"workspace_root"`
+	ConfigPath        string                     `json:"config_path"`
+	ConfigResolution  *configResolution          `json:"config_resolution,omitempty"`
+	IndexPath         string                     `json:"index_path"`
+	IndexExists       bool                       `json:"index_exists"`
+	Freshness         *index.FreshnessStatus     `json:"freshness,omitempty"`
+	SpecCount         int                        `json:"spec_count"`
+	DocCount          int                        `json:"doc_count"`
+	ChunkCount        int                        `json:"chunk_count"`
+	ArtifactLocations *statusArtifactLocation    `json:"artifact_locations,omitempty"`
+	RelationGraph     *index.RelationGraphStatus `json:"relation_graph,omitempty"`
+	Runtime           *runtimeprobe.Result       `json:"runtime,omitempty"`
 }
 
 type statusArtifactLocation struct {
@@ -108,6 +110,13 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 			Message: "invalid config:\n" + err.Error(),
 		}, 2)
 	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
+			Code:    "source_error",
+			Message: "source load failed:\n" + err.Error(),
+		}, 2)
+	}
 
 	status, err := index.ReadStatusContext(ctx, cfg.Workspace.ResolvedIndexPath)
 	if err != nil {
@@ -154,6 +163,7 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 		DocCount:          status.DocCount,
 		ChunkCount:        status.ChunkCount,
 		ArtifactLocations: buildStatusArtifactLocations(cfg),
+		RelationGraph:     index.InspectRelationGraph(records.Specs),
 		Runtime:           runtimeResult,
 	}, nil)
 }

--- a/internal/index/graph_validation.go
+++ b/internal/index/graph_validation.go
@@ -1,0 +1,263 @@
+package index
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/model"
+)
+
+// RelationGraphFinding reports one invalid graph condition.
+type RelationGraphFinding struct {
+	Code         string   `json:"code"`
+	RelationType string   `json:"relation_type,omitempty"`
+	Refs         []string `json:"refs,omitempty"`
+	Message      string   `json:"message"`
+}
+
+// RelationGraphStatus reports whether the current spec graph is structurally valid.
+type RelationGraphStatus struct {
+	State    string                 `json:"state"`
+	Findings []RelationGraphFinding `json:"findings,omitempty"`
+}
+
+// GraphValidationError reports invalid relation-graph findings.
+type GraphValidationError struct {
+	Findings []RelationGraphFinding
+}
+
+func (e *GraphValidationError) Error() string {
+	if e == nil || len(e.Findings) == 0 {
+		return "relation graph is invalid"
+	}
+
+	lines := make([]string, 0, len(e.Findings)+1)
+	lines = append(lines, "relation graph is invalid:")
+	for _, finding := range e.Findings {
+		lines = append(lines, "- "+finding.Message)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// IsGraphValidationError reports whether err is a graph-validation error.
+func IsGraphValidationError(err error) bool {
+	_, ok := err.(*GraphValidationError)
+	return ok
+}
+
+// InspectRelationGraph validates spec relations and returns a structured status.
+func InspectRelationGraph(specs []model.SpecRecord) *RelationGraphStatus {
+	findings := relationGraphFindings(specs)
+	status := &RelationGraphStatus{State: "valid"}
+	if len(findings) > 0 {
+		status.State = "invalid"
+		status.Findings = findings
+	}
+	return status
+}
+
+// ValidateRelationGraph returns an error when the spec graph is invalid.
+func ValidateRelationGraph(specs []model.SpecRecord) error {
+	status := InspectRelationGraph(specs)
+	if status.State == "valid" {
+		return nil
+	}
+	return &GraphValidationError{Findings: status.Findings}
+}
+
+func relationGraphFindings(specs []model.SpecRecord) []RelationGraphFinding {
+	specRefs := make(map[string]struct{}, len(specs))
+	edgeKinds := make(map[string]map[string]map[model.RelationType]struct{}, len(specs))
+	dependsOn := make(map[string][]string, len(specs))
+	supersedes := make(map[string][]string, len(specs))
+	findings := make([]RelationGraphFinding, 0, 8)
+	seenFinding := map[string]struct{}{}
+
+	for _, spec := range specs {
+		specRefs[spec.Ref] = struct{}{}
+	}
+	for _, spec := range specs {
+		targetKinds := edgeKinds[spec.Ref]
+		if targetKinds == nil {
+			targetKinds = make(map[string]map[model.RelationType]struct{})
+			edgeKinds[spec.Ref] = targetKinds
+		}
+
+		for _, relation := range spec.Relations {
+			if relation.Ref == "" {
+				continue
+			}
+			if relation.Ref == spec.Ref {
+				appendRelationFinding(&findings, seenFinding, RelationGraphFinding{
+					Code:         "self_reference",
+					RelationType: string(relation.Type),
+					Refs:         []string{spec.Ref},
+					Message:      fmt.Sprintf("%s declares %s on itself", spec.Ref, relation.Type),
+				})
+			}
+
+			types := targetKinds[relation.Ref]
+			if types == nil {
+				types = make(map[model.RelationType]struct{})
+				targetKinds[relation.Ref] = types
+			}
+			types[relation.Type] = struct{}{}
+
+			if relation.Type == model.RelationDependsOn {
+				appendUniqueEdge(dependsOn, spec.Ref, relation.Ref, specRefs)
+			}
+			if relation.Type == model.RelationSupersedes {
+				appendUniqueEdge(supersedes, spec.Ref, relation.Ref, specRefs)
+			}
+		}
+	}
+
+	for fromRef, targets := range edgeKinds {
+		for toRef, types := range targets {
+			if hasRelationType(types, model.RelationDependsOn) && hasRelationType(types, model.RelationSupersedes) {
+				appendRelationFinding(&findings, seenFinding, RelationGraphFinding{
+					Code:         "contradictory_relation_pair",
+					RelationType: "depends_on+supersedes",
+					Refs:         []string{fromRef, toRef},
+					Message:      fmt.Sprintf("%s declares both depends_on and supersedes for %s", fromRef, toRef),
+				})
+			}
+			if hasRelationType(types, model.RelationSupersedes) && hasEdge(dependsOn, toRef, fromRef) {
+				appendRelationFinding(&findings, seenFinding, RelationGraphFinding{
+					Code:         "supersedes_depends_on_conflict",
+					RelationType: "supersedes+depends_on",
+					Refs:         []string{fromRef, toRef},
+					Message:      fmt.Sprintf("%s supersedes %s while %s depends_on %s", fromRef, toRef, toRef, fromRef),
+				})
+			}
+		}
+	}
+
+	findings = append(findings, detectRelationCycles(model.RelationDependsOn, dependsOn)...)
+	findings = append(findings, detectRelationCycles(model.RelationSupersedes, supersedes)...)
+	sort.Slice(findings, func(i, j int) bool {
+		switch {
+		case findings[i].Code != findings[j].Code:
+			return findings[i].Code < findings[j].Code
+		case findings[i].RelationType != findings[j].RelationType:
+			return findings[i].RelationType < findings[j].RelationType
+		default:
+			return strings.Join(findings[i].Refs, ",") < strings.Join(findings[j].Refs, ",")
+		}
+	})
+	return findings
+}
+
+func appendUniqueEdge(edges map[string][]string, fromRef, toRef string, specRefs map[string]struct{}) {
+	if _, ok := specRefs[toRef]; !ok {
+		return
+	}
+	if hasEdge(edges, fromRef, toRef) {
+		return
+	}
+	edges[fromRef] = append(edges[fromRef], toRef)
+	sort.Strings(edges[fromRef])
+}
+
+func hasEdge(edges map[string][]string, fromRef, toRef string) bool {
+	for _, candidate := range edges[fromRef] {
+		if candidate == toRef {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRelationType(types map[model.RelationType]struct{}, relationType model.RelationType) bool {
+	_, ok := types[relationType]
+	return ok
+}
+
+func appendRelationFinding(findings *[]RelationGraphFinding, seen map[string]struct{}, finding RelationGraphFinding) {
+	key := finding.Code + "|" + finding.RelationType + "|" + strings.Join(finding.Refs, ",")
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = struct{}{}
+	*findings = append(*findings, finding)
+}
+
+func detectRelationCycles(relationType model.RelationType, adjacency map[string][]string) []RelationGraphFinding {
+	visited := make(map[string]int, len(adjacency))
+	stack := make([]string, 0, len(adjacency))
+	stackIndex := make(map[string]int, len(adjacency))
+	seenCycles := map[string]struct{}{}
+	findings := make([]RelationGraphFinding, 0, 2)
+
+	var visit func(string)
+	visit = func(ref string) {
+		visited[ref] = 1
+		stackIndex[ref] = len(stack)
+		stack = append(stack, ref)
+
+		for _, next := range adjacency[ref] {
+			switch visited[next] {
+			case 0:
+				visit(next)
+			case 1:
+				refs := append([]string{}, stack[stackIndex[next]:]...)
+				refs = append(refs, next)
+				key := relationTypeCycleKey(relationType, refs)
+				if _, ok := seenCycles[key]; ok {
+					continue
+				}
+				seenCycles[key] = struct{}{}
+				findings = append(findings, RelationGraphFinding{
+					Code:         "cycle_detected",
+					RelationType: string(relationType),
+					Refs:         refs,
+					Message:      fmt.Sprintf("%s cycle detected: %s", relationType, strings.Join(refs, " -> ")),
+				})
+			}
+		}
+
+		stack = stack[:len(stack)-1]
+		delete(stackIndex, ref)
+		visited[ref] = 2
+	}
+
+	nodes := make([]string, 0, len(adjacency))
+	for ref := range adjacency {
+		nodes = append(nodes, ref)
+	}
+	sort.Strings(nodes)
+	for _, ref := range nodes {
+		if visited[ref] == 0 {
+			visit(ref)
+		}
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		return strings.Join(findings[i].Refs, ",") < strings.Join(findings[j].Refs, ",")
+	})
+	return findings
+}
+
+func relationTypeCycleKey(relationType model.RelationType, refs []string) string {
+	if len(refs) == 0 {
+		return string(relationType)
+	}
+	cycle := append([]string{}, refs...)
+	if len(cycle) > 1 && cycle[0] == cycle[len(cycle)-1] {
+		cycle = cycle[:len(cycle)-1]
+	}
+	if len(cycle) == 0 {
+		return string(relationType)
+	}
+
+	best := strings.Join(cycle, ",")
+	for i := 1; i < len(cycle); i++ {
+		rotated := append(append([]string{}, cycle[i:]...), cycle[:i]...)
+		candidate := strings.Join(rotated, ",")
+		if candidate < best {
+			best = candidate
+		}
+	}
+	return string(relationType) + "|" + best
+}

--- a/internal/index/graph_validation_test.go
+++ b/internal/index/graph_validation_test.go
@@ -1,0 +1,86 @@
+package index
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/model"
+)
+
+func TestInspectRelationGraphDetectsDependsOnCycle(t *testing.T) {
+	t.Parallel()
+
+	status := InspectRelationGraph([]model.SpecRecord{
+		specWithRelations("SPEC-100", model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-101"}),
+		specWithRelations("SPEC-101", model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-100"}),
+	})
+
+	if got, want := status.State, "invalid"; got != want {
+		t.Fatalf("state = %q, want %q", got, want)
+	}
+	if len(status.Findings) != 1 {
+		t.Fatalf("findings = %+v, want one cycle finding", status.Findings)
+	}
+	if status.Findings[0].Code != "cycle_detected" || status.Findings[0].RelationType != string(model.RelationDependsOn) {
+		t.Fatalf("finding = %+v, want depends_on cycle", status.Findings[0])
+	}
+	if !strings.Contains(status.Findings[0].Message, "SPEC-100 -> SPEC-101 -> SPEC-100") &&
+		!strings.Contains(status.Findings[0].Message, "SPEC-101 -> SPEC-100 -> SPEC-101") {
+		t.Fatalf("finding message = %q, want explicit cycle path", status.Findings[0].Message)
+	}
+}
+
+func TestInspectRelationGraphDetectsSupersedesCycleAndContradictions(t *testing.T) {
+	t.Parallel()
+
+	status := InspectRelationGraph([]model.SpecRecord{
+		specWithRelations("SPEC-200",
+			model.Relation{Type: model.RelationSupersedes, Ref: "SPEC-201"},
+			model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-201"},
+		),
+		specWithRelations("SPEC-201",
+			model.Relation{Type: model.RelationSupersedes, Ref: "SPEC-200"},
+			model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-200"},
+		),
+	})
+
+	if got, want := status.State, "invalid"; got != want {
+		t.Fatalf("state = %q, want %q", got, want)
+	}
+	codes := make(map[string]struct{}, len(status.Findings))
+	for _, finding := range status.Findings {
+		codes[finding.Code] = struct{}{}
+	}
+	for _, want := range []string{"cycle_detected", "contradictory_relation_pair", "supersedes_depends_on_conflict"} {
+		if _, ok := codes[want]; !ok {
+			t.Fatalf("findings = %+v, want %s", status.Findings, want)
+		}
+	}
+}
+
+func TestValidateRelationGraphReturnsStructuredError(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateRelationGraph([]model.SpecRecord{
+		specWithRelations("SPEC-300", model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-300"}),
+	})
+	if err == nil {
+		t.Fatal("ValidateRelationGraph() error = nil, want validation failure")
+	}
+	if !IsGraphValidationError(err) {
+		t.Fatalf("ValidateRelationGraph() error = %T, want GraphValidationError", err)
+	}
+	if !strings.Contains(err.Error(), "SPEC-300 declares depends_on on itself") {
+		t.Fatalf("ValidateRelationGraph() error = %q, want self-reference detail", err)
+	}
+}
+
+func specWithRelations(ref string, relations ...model.Relation) model.SpecRecord {
+	return model.SpecRecord{
+		Ref:       ref,
+		Kind:      model.ArtifactKindSpec,
+		Title:     ref,
+		Status:    model.StatusAccepted,
+		Relations: relations,
+	}
+}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -164,6 +164,9 @@ func prepareRebuildContext(ctx context.Context, cfg *config.Config, records *sou
 	if records == nil {
 		return nil, fmt.Errorf("records are required")
 	}
+	if err := ValidateRelationGraph(records.Specs); err != nil {
+		return nil, err
+	}
 
 	embedder, err := newEmbedder(cfg.Runtime.Embedder)
 	if err != nil {


### PR DESCRIPTION
## Summary
- validate depends_on and supersedes graphs for cycles and contradiction pairs
- fail index rebuilds and dry runs before writing SQLite when the relation graph is invalid
- surface relation graph health in status with exact refs involved

Closes #86

## Testing
- go test ./internal/index ./cmd
- go test ./...