### PR TITLE
Ignore source ordering in freshness fingerprint

### DIFF
--- a/internal/index/freshness.go
+++ b/internal/index/freshness.go
@@ -287,6 +287,7 @@ func sourceFingerprint(cfg *config.Config) string {
 		}, "|")
 		parts = append(parts, part)
 	}
+	sort.Strings(parts)
 	return fingerprint(parts)
 }
 

--- a/internal/index/freshness_test.go
+++ b/internal/index/freshness_test.go
@@ -98,6 +98,32 @@ func TestInspectFreshnessReportsIncompatibleWhenSourceConfigChanges(t *testing.T
 	}
 }
 
+func TestInspectFreshnessIgnoresSourceOrderingChanges(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFreshnessFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	cfg.Sources[0], cfg.Sources[1] = cfg.Sources[1], cfg.Sources[0]
+
+	status, err := InspectFreshnessContext(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("InspectFreshnessContext() error = %v", err)
+	}
+	if got, want := status.State, freshnessStateFresh; got != want {
+		t.Fatalf("freshness.state = %q, want %q", got, want)
+	}
+	if len(status.Issues) != 0 {
+		t.Fatalf("freshness.issues = %+v, want none", status.Issues)
+	}
+}
+
 func TestInspectFreshnessReportsIncompatibleWhenMetadataIsMissing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- sort per-source fingerprint parts before hashing
- keep selector normalization intact within each source entry
- add a freshness regression for reordered but semantically identical sources

## Validation
- go test ./internal/index -run 'TestInspectFreshness(ReportsFreshAfterRebuild|ReportsStaleWhenWorkspaceContentChanges|ReportsIncompatibleWhenSourceConfigChanges|IgnoresSourceOrderingChanges|ReportsIncompatibleWhenMetadataIsMissing|DoesNotRequireEmbedderCredentialsForFingerprintCheck|ReturnsSourceMismatchBeforeReloadingWorkspaceContent)'

Closes #105