### PR TITLE
Relax deterministic runtime gating

### DIFF
--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -127,6 +127,11 @@ type complianceTarget struct {
 	RemovedOnly   bool
 }
 
+type complianceEvaluationTarget struct {
+	Target       complianceTarget
+	ExplicitRefs []string
+}
+
 type complianceAssessment struct {
 	Kind    string
 	Finding ComplianceFinding
@@ -167,12 +172,11 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	}
 	defer repo.Close()
 
-	embedder, err := index.NewEmbedder(cfg.Runtime.Embedder)
+	targets, err := loadComplianceTargetsContext(ctx, cfg, request)
 	if err != nil {
 		return nil, err
 	}
-
-	targets, err := loadComplianceTargetsContext(ctx, cfg, request, embedder)
+	evaluationTargets, err := prepareComplianceEvaluationTargetsContext(ctx, repo, cfg, targets)
 	if err != nil {
 		return nil, err
 	}
@@ -185,13 +189,9 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	}
 	relevant := map[string]*complianceRelevantAccumulator{}
 
-	for _, target := range targets {
-		explicitRefs, err := repo.specRefsForGovernedRefs(target.RefCandidates)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(explicitRefs) == 0 {
+	for _, item := range evaluationTargets {
+		target := item.Target
+		if len(item.ExplicitRefs) == 0 {
 			suggestions, err := repo.complianceSemanticSuggestions(target.Embedding)
 			if err != nil {
 				return nil, err
@@ -206,11 +206,11 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 			continue
 		}
 
-		specs, err := repo.loadSelectedSpecs(explicitRefs)
+		specs, err := repo.loadSelectedSpecs(item.ExplicitRefs)
 		if err != nil {
 			return nil, err
 		}
-		for _, ref := range explicitRefs {
+		for _, ref := range item.ExplicitRefs {
 			spec, ok := specs[ref]
 			if !ok {
 				continue
@@ -259,16 +259,15 @@ func normalizeComplianceRequest(request ComplianceRequest) (ComplianceRequest, e
 	}
 }
 
-func loadComplianceTargetsContext(ctx context.Context, cfg *config.Config, request ComplianceRequest, embedder index.Embedder) ([]complianceTarget, error) {
+func loadComplianceTargetsContext(ctx context.Context, cfg *config.Config, request ComplianceRequest) ([]complianceTarget, error) {
 	if len(request.Paths) > 0 {
-		return loadPathComplianceTargetsContext(ctx, cfg, request.Paths, embedder)
+		return loadPathComplianceTargetsContext(ctx, cfg, request.Paths)
 	}
-	return loadDiffComplianceTargetsContext(ctx, request.DiffText, embedder)
+	return loadDiffComplianceTargetsContext(ctx, request.DiffText)
 }
 
-func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, paths []string, embedder index.Embedder) ([]complianceTarget, error) {
+func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, paths []string) ([]complianceTarget, error) {
 	targets := make([]complianceTarget, 0, len(paths))
-	texts := make([]string, 0, len(paths))
 
 	for _, rawPath := range paths {
 		relPath, absPath, err := resolveWorkspaceFilePath(cfg.Workspace.RootPath, rawPath)
@@ -294,27 +293,17 @@ func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, p
 			RefCandidates: governedRefsForPath(relPath),
 			Content:       string(data),
 		})
-		texts = append(texts, textForEmbedding(relPath, relPath, string(data)))
-	}
-
-	vectors, err := embedder.EmbedDocuments(ctx, texts)
-	if err != nil {
-		return nil, fmt.Errorf("embed code paths: %w", err)
-	}
-	for i := range targets {
-		targets[i].Embedding = vectors[i]
 	}
 	return targets, nil
 }
 
-func loadDiffComplianceTargetsContext(ctx context.Context, diffText string, embedder index.Embedder) ([]complianceTarget, error) {
+func loadDiffComplianceTargetsContext(ctx context.Context, diffText string) ([]complianceTarget, error) {
 	parsed, err := parseDiffTargets(diffText)
 	if err != nil {
 		return nil, err
 	}
 
 	targets := make([]complianceTarget, 0, len(parsed))
-	texts := make([]string, 0, len(parsed))
 	for _, item := range parsed {
 		content, removedOnly := parsedDiffTargetContent(item)
 		if stringsTrimSpace(content) == "" && !removedOnly {
@@ -326,20 +315,58 @@ func loadDiffComplianceTargetsContext(ctx context.Context, diffText string, embe
 			Content:       content,
 			RemovedOnly:   removedOnly,
 		})
-		texts = append(texts, textForEmbedding(item.Path, item.Path, content))
 	}
 	if len(targets) == 0 {
 		return nil, fmt.Errorf("diff_text does not contain any changed paths with readable content")
 	}
+	return targets, nil
+}
+
+func prepareComplianceEvaluationTargetsContext(ctx context.Context, repo *analysisRepository, cfg *config.Config, targets []complianceTarget) ([]complianceEvaluationTarget, error) {
+	prepared := make([]complianceEvaluationTarget, 0, len(targets))
+	fallbackIndexes := make([]int, 0, len(targets))
+	for _, target := range targets {
+		explicitRefs, err := repo.specRefsForGovernedRefs(target.RefCandidates)
+		if err != nil {
+			return nil, err
+		}
+		prepared = append(prepared, complianceEvaluationTarget{
+			Target:       target,
+			ExplicitRefs: explicitRefs,
+		})
+		if len(explicitRefs) == 0 {
+			fallbackIndexes = append(fallbackIndexes, len(prepared)-1)
+		}
+	}
+	if len(fallbackIndexes) == 0 {
+		return prepared, nil
+	}
+	if err := embedComplianceFallbackTargetsContext(ctx, cfg, prepared, fallbackIndexes); err != nil {
+		return nil, err
+	}
+	return prepared, nil
+}
+
+func embedComplianceFallbackTargetsContext(ctx context.Context, cfg *config.Config, targets []complianceEvaluationTarget, indexes []int) error {
+	embedder, err := index.NewEmbedder(cfg.Runtime.Embedder)
+	if err != nil {
+		return err
+	}
+
+	texts := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		target := targets[idx].Target
+		texts = append(texts, textForEmbedding(target.Path, target.Path, target.Content))
+	}
 
 	vectors, err := embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
-		return nil, fmt.Errorf("embed diff paths: %w", err)
+		return fmt.Errorf("embed compliance fallback targets: %w", err)
 	}
-	for i := range targets {
-		targets[i].Embedding = vectors[i]
+	for i, idx := range indexes {
+		targets[idx].Target.Embedding = vectors[i]
 	}
-	return targets, nil
+	return nil
 }
 
 func resolveWorkspaceFilePath(rootPath, rawPath string) (string, string, error) {

--- a/internal/app/operations_test.go
+++ b/internal/app/operations_test.go
@@ -245,6 +245,78 @@ max_retries = 0
 	}
 }
 
+func TestCheckComplianceUsesExplicitTraceabilityWithoutLiveEmbedder(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			t.Fatalf("request path = %q, want /v1/embeddings", r.URL.Path)
+		}
+
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		response := map[string]any{"data": []map[string]any{}}
+		for i := range request.Input {
+			response["data"] = append(response["data"].([]map[string]any), map[string]any{
+				"index":     i,
+				"embedding": []float64{float64(i + 1), float64(i + 2), float64(i + 3)},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+
+	configPath := writeOperationWorkspaceWithRuntime(t, fmt.Sprintf(`
+[runtime.embedder]
+provider = "openai_compatible"
+model = "pituitary-embed"
+endpoint = %q
+timeout_ms = 1000
+max_retries = 0
+`, server.URL+"/v1"), "")
+	server.Close()
+
+	repoRoot := filepath.Dir(configPath)
+	codePath := filepath.Join(repoRoot, "src", "api", "middleware", "ratelimiter.go")
+	if err := os.MkdirAll(filepath.Dir(codePath), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(codePath, []byte(strings.TrimSpace(`
+package middleware
+
+// Apply limits per tenant rather than per API key.
+// Enforce a default limit of 200 requests per minute.
+// Allow short bursts above the steady-state tenant limit.
+// Use a sliding-window limiter and tenant-specific overrides.
+func buildLimiter() {}
+`)+"\n"), 0o644); err != nil {
+		t.Fatalf("write code path: %v", err)
+	}
+
+	operation := CheckCompliance(context.Background(), configPath, analysis.ComplianceRequest{
+		Paths: []string{"src/api/middleware/ratelimiter.go"},
+	})
+	if operation.Issue != nil {
+		t.Fatalf("CheckCompliance() issue = %+v, want success without live embedder", operation.Issue)
+	}
+	if operation.Result == nil {
+		t.Fatal("CheckCompliance() result = nil, want structured result")
+	}
+	if len(operation.Result.Conflicts) != 0 {
+		t.Fatalf("CheckCompliance() conflicts = %+v, want none", operation.Result.Conflicts)
+	}
+	if len(operation.Result.Compliant) == 0 {
+		t.Fatal("CheckCompliance() compliant = empty, want explicit compliance findings")
+	}
+}
+
 func TestCheckDocDriftClassifiesAnalysisProviderDependencyFailures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/index/freshness.go
+++ b/internal/index/freshness.go
@@ -94,7 +94,7 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 		return nil, fmt.Errorf("index path %s is a directory", cfg.Workspace.ResolvedIndexPath)
 	}
 
-	configuredEmbedderFingerprint, err := configuredEmbedderFingerprint(cfg.Runtime.Embedder)
+	configuredEmbedderFingerprint, err := ConfiguredEmbedderFingerprint(cfg.Runtime.Embedder)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,8 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 	return status, nil
 }
 
-func configuredEmbedderFingerprint(provider config.RuntimeProvider) (string, error) {
+// ConfiguredEmbedderFingerprint derives the configured embedder fingerprint without contacting the provider.
+func ConfiguredEmbedderFingerprint(provider config.RuntimeProvider) (string, error) {
 	switch provider.Provider {
 	case "", config.RuntimeProviderFixture:
 		if _, err := fixtureDimension(provider.Model); err != nil {

--- a/internal/index/freshness_test.go
+++ b/internal/index/freshness_test.go
@@ -179,7 +179,7 @@ func TestInspectFreshnessDoesNotRequireEmbedderCredentialsForFingerprintCheck(t 
 	}
 	t.Setenv("PITUITARY_TEST_EMBEDDER_API_KEY", "")
 
-	fingerprint, err := configuredEmbedderFingerprint(cfg.Runtime.Embedder)
+	fingerprint, err := ConfiguredEmbedderFingerprint(cfg.Runtime.Embedder)
 	if err != nil {
 		t.Fatalf("configuredEmbedderFingerprint() error = %v", err)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,11 +1,9 @@
 package mcp
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/config"
@@ -78,7 +76,7 @@ func validateStartup(options Options) error {
 		return fmt.Errorf("load config %s: %w", options.ConfigPath, err)
 	}
 
-	embedder, err := index.NewEmbedder(cfg.Runtime.Embedder)
+	configuredFingerprint, err := index.ConfiguredEmbedderFingerprint(cfg.Runtime.Embedder)
 	if err != nil {
 		return err
 	}
@@ -99,40 +97,19 @@ func validateStartup(options Options) error {
 	}
 	defer db.Close()
 
-	dimension, err := embedder.Dimension(context.Background())
-	if err != nil {
-		return err
-	}
-	if err := validateIndexReady(db, embedder.Fingerprint(), dimension); err != nil {
+	if err := validateIndexReady(db, configuredFingerprint); err != nil {
 		return err
 	}
 	return nil
 }
 
-func validateIndexReady(db *sql.DB, configuredFingerprint string, configuredDimension int) error {
-	var raw string
-	err := db.QueryRow(`SELECT value FROM metadata WHERE key = 'embedder_dimension'`).Scan(&raw)
-	if err == sql.ErrNoRows {
-		return fmt.Errorf("index metadata is missing embedder_dimension; run `pituitary index --rebuild`")
-	}
-	if err != nil {
-		return fmt.Errorf("read index metadata: %w", err)
-	}
-
-	stored, err := strconv.Atoi(raw)
-	if err != nil {
-		return fmt.Errorf("parse embedder_dimension %q: %w", raw, err)
-	}
-	if stored != configuredDimension {
-		return fmt.Errorf("index embedder dimension %d does not match configured embedder dimension %d; run `pituitary index --rebuild`", stored, configuredDimension)
-	}
-
+func validateIndexReady(db *sql.DB, configuredFingerprint string) error {
 	if strings.TrimSpace(configuredFingerprint) == "" {
 		return nil
 	}
 
 	var storedFingerprint string
-	err = db.QueryRow(`SELECT value FROM metadata WHERE key = 'embedder_fingerprint'`).Scan(&storedFingerprint)
+	err := db.QueryRow(`SELECT value FROM metadata WHERE key = 'embedder_fingerprint'`).Scan(&storedFingerprint)
 	if err == sql.ErrNoRows {
 		return fmt.Errorf("index metadata is missing embedder_fingerprint; run `pituitary index --rebuild`")
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,6 +33,23 @@ func TestValidateStartupAcceptsReadyWorkspace(t *testing.T) {
 	configPath := writeMCPWorkspace(t)
 	if err := validateStartup(Options{ConfigPath: configPath}); err != nil {
 		t.Fatalf("validateStartup() error = %v", err)
+	}
+}
+
+func TestValidateStartupDoesNotRequireLiveEmbedderEndpointWhenIndexAlreadyExists(t *testing.T) {
+	server := newOpenAICompatibleEmbeddingServer(t)
+	configPath := writeMCPWorkspaceWithRuntime(t, fmt.Sprintf(`
+[runtime.embedder]
+provider = "openai_compatible"
+model = "pituitary-embed"
+endpoint = %q
+timeout_ms = 1000
+max_retries = 0
+`, server.URL+"/v1"))
+	server.Close()
+
+	if err := validateStartup(Options{ConfigPath: configPath}); err != nil {
+		t.Fatalf("validateStartup() error = %v, want startup to rely on stored metadata", err)
 	}
 }
 
@@ -625,6 +645,16 @@ func shippedToolNames() []string {
 }
 
 func writeMCPWorkspace(t *testing.T) string {
+	return writeMCPWorkspaceWithRuntime(t, `
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+`)
+}
+
+func writeMCPWorkspaceWithRuntime(t *testing.T, runtimeEmbedder string) string {
 	t.Helper()
 
 	repoRoot := mcpRepoRoot(t)
@@ -638,11 +668,7 @@ func writeMCPWorkspace(t *testing.T) string {
 root = "."
 index_path = ".pituitary/pituitary.db"
 
-[runtime.embedder]
-provider = "fixture"
-model = "fixture-8d"
-timeout_ms = 1000
-max_retries = 0
+`+strings.TrimSpace(runtimeEmbedder)+`
 
 [[sources]]
 name = "specs"
@@ -671,6 +697,35 @@ include = ["guides/*.md", "runbooks/*.md"]
 	}
 
 	return configPath
+}
+
+func newOpenAICompatibleEmbeddingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			t.Fatalf("request path = %q, want /v1/embeddings", r.URL.Path)
+		}
+
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		response := map[string]any{"data": []map[string]any{}}
+		for i := range request.Input {
+			response["data"] = append(response["data"].([]map[string]any), map[string]any{
+				"index":     i,
+				"embedding": []float64{float64(i + 1), float64(i + 2), float64(i + 3)},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
 }
 
 func writeMCPServeWorkspace(t *testing.T, content string) string {


### PR DESCRIPTION
## Summary
- avoid embedding compliance targets until semantic fallback is actually needed
- make MCP startup validate stored embedder metadata without probing a live provider endpoint
- add regression coverage for explicit-traceability compliance and startup with an already-built OpenAI-compatible index

Closes #101