### PR TITLE
Reject duplicate parser keys

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,6 +223,11 @@ func parse(file io.Reader) (rawConfig, error) {
 	var currentSource *rawSource
 	var activeSourceArrayKey string
 	var activeSourceArrayLine int
+	seenRoot := map[string]int{}
+	seenWorkspace := map[string]int{}
+	seenRuntimeEmbedder := map[string]int{}
+	seenRuntimeAnalysis := map[string]int{}
+	var seenCurrentSource map[string]int
 
 	scanner := bufio.NewScanner(file)
 	for lineNo := 1; scanner.Scan(); lineNo++ {
@@ -266,6 +271,7 @@ func parse(file io.Reader) (rawConfig, error) {
 			}
 			cfg.sources = append(cfg.sources, rawSource{})
 			currentSource = &cfg.sources[len(cfg.sources)-1]
+			seenCurrentSource = map[string]int{}
 			section = name
 			continue
 		case strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]"):
@@ -292,20 +298,32 @@ func parse(file io.Reader) (rawConfig, error) {
 			if key != "schema_version" {
 				return rawConfig{}, fmt.Errorf("line %d: key %q is outside a supported section", lineNo, key)
 			}
+			if err := markDuplicateKey(seenRoot, "schema_version", lineNo); err != nil {
+				return rawConfig{}, err
+			}
 			parsed, err := strconv.Atoi(value)
 			if err != nil {
 				return rawConfig{}, fmt.Errorf("line %d: schema_version: expected integer", lineNo)
 			}
 			cfg.schemaVersion = parsed
 		case "workspace":
+			if err := markDuplicateKey(seenWorkspace, "workspace."+key, lineNo); err != nil {
+				return rawConfig{}, err
+			}
 			if err := parseWorkspaceField(&cfg.workspace, key, value, lineNo); err != nil {
 				return rawConfig{}, err
 			}
 		case "runtime.embedder":
+			if err := markDuplicateKey(seenRuntimeEmbedder, "runtime.embedder."+key, lineNo); err != nil {
+				return rawConfig{}, err
+			}
 			if err := parseRuntimeField(&cfg.runtimeEmbedder, key, value, lineNo, section); err != nil {
 				return rawConfig{}, err
 			}
 		case "runtime.analysis":
+			if err := markDuplicateKey(seenRuntimeAnalysis, "runtime.analysis."+key, lineNo); err != nil {
+				return rawConfig{}, err
+			}
 			if err := parseRuntimeField(&cfg.runtimeAnalysis, key, value, lineNo, section); err != nil {
 				return rawConfig{}, err
 			}
@@ -313,9 +331,15 @@ func parse(file io.Reader) (rawConfig, error) {
 			if currentSource == nil {
 				return rawConfig{}, fmt.Errorf("line %d: source entry missing array header", lineNo)
 			}
+			if seenCurrentSource == nil {
+				seenCurrentSource = map[string]int{}
+			}
 			if value == "[" {
 				if !isSourceArrayField(key) {
 					return rawConfig{}, fmt.Errorf("line %d: unsupported sources array field %q", lineNo, key)
+				}
+				if err := markDuplicateKey(seenCurrentSource, "sources."+key, lineNo); err != nil {
+					return rawConfig{}, err
 				}
 				activeSourceArrayKey = key
 				activeSourceArrayLine = lineNo
@@ -328,6 +352,9 @@ func parse(file io.Reader) (rawConfig, error) {
 				if !isSourceArrayField(key) {
 					return rawConfig{}, fmt.Errorf("line %d: unsupported sources array field %q", lineNo, key)
 				}
+				if err := markDuplicateKey(seenCurrentSource, "sources."+key, lineNo); err != nil {
+					return rawConfig{}, err
+				}
 				values, err := parseQuotedValues(value)
 				if err != nil {
 					return rawConfig{}, fmt.Errorf("line %d: sources.%s: %w", lineNo, key, err)
@@ -336,6 +363,9 @@ func parse(file io.Reader) (rawConfig, error) {
 					return rawConfig{}, fmt.Errorf("line %d: %w", lineNo, err)
 				}
 				continue
+			}
+			if err := markDuplicateKey(seenCurrentSource, "sources."+key, lineNo); err != nil {
+				return rawConfig{}, err
 			}
 			if err := parseSourceField(currentSource, key, value, lineNo); err != nil {
 				return rawConfig{}, err
@@ -354,6 +384,14 @@ func parse(file io.Reader) (rawConfig, error) {
 		)
 	}
 	return cfg, nil
+}
+
+func markDuplicateKey(seen map[string]int, key string, lineNo int) error {
+	if firstLine, ok := seen[key]; ok {
+		return fmt.Errorf("line %d: duplicate %s; first defined at line %d", lineNo, key, firstLine)
+	}
+	seen[key] = lineNo
+	return nil
 }
 
 func parseWorkspaceField(workspace *rawWorkspace, key, value string, lineNo int) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,6 +136,51 @@ path = "specs"
 		t.Fatalf("runtime.analysis.provider = %q, want %q", got, want)
 	}
 }
+
+func TestParseRejectsDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("workspace scalar", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parse(bytes.NewBufferString(`
+[workspace]
+root = "."
+root = "other"
+`))
+		if err == nil {
+			t.Fatal("parse() error = nil, want duplicate workspace field error")
+		}
+		if !strings.Contains(err.Error(), "duplicate workspace.root; first defined at line 3") {
+			t.Fatalf("parse() error = %q, want duplicate workspace.root details", err)
+		}
+	})
+
+	t.Run("source array", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parse(bytes.NewBufferString(`
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+include = ["runbooks/*.md"]
+`))
+		if err == nil {
+			t.Fatal("parse() error = nil, want duplicate sources array field error")
+		}
+		if !strings.Contains(err.Error(), "duplicate sources.include; first defined at line 11") {
+			t.Fatalf("parse() error = %q, want duplicate sources.include details", err)
+		}
+	})
+}
+
 func TestLoadPreservesSourceSelectors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -815,6 +815,7 @@ func markdownContractRefForPath(workspaceRoot, path string) (string, error) {
 func parseSpecBundle(contents []byte) (rawSpecBundle, error) {
 	var spec rawSpecBundle
 	var activeArrayKey string
+	seenKeys := map[string]int{}
 
 	scanner := bufio.NewScanner(bytes.NewReader(contents))
 	scanner.Buffer(make([]byte, 0, 64*1024), maxScannerTokenSize(len(contents)))
@@ -845,6 +846,9 @@ func parseSpecBundle(contents []byte) (rawSpecBundle, error) {
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
+		if err := markSpecDuplicateKey(seenKeys, key, lineNo); err != nil {
+			return rawSpecBundle{}, err
+		}
 
 		if value == "[" {
 			if !isSpecArrayField(key) {
@@ -886,6 +890,14 @@ func parseSpecBundle(contents []byte) (rawSpecBundle, error) {
 	}
 
 	return spec, nil
+}
+
+func markSpecDuplicateKey(seen map[string]int, key string, lineNo int) error {
+	if firstLine, ok := seen[key]; ok {
+		return fmt.Errorf("line %d: duplicate %s; first defined at line %d", lineNo, key, firstLine)
+	}
+	seen[key] = lineNo
+	return nil
 }
 
 func assignSpecScalarField(spec *rawSpecBundle, key, value string) error {

--- a/internal/source/filesystem_test.go
+++ b/internal/source/filesystem_test.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"sort"
@@ -239,6 +240,51 @@ body = "body.md"
 	if got, want := preview.Sources[0].Items[0].Path, "specs/parent/spec.toml"; got != want {
 		t.Fatalf("preview item path = %q, want %q", got, want)
 	}
+}
+
+func TestParseSpecBundleRejectsDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("scalar", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parseSpecBundle([]byte(`
+id = "SPEC-100"
+title = "First"
+title = "Second"
+status = "draft"
+domain = "api"
+body = "body.md"
+`))
+		if err == nil {
+			t.Fatal("parseSpecBundle() error = nil, want duplicate scalar field error")
+		}
+		if !strings.Contains(err.Error(), "duplicate title; first defined at line 3") {
+			t.Fatalf("parseSpecBundle() error = %q, want duplicate title details", err)
+		}
+	})
+
+	t.Run("array", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parseSpecBundle(bytes.TrimSpace([]byte(`
+id = "SPEC-100"
+title = "Example"
+status = "draft"
+domain = "api"
+body = "body.md"
+authors = ["one"]
+authors = [
+  "two",
+]
+`)))
+		if err == nil {
+			t.Fatal("parseSpecBundle() error = nil, want duplicate array field error")
+		}
+		if !strings.Contains(err.Error(), "duplicate authors; first defined at line 6") {
+			t.Fatalf("parseSpecBundle() error = %q, want duplicate authors details", err)
+		}
+	})
 }
 
 func TestLoadFromConfigRejectsMalformedSpecArrays(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject duplicate keys in pituitary.toml parsing
- reject duplicate keys in spec.toml bundle parsing
- add regression coverage for duplicate scalar and array fields

## Validation
- go test ./internal/config ./internal/source

Closes #103