### PR TITLE
Clarify compliance traceability gaps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -717,7 +717,10 @@ Process:
        - weak_traceability
        - traceability_gap
        - insufficient_evidence
-  4. Cite spec refs, section headings, changed paths, and applies_to guidance when traceability is the limiting factor
+  4. Surface the limiting factor explicitly:
+     - spec_metadata_gap when accepted governance is missing or too weak
+     - code_evidence_gap when governance exists but literal code/diff evidence is insufficient
+  5. Cite spec refs, section headings, changed paths, and applies_to guidance when traceability is the limiting factor
 
 Output:
   compliant[]

--- a/README.md
+++ b/README.md
@@ -326,7 +326,12 @@ If a changed path has no explicit governance yet, `check-compliance` now disting
 - a likely traceability gap where a nearby accepted spec exists but does not govern the path explicitly
 - explicitly governed paths where deterministic evidence is still too weak to confirm or deny compliance
 
-Each `unspecified` finding includes traceability guidance plus a concrete `applies_to` suggestion so you can tighten the accepted spec and rebuild the index.
+Each `unspecified` finding now also includes a `limiting_factor` so you can tell what to fix first:
+
+- `spec_metadata_gap`: accepted spec governance is missing or too weak; tighten `applies_to`
+- `code_evidence_gap`: governance is explicit, but the changed code or diff does not expose enough literal evidence yet
+
+If `check-compliance` gets far enough to return findings at all, the index freshness checks have already passed. That means `unspecified` findings are about spec metadata or code evidence, not stale indexing.
 
 ## MCP Server
 

--- a/cmd/check_compliance_test.go
+++ b/cmd/check_compliance_test.go
@@ -178,11 +178,12 @@ plinth ember quartz
 			Compliant   []any `json:"compliant"`
 			Conflicts   []any `json:"conflicts"`
 			Unspecified []struct {
-				Path         string `json:"path"`
-				Code         string `json:"code"`
-				Message      string `json:"message"`
-				Traceability string `json:"traceability"`
-				Suggestion   string `json:"suggestion"`
+				Path           string `json:"path"`
+				Code           string `json:"code"`
+				Message        string `json:"message"`
+				Traceability   string `json:"traceability"`
+				LimitingFactor string `json:"limiting_factor"`
+				Suggestion     string `json:"suggestion"`
 			} `json:"unspecified"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
@@ -207,6 +208,9 @@ plinth ember quartz
 	}
 	if payload.Result.Unspecified[0].Traceability != "weak_semantic_retrieval" {
 		t.Fatalf("unspecified finding = %+v, want weak_semantic_retrieval traceability", payload.Result.Unspecified[0])
+	}
+	if payload.Result.Unspecified[0].LimitingFactor != "spec_metadata_gap" {
+		t.Fatalf("unspecified finding = %+v, want spec_metadata_gap limiting factor", payload.Result.Unspecified[0])
 	}
 	if !strings.Contains(payload.Result.Unspecified[0].Suggestion, `applies_to = ["code://notes/ungoverned.txt"]`) {
 		t.Fatalf("unspecified finding = %+v, want applies_to suggestion", payload.Result.Unspecified[0])
@@ -244,11 +248,12 @@ func buildTenantLimiter() {}
 	var payload struct {
 		Result struct {
 			Unspecified []struct {
-				Path         string `json:"path"`
-				SpecRef      string `json:"spec_ref"`
-				Code         string `json:"code"`
-				Traceability string `json:"traceability"`
-				Suggestion   string `json:"suggestion"`
+				Path           string `json:"path"`
+				SpecRef        string `json:"spec_ref"`
+				Code           string `json:"code"`
+				Traceability   string `json:"traceability"`
+				LimitingFactor string `json:"limiting_factor"`
+				Suggestion     string `json:"suggestion"`
 			} `json:"unspecified"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
@@ -270,6 +275,9 @@ func buildTenantLimiter() {}
 	}
 	if payload.Result.Unspecified[0].Traceability != "semantic_neighbor_without_applies_to" {
 		t.Fatalf("unspecified finding = %+v, want semantic_neighbor_without_applies_to", payload.Result.Unspecified[0])
+	}
+	if payload.Result.Unspecified[0].LimitingFactor != "spec_metadata_gap" {
+		t.Fatalf("unspecified finding = %+v, want spec_metadata_gap limiting factor", payload.Result.Unspecified[0])
 	}
 	if !strings.Contains(payload.Result.Unspecified[0].Suggestion, `applies_to = ["code://src/api/middleware/tenant_limiter.go"]`) {
 		t.Fatalf("unspecified finding = %+v, want applies_to suggestion for tenant_limiter", payload.Result.Unspecified[0])
@@ -304,10 +312,11 @@ func buildLimiter() {}
 	var payload struct {
 		Result struct {
 			Unspecified []struct {
-				SpecRef      string `json:"spec_ref"`
-				Code         string `json:"code"`
-				Traceability string `json:"traceability"`
-				Suggestion   string `json:"suggestion"`
+				SpecRef        string `json:"spec_ref"`
+				Code           string `json:"code"`
+				Traceability   string `json:"traceability"`
+				LimitingFactor string `json:"limiting_factor"`
+				Suggestion     string `json:"suggestion"`
 			} `json:"unspecified"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
@@ -327,6 +336,9 @@ func buildLimiter() {}
 		}
 		if item.Traceability != "explicit_applies_to" {
 			t.Fatalf("unspecified finding = %+v, want explicit_applies_to", item)
+		}
+		if item.LimitingFactor != "code_evidence_gap" {
+			t.Fatalf("unspecified finding = %+v, want code_evidence_gap limiting factor", item)
 		}
 		if !strings.Contains(item.Suggestion, "already governs") {
 			t.Fatalf("unspecified finding = %+v, want explicit guidance", item)
@@ -448,9 +460,10 @@ index 1111111..0000000
 			Compliant   []any    `json:"compliant"`
 			Conflicts   []any    `json:"conflicts"`
 			Unspecified []struct {
-				Path    string `json:"path"`
-				SpecRef string `json:"spec_ref"`
-				Code    string `json:"code"`
+				Path           string `json:"path"`
+				SpecRef        string `json:"spec_ref"`
+				Code           string `json:"code"`
+				LimitingFactor string `json:"limiting_factor"`
 			} `json:"unspecified"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
@@ -482,6 +495,9 @@ index 1111111..0000000
 		}
 		if item.Code != "removed_content" {
 			t.Fatalf("unspecified finding = %+v, want removed_content", item)
+		}
+		if item.LimitingFactor != "code_evidence_gap" {
+			t.Fatalf("unspecified finding = %+v, want code_evidence_gap limiting factor", item)
 		}
 	}
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -491,6 +491,9 @@ func renderComplianceFindingGroup(w io.Writer, label string, findings []analysis
 		if item.Traceability != "" {
 			fmt.Fprintf(w, "  traceability: %s\n", item.Traceability)
 		}
+		if item.LimitingFactor != "" {
+			fmt.Fprintf(w, "  limiting factor: %s\n", item.LimitingFactor)
+		}
 		if item.Suggestion != "" {
 			fmt.Fprintf(w, "  suggestion: %s\n", item.Suggestion)
 		}

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -267,12 +267,13 @@ func TestRenderComplianceResultIncludesTraceabilityGuidance(t *testing.T) {
 		Paths: []string{"src/api/middleware/tenant_limiter.go"},
 		Unspecified: []analysis.ComplianceFinding{
 			{
-				Path:         "src/api/middleware/tenant_limiter.go",
-				SpecRef:      "SPEC-042",
-				Code:         "traceability_gap",
-				Message:      "src/api/middleware/tenant_limiter.go is not explicitly governed by any accepted applies_to ref; nearest accepted match is SPEC-042",
-				Traceability: "semantic_neighbor_without_applies_to",
-				Suggestion:   `If SPEC-042 governs src/api/middleware/tenant_limiter.go, add applies_to = ["code://src/api/middleware/tenant_limiter.go"] to that accepted spec and rebuild the index.`,
+				Path:           "src/api/middleware/tenant_limiter.go",
+				SpecRef:        "SPEC-042",
+				Code:           "traceability_gap",
+				Message:        "src/api/middleware/tenant_limiter.go is not explicitly governed by any accepted applies_to ref; nearest accepted match is SPEC-042, so the limiting factor is accepted spec metadata rather than indexing",
+				Traceability:   "semantic_neighbor_without_applies_to",
+				LimitingFactor: "spec_metadata_gap",
+				Suggestion:     `If SPEC-042 governs src/api/middleware/tenant_limiter.go, add applies_to = ["code://src/api/middleware/tenant_limiter.go"] to that accepted spec and rebuild the index.`,
 			},
 		},
 	})
@@ -282,6 +283,7 @@ func TestRenderComplianceResultIncludesTraceabilityGuidance(t *testing.T) {
 		"paths: src/api/middleware/tenant_limiter.go",
 		"unspecified: 1",
 		"traceability: semantic_neighbor_without_applies_to",
+		"limiting factor: spec_metadata_gap",
 		`suggestion: If SPEC-042 governs src/api/middleware/tenant_limiter.go, add applies_to = ["code://src/api/middleware/tenant_limiter.go"] to that accepted spec and rebuild the index.`,
 	} {
 		if !strings.Contains(output, want) {

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -20,6 +20,8 @@ const (
 	complianceSemanticSuggestionLimit     = 4
 	complianceSemanticSuggestionThreshold = 0.45
 	complianceWeakSuggestionThreshold     = 0.25
+	complianceFactorSpecMetadataGap       = "spec_metadata_gap"
+	complianceFactorCodeEvidenceGap       = "code_evidence_gap"
 )
 
 var complianceRequestsPerMinutePattern = regexp.MustCompile(`(?i)\b(\d+)\s+requests?\s+per\s+minute\b`)
@@ -105,6 +107,7 @@ type ComplianceFinding struct {
 	Code           string `json:"code"`
 	Message        string `json:"message"`
 	Traceability   string `json:"traceability,omitempty"`
+	LimitingFactor string `json:"limiting_factor,omitempty"`
 	Suggestion     string `json:"suggestion,omitempty"`
 	Expected       string `json:"expected,omitempty"`
 	Observed       string `json:"observed,omitempty"`
@@ -592,14 +595,15 @@ func (r *analysisRepository) complianceSemanticSuggestions(embedding []float64) 
 
 func complianceNoSpecFinding(repo *analysisRepository, target complianceTarget, suggestions []scoredArtifactRef) (ComplianceFinding, string, string, string) {
 	finding := ComplianceFinding{
-		Path:         target.Path,
-		Code:         "no_governing_spec",
-		Traceability: "missing_applies_to",
-		Message:      fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref in the current index", target.Path),
-		Suggestion:   complianceAppliesToSuggestion(target.Path, ""),
+		Path:           target.Path,
+		Code:           "no_governing_spec",
+		Traceability:   "missing_applies_to",
+		LimitingFactor: complianceFactorSpecMetadataGap,
+		Message:        fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref in the current index; the limiting factor is accepted spec metadata, not indexing", target.Path),
+		Suggestion:     complianceAppliesToSuggestion(target.Path, ""),
 	}
 	if len(suggestions) == 0 {
-		finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref, and semantic retrieval did not find a strong accepted spec match", target.Path)
+		finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref, and semantic retrieval did not find a strong accepted spec match; the limiting factor is accepted spec metadata, not indexing", target.Path)
 		return finding, "", "", ""
 	}
 
@@ -641,14 +645,15 @@ func complianceNoSpecFinding(repo *analysisRepository, target complianceTarget, 
 		if bestRef != "" && bestScore >= complianceWeakSuggestionThreshold {
 			finding.Code = "weak_traceability"
 			finding.Traceability = "weak_semantic_retrieval"
+			finding.LimitingFactor = complianceFactorSpecMetadataGap
 			finding.SpecRef = bestRef
 			finding.Title = bestTitle
 			finding.SectionHeading = bestHeading
-			finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref; nearest accepted match %s was too weak to trust as the governing spec", target.Path, bestRef)
+			finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref; nearest accepted match %s was too weak to trust as the governing spec, so the limiting factor is still accepted spec metadata", target.Path, bestRef)
 			finding.Suggestion = complianceAppliesToSuggestion(target.Path, bestRef)
 			return finding, bestRef, bestTitle, "semantic"
 		}
-		finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref, and semantic retrieval only found low-confidence accepted matches", target.Path)
+		finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref, and semantic retrieval only found low-confidence accepted matches; the limiting factor is accepted spec metadata, not indexing", target.Path)
 		return finding, "", "", ""
 	}
 
@@ -657,7 +662,8 @@ func complianceNoSpecFinding(repo *analysisRepository, target complianceTarget, 
 	finding.SectionHeading = bestHeading
 	finding.Code = "traceability_gap"
 	finding.Traceability = "semantic_neighbor_without_applies_to"
-	finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref; nearest accepted match is %s", target.Path, bestRef)
+	finding.LimitingFactor = complianceFactorSpecMetadataGap
+	finding.Message = fmt.Sprintf("%s is not explicitly governed by any accepted applies_to ref; nearest accepted match is %s, so the limiting factor is accepted spec metadata rather than indexing", target.Path, bestRef)
 	finding.Suggestion = complianceAppliesToSuggestion(target.Path, bestRef)
 	return finding, bestRef, bestTitle, "semantic"
 }
@@ -673,8 +679,9 @@ func assessComplianceSpec(spec specDocument, target complianceTarget) compliance
 				Title:          spec.Record.Title,
 				SectionHeading: heading,
 				Code:           "removed_content",
-				Message:        fmt.Sprintf("%s removes code governed by %s; deleted lines are not treated as active evidence, so compliance cannot be confirmed from the diff alone", target.Path, spec.Record.Ref),
+				Message:        fmt.Sprintf("%s removes code governed by %s; deleted lines are not treated as active evidence, so compliance cannot be confirmed from the diff alone and the limiting factor is diff evidence rather than governance metadata", target.Path, spec.Record.Ref),
 				Traceability:   "explicit_applies_to",
+				LimitingFactor: complianceFactorCodeEvidenceGap,
 				Suggestion:     fmt.Sprintf("%s already governs %s via applies_to. Review the surrounding spec change with analyze-impact or review-spec before treating the deletion as compliant.", spec.Record.Ref, target.Path),
 			},
 			Score: score,
@@ -728,8 +735,9 @@ func assessComplianceSpec(spec specDocument, target complianceTarget) compliance
 			Title:          spec.Record.Title,
 			SectionHeading: heading,
 			Code:           "insufficient_evidence",
-			Message:        fmt.Sprintf("%s governs %s but the provided code or diff does not contain enough deterministic evidence to confirm compliance", spec.Record.Ref, target.Path),
+			Message:        fmt.Sprintf("%s governs %s but the provided code or diff does not contain enough deterministic evidence to confirm compliance; the limiting factor is literal code evidence rather than applies_to coverage", spec.Record.Ref, target.Path),
 			Traceability:   "explicit_applies_to",
+			LimitingFactor: complianceFactorCodeEvidenceGap,
 			Suggestion:     fmt.Sprintf("%s already governs %s via applies_to. Strengthen the accepted requirement wording or the changed code surface with more literal evidence, then rerun check-compliance.", spec.Record.Ref, target.Path),
 		},
 		Score: score,


### PR DESCRIPTION
## Summary
- make compliance findings state whether the limiting factor is spec metadata or code evidence
- surface that limiting factor in text output and docs
- extend regression coverage for weak traceability, traceability gaps, insufficient evidence, and removed content

Closes #104