### PR TITLE
Bump release artifact download action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download packaged artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: release-*
           merge-multiple: true


### PR DESCRIPTION
## Summary
- bump the release publish job from actions/download-artifact@v5 to @v6
- remove the remaining Node 20 deprecation path in the release workflow

## Validation
- workflow-only change; no local test suite run
- verified the repo has no remaining download-artifact@v5 references after the patch