### PR TITLE
Keep possible drift in mixed batches

### DIFF
--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -264,6 +264,20 @@ func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, scop
 					warningSpecs = append(warningSpecs, spec)
 				}
 			}
+		} else if item == nil {
+			allSpecs, err := ensureAllSpecs()
+			if err != nil {
+				return nil, err
+			}
+			if assessment := possibleDriftAssessment(doc, allSpecs); assessment != nil {
+				assessments = append(assessments, *assessment)
+				relevantSpecRefs = append(relevantSpecRefs, assessment.SpecRefs...)
+				for _, specRef := range assessment.SpecRefs {
+					if spec, ok := allSpecs[specRef]; ok {
+						warningSpecs = append(warningSpecs, spec)
+					}
+				}
+			}
 		}
 		if item == nil {
 			continue
@@ -276,26 +290,6 @@ func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, scop
 			if spec, ok := specs[specRef]; ok {
 				relevantSpecRefs = append(relevantSpecRefs, specRef)
 				warningSpecs = append(warningSpecs, spec)
-			}
-		}
-	}
-	relevantSpecRefs = uniqueStrings(relevantSpecRefs)
-	if len(driftItems) == 0 && len(assessments) == 0 {
-		allSpecs, err := ensureAllSpecs()
-		if err != nil {
-			return nil, err
-		}
-		for _, ref := range sortedDocRefs(selectedDocs) {
-			assessment := possibleDriftAssessment(selectedDocs[ref], allSpecs)
-			if assessment == nil {
-				continue
-			}
-			assessments = append(assessments, *assessment)
-			relevantSpecRefs = append(relevantSpecRefs, assessment.SpecRefs...)
-			for _, specRef := range assessment.SpecRefs {
-				if spec, ok := allSpecs[specRef]; ok {
-					warningSpecs = append(warningSpecs, spec)
-				}
 			}
 		}
 	}

--- a/internal/analysis/doc_drift_test.go
+++ b/internal/analysis/doc_drift_test.go
@@ -321,6 +321,46 @@ func TestCheckDocDriftSurfacesPossibleDriftForConceptualNearMatch(t *testing.T) 
 	}
 }
 
+func TestCheckDocDriftKeepsPossibleDriftInMixedBatches(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeMixedDocDriftWorkspace(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := CheckDocDrift(cfg, DocDriftRequest{Scope: "all"})
+	if err != nil {
+		t.Fatalf("CheckDocDrift() error = %v", err)
+	}
+
+	var foundDrift, foundPossible bool
+	for _, assessment := range result.Assessments {
+		switch assessment.DocRef {
+		case "doc://guides/api-rate-limits":
+			if got, want := assessment.Status, "drift"; got != want {
+				t.Fatalf("api-rate-limits assessment.status = %q, want %q", got, want)
+			}
+			foundDrift = true
+		case "doc://guides/kernel-migration":
+			if got, want := assessment.Status, "possible_drift"; got != want {
+				t.Fatalf("migration assessment.status = %q, want %q", got, want)
+			}
+			foundPossible = true
+		}
+	}
+	if !foundDrift {
+		t.Fatalf("assessments = %+v, want deterministic drift doc", result.Assessments)
+	}
+	if !foundPossible {
+		t.Fatalf("assessments = %+v, want possible_drift doc in mixed batch", result.Assessments)
+	}
+}
+
 func TestClassifyArtifactConstraintScopesRuntimeInputToLocalArtifact(t *testing.T) {
 	t.Parallel()
 
@@ -428,6 +468,99 @@ Use locality and continuity language in operator guidance.
 
 The kernel keeps continuity in local state during migration.
 Operators should map old repository language to the new locality model while updating guides.
+`)
+
+	mustWriteFile(tb, configPath, fmt.Sprintf(`
+[workspace]
+root = %q
+index_path = %q
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = %q
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = %q
+`, root, indexPath, filepath.Join(root, "specs"), filepath.Join(root, "docs")))
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
+}
+
+func writeMixedDocDriftWorkspace(tb testing.TB) *config.Config {
+	tb.Helper()
+
+	root := tb.TempDir()
+	indexPath := filepath.Join(root, ".pituitary", "pituitary.db")
+	configPath := filepath.Join(root, "pituitary.toml")
+
+	mustWriteFile(tb, filepath.Join(root, "specs", "kernel-locality", "spec.toml"), `
+id = "SPEC-LOCALITY"
+title = "Kernel Locality Contract"
+status = "accepted"
+domain = "kernel"
+body = "body.md"
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "kernel-locality", "body.md"), `
+# Kernel Locality Contract
+
+## Core Model
+
+The kernel keeps continuity in clone-local state and treats locality as the primary runtime boundary.
+
+## Operator Guidance
+
+Use locality and continuity language in operator guidance.
+`)
+
+	mustWriteFile(tb, filepath.Join(root, "docs", "guides", "kernel-migration.md"), `
+# Kernel Migration Guide
+
+## Working Notes
+
+The kernel keeps continuity in local state during migration.
+Operators should map old repository language to the new locality model while updating guides.
+`)
+
+	mustWriteFile(tb, filepath.Join(root, "specs", "rate-limit", "spec.toml"), `
+id = "SPEC-042"
+title = "Per-Tenant Rate Limiting"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "rate-limit", "body.md"), `
+# Per-Tenant Rate Limiting
+
+## Enforcement
+
+Use a sliding-window limiter with a default limit of 200 requests per minute.
+
+## Subject
+
+Apply limits per tenant rather than per API key.
+`)
+
+	mustWriteFile(tb, filepath.Join(root, "docs", "guides", "api-rate-limits.md"), `
+# Public API Rate Limits
+
+## Current Policy
+
+Apply limits per API key using a fixed-window limiter with a default limit of 100 requests per minute.
 `)
 
 	mustWriteFile(tb, configPath, fmt.Sprintf(`


### PR DESCRIPTION
## Summary
- emit possible_drift assessments per document instead of only when an entire batch is empty
- keep deterministic drift findings intact in mixed batches
- add a regression workspace with one deterministic drift doc and one conceptual near-match doc

## Validation
- go test ./internal/analysis -run 'TestCheckDocDrift(SurfacesPossibleDriftForConceptualNearMatch|KeepsPossibleDriftInMixedBatches|FlagsGuideButNotRunbook|SupportsTargetedDocRefs|FlagsStaleNamedArtifacts)'

Closes #106