### PR TITLE
Reduce DRY drift in CLI and runtime plumbing

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -22,26 +22,22 @@ type cliEnvelope struct {
 }
 
 func isSupportedFormat(format string) bool {
-	return format == "text" || format == "json" || format == "table" || format == "markdown"
-}
-
-func supportsTableFormat(command string) bool {
-	return command == "search-specs"
-}
-
-func supportsMarkdownFormat(command string) bool {
-	return command == "review-spec"
+	return format == commandFormatText || format == commandFormatJSON || format == commandFormatTable || format == commandFormatMarkdown
 }
 
 func validateCLIFormat(command, format string) error {
 	if !isSupportedFormat(format) {
 		return fmt.Errorf("unsupported format %q", format)
 	}
-	if format == "table" && !supportsTableFormat(command) {
-		return fmt.Errorf("format %q is only supported for search-specs", format)
-	}
-	if format == "markdown" && !supportsMarkdownFormat(command) {
-		return fmt.Errorf("format %q is only supported for review-spec", format)
+	if !commandSupportsFormat(command, format) {
+		switch format {
+		case commandFormatTable:
+			return fmt.Errorf("format %q is only supported for search-specs", format)
+		case commandFormatMarkdown:
+			return fmt.Errorf("format %q is only supported for review-spec", format)
+		default:
+			return fmt.Errorf("format %q is not supported for %s", format, command)
+		}
 	}
 	return nil
 }
@@ -50,7 +46,7 @@ func writeCLISuccess(stdout, stderr io.Writer, format, command string, request, 
 	if len(warnings) == 0 {
 		warnings = cliWarningsForResult(result)
 	}
-	if format == "json" {
+	if format == commandFormatJSON {
 		return writeCLIJSON(stdout, cliEnvelope{
 			Request:  request,
 			Result:   result,
@@ -58,7 +54,7 @@ func writeCLISuccess(stdout, stderr io.Writer, format, command string, request, 
 			Errors:   []cliIssue{},
 		})
 	}
-	if format == "table" {
+	if format == commandFormatTable {
 		writeCLIWarnings(stderr, command, warnings)
 		if err := renderCommandTable(stdout, command, result); err != nil {
 			fmt.Fprintf(stderr, "pituitary %s: %s\n", command, err)
@@ -66,7 +62,7 @@ func writeCLISuccess(stdout, stderr io.Writer, format, command string, request, 
 		}
 		return 0
 	}
-	if format == "markdown" {
+	if format == commandFormatMarkdown {
 		writeCLIWarnings(stderr, command, warnings)
 		if err := renderCommandMarkdown(stdout, command, result); err != nil {
 			fmt.Fprintf(stderr, "pituitary %s: %s\n", command, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,71 +8,70 @@ import (
 	"sort"
 )
 
+const (
+	commandFormatText     = "text"
+	commandFormatJSON     = "json"
+	commandFormatTable    = "table"
+	commandFormatMarkdown = "markdown"
+)
+
 type commandSpec struct {
-	Run func(context.Context, []string, io.Writer, io.Writer) int
+	Description string
+	Formats     map[string]struct{}
+	Run         func(context.Context, []string, io.Writer, io.Writer) int
 }
 
-var commands = map[string]commandSpec{
-	"canonicalize":      {Run: runCanonicalizeContext},
-	"discover":          {Run: runDiscoverContext},
-	"migrate-config":    {Run: runMigrateConfigContext},
-	"index":             {Run: runIndexContext},
-	"status":            {Run: runStatusContext},
-	"version":           {Run: runVersionContext},
-	"preview-sources":   {Run: runPreviewSourcesContext},
-	"explain-file":      {Run: runExplainFileContext},
-	"search-specs":      {Run: runSearchSpecsContext},
-	"check-overlap":     {Run: runCheckOverlapContext},
-	"compare-specs":     {Run: runCompareSpecsContext},
-	"analyze-impact":    {Run: runAnalyzeImpactContext},
-	"check-terminology": {Run: runCheckTerminologyContext},
-	"check-compliance":  {Run: runCheckComplianceContext},
-	"check-doc-drift":   {Run: runCheckDocDriftContext},
-	"review-spec":       {Run: runReviewSpecContext},
-	"serve":             {Run: runServeContext},
+func commandRegistry() map[string]commandSpec {
+	return map[string]commandSpec{
+		"canonicalize":      {Description: "promote an inferred contract into a spec bundle", Formats: commandFormats(), Run: runCanonicalizeContext},
+		"discover":          {Description: "scan a repo and propose a local config", Formats: commandFormats(), Run: runDiscoverContext},
+		"migrate-config":    {Description: "rewrite a legacy config into the current schema", Formats: commandFormats(), Run: runMigrateConfigContext},
+		"index":             {Description: "rebuild or validate the local Pituitary index", Formats: commandFormats(), Run: runIndexContext},
+		"status":            {Description: "show current index status", Formats: commandFormats(), Run: runStatusContext},
+		"version":           {Description: "show Pituitary and Go runtime versions", Formats: commandFormats(), Run: runVersionContext},
+		"preview-sources":   {Description: "show which files each source will index", Formats: commandFormats(), Run: runPreviewSourcesContext},
+		"explain-file":      {Description: "explain how one file is treated by configured sources", Formats: commandFormats(), Run: runExplainFileContext},
+		"search-specs":      {Description: "search spec sections semantically", Formats: commandFormats(commandFormatTable), Run: runSearchSpecsContext},
+		"check-overlap":     {Description: "find overlapping specs", Formats: commandFormats(), Run: runCheckOverlapContext},
+		"compare-specs":     {Description: "compare design tradeoffs across specs", Formats: commandFormats(), Run: runCompareSpecsContext},
+		"analyze-impact":    {Description: "report affected specs and docs", Formats: commandFormats(), Run: runAnalyzeImpactContext},
+		"check-terminology": {Description: "audit terminology consistency after conceptual changes", Formats: commandFormats(), Run: runCheckTerminologyContext},
+		"check-compliance":  {Description: "check code paths and diffs against accepted specs", Formats: commandFormats(), Run: runCheckComplianceContext},
+		"check-doc-drift":   {Description: "find docs that drift from specs", Formats: commandFormats(), Run: runCheckDocDriftContext},
+		"review-spec":       {Description: "run the common spec-review workflow", Formats: commandFormats(commandFormatMarkdown), Run: runReviewSpecContext},
+		"serve":             {Description: "run the optional MCP server transport", Formats: commandFormats(), Run: runServeContext},
+	}
+}
+
+func commandFormats(extra ...string) map[string]struct{} {
+	formats := map[string]struct{}{
+		commandFormatText: {},
+		commandFormatJSON: {},
+	}
+	for _, format := range extra {
+		formats[format] = struct{}{}
+	}
+	return formats
 }
 
 func commandDescription(name string) string {
-	switch name {
-	case "canonicalize":
-		return "promote an inferred contract into a spec bundle"
-	case "discover":
-		return "scan a repo and propose a local config"
-	case "migrate-config":
-		return "rewrite a legacy config into the current schema"
-	case "index":
-		return "rebuild or validate the local Pituitary index"
-	case "status":
-		return "show current index status"
-	case "version":
-		return "show Pituitary and Go runtime versions"
-	case "preview-sources":
-		return "show which files each source will index"
-	case "explain-file":
-		return "explain how one file is treated by configured sources"
-	case "search-specs":
-		return "search spec sections semantically"
-	case "check-overlap":
-		return "find overlapping specs"
-	case "compare-specs":
-		return "compare design tradeoffs across specs"
-	case "analyze-impact":
-		return "report affected specs and docs"
-	case "check-terminology":
-		return "audit terminology consistency after conceptual changes"
-	case "check-compliance":
-		return "check code paths and diffs against accepted specs"
-	case "check-doc-drift":
-		return "find docs that drift from specs"
-	case "review-spec":
-		return "run the common spec-review workflow"
-	case "serve":
-		return "run the optional MCP server transport"
-	case "help":
+	if name == "help" {
 		return "show available commands"
-	default:
+	}
+	command, ok := commandRegistry()[name]
+	if !ok {
 		return ""
 	}
+	return command.Description
+}
+
+func commandSupportsFormat(name, format string) bool {
+	command, ok := commandRegistry()[name]
+	if !ok {
+		return false
+	}
+	_, ok = command.Formats[format]
+	return ok
 }
 
 // Run executes the bootstrap CLI transport and returns the desired process exit code.
@@ -110,7 +109,7 @@ func RunContext(ctx context.Context, args []string, stdout, stderr io.Writer) in
 		return 0
 	}
 
-	command, ok := commands[name]
+	command, ok := commandRegistry()[name]
 	if !ok {
 		fmt.Fprintf(stderr, "unknown command %q\n\n", name)
 		printHelp(stderr)
@@ -130,8 +129,9 @@ func printHelp(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "available commands:")
 
-	names := make([]string, 0, len(commands))
-	for name := range commands {
+	registry := commandRegistry()
+	names := make([]string, 0, len(registry))
+	for name := range registry {
 		names = append(names, name)
 	}
 	sort.Strings(names)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRunKnownCommandsStayCallable(t *testing.T) {
-	for name := range commands {
+	for name := range commandRegistry() {
 		if name == "help" {
 			continue
 		}
@@ -136,9 +136,18 @@ func buildLimiter() {}
 func TestCommandsRegistryHasRunners(t *testing.T) {
 	t.Parallel()
 
-	for name, command := range commands {
-		if commandDescription(name) == "" {
+	for name, command := range commandRegistry() {
+		if strings.TrimSpace(command.Description) == "" {
 			t.Fatalf("command %q description is empty", name)
+		}
+		if len(command.Formats) == 0 {
+			t.Fatalf("command %q formats are empty", name)
+		}
+		if _, ok := command.Formats[commandFormatText]; !ok {
+			t.Fatalf("command %q does not support text format", name)
+		}
+		if _, ok := command.Formats[commandFormatJSON]; !ok {
+			t.Fatalf("command %q does not support json format", name)
 		}
 		if command.Run == nil {
 			t.Fatalf("command %q has no runner", name)
@@ -180,7 +189,7 @@ func TestRunHelpIncludesCommandSurface(t *testing.T) {
 	}
 
 	out := stdout.String()
-	for name := range commands {
+	for name := range commandRegistry() {
 		if name == "help" {
 			continue
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,10 +10,8 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/app"
-	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/runtimeprobe"
-	"github.com/dusk-network/pituitary/internal/source"
 )
 
 type statusRequest struct {
@@ -103,85 +101,44 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 		}, 2)
 	}
 
-	cfg, err := config.Load(resolvedConfigPath)
-	if err != nil {
+	response := app.Status(ctx, resolvedConfigPath, app.StatusRequest{CheckRuntime: scope})
+	if response.Issue != nil {
 		return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
-			Code:    "config_error",
-			Message: "invalid config:\n" + err.Error(),
-		}, 2)
+			Code:    response.Issue.Code,
+			Message: response.Issue.Message,
+		}, response.Issue.ExitCode)
 	}
-	records, err := source.LoadFromConfig(cfg)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
-			Code:    "source_error",
-			Message: "source load failed:\n" + err.Error(),
-		}, 2)
-	}
-
-	status, err := index.ReadStatusContext(ctx, cfg.Workspace.ResolvedIndexPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
-			Code:    "index_error",
-			Message: "inspect index failed:\n" + err.Error(),
-		}, 2)
-	}
-	freshness, err := index.InspectFreshnessContext(ctx, cfg)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
-			Code:    "index_error",
-			Message: "inspect index freshness failed:\n" + err.Error(),
-		}, 2)
-	}
-
-	var runtimeResult *runtimeprobe.Result
-	if scope != runtimeprobe.ScopeNone {
-		runtimeResult, err = runtimeprobe.Run(ctx, cfg, scope)
-		if err != nil {
-			code := "internal_error"
-			exitCode := 2
-			message := err.Error()
-			if index.IsDependencyUnavailable(err) {
-				code = app.CodeDependencyUnavailable
-				exitCode = 3
-				message = app.FormatDependencyUnavailableMessage(cfg, err)
-			}
-			return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
-				Code:    code,
-				Message: message,
-			}, exitCode)
-		}
-	}
+	result := response.Result
 
 	return writeCLISuccess(stdout, stderr, format, "status", request, &statusResult{
-		WorkspaceRoot:     cfg.Workspace.RootPath,
-		ConfigPath:        cfg.ConfigPath,
+		WorkspaceRoot:     result.WorkspaceRoot,
+		ConfigPath:        result.ConfigPath,
 		ConfigResolution:  resolution,
-		IndexPath:         status.IndexPath,
-		IndexExists:       status.Exists,
-		Freshness:         freshness,
-		SpecCount:         status.SpecCount,
-		DocCount:          status.DocCount,
-		ChunkCount:        status.ChunkCount,
-		ArtifactLocations: buildStatusArtifactLocations(cfg),
-		RelationGraph:     index.InspectRelationGraph(records.Specs),
-		Runtime:           runtimeResult,
+		IndexPath:         result.Index.IndexPath,
+		IndexExists:       result.Index.Exists,
+		Freshness:         result.Freshness,
+		SpecCount:         result.Index.SpecCount,
+		DocCount:          result.Index.DocCount,
+		ChunkCount:        result.Index.ChunkCount,
+		ArtifactLocations: buildStatusArtifactLocations(result.WorkspaceRoot, result.Index.IndexPath),
+		RelationGraph:     result.RelationGraph,
+		Runtime:           result.Runtime,
 	}, nil)
 }
 
-func buildStatusArtifactLocations(cfg *config.Config) *statusArtifactLocation {
-	if cfg == nil {
+func buildStatusArtifactLocations(workspaceRoot, indexPath string) *statusArtifactLocation {
+	if strings.TrimSpace(workspaceRoot) == "" || strings.TrimSpace(indexPath) == "" {
 		return nil
 	}
 
-	workspaceRoot := cfg.Workspace.RootPath
-	indexDir := filepath.Dir(cfg.Workspace.ResolvedIndexPath)
+	indexDir := filepath.Dir(indexPath)
 	discoverConfigPath := filepath.Join(workspaceRoot, localConfigDirName, defaultConfigName)
 	canonicalizeBundleRoot := filepath.Join(workspaceRoot, localConfigDirName, "canonicalized")
 
 	ignoreSet := map[string]struct{}{
 		filepath.ToSlash(localConfigDirName) + "/": {},
 	}
-	indexPattern := relativeStatusPath(workspaceRoot, cfg.Workspace.ResolvedIndexPath)
+	indexPattern := relativeStatusPath(workspaceRoot, indexPath)
 	if indexPattern != "" && indexPattern != "." && !strings.HasPrefix(indexPattern, filepath.ToSlash(localConfigDirName)+"/") {
 		ignoreSet[indexPattern] = struct{}{}
 	}

--- a/internal/analysis/openai_provider.go
+++ b/internal/analysis/openai_provider.go
@@ -1,22 +1,13 @@
 package analysis
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"os"
 	"sort"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dusk-network/pituitary/internal/config"
-	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/openaicompat"
 )
 
@@ -27,36 +18,11 @@ type qualitativeAnalyzer interface {
 }
 
 type openAICompatibleAnalysisProvider struct {
-	model      string
-	endpoint   string
-	token      string
-	maxRetries int
-	client     *http.Client
+	client *openaicompat.Client
 }
 
-type openAICompatibleChatRequest struct {
-	Model       string                        `json:"model"`
-	Messages    []openAICompatibleChatMessage `json:"messages"`
-	Temperature float64                       `json:"temperature"`
-}
-
-type openAICompatibleChatMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-type openAICompatibleChatResponse struct {
-	Choices []openAICompatibleChoice `json:"choices"`
-	Err     json.RawMessage          `json:"error,omitempty"`
-}
-
-type openAICompatibleChoice struct {
-	Message openAICompatibleChoiceMessage `json:"message"`
-}
-
-type openAICompatibleChoiceMessage struct {
-	Content json.RawMessage `json:"content"`
-}
+type openAICompatibleChatRequest = openaicompat.ChatRequest
+type openAICompatibleChatMessage = openaicompat.ChatMessage
 
 type compareAnalysisPrompt struct {
 	Command     string               `json:"command"`
@@ -131,25 +97,13 @@ func newQualitativeAnalyzer(provider config.RuntimeProvider) (qualitativeAnalyze
 }
 
 func newOpenAICompatibleAnalysisProvider(provider config.RuntimeProvider) (qualitativeAnalyzer, error) {
-	token := ""
-	if envVar := strings.TrimSpace(provider.APIKeyEnv); envVar != "" {
-		token = strings.TrimSpace(os.Getenv(envVar))
-		if token == "" {
-			return nil, analysisDependencyUnavailable("missing API key for %s", openAICompatibleAnalysisRuntime)
-		}
-	}
-
-	client := &http.Client{}
-	if provider.TimeoutMS > 0 {
-		client.Timeout = time.Duration(provider.TimeoutMS) * time.Millisecond
+	client, err := openaicompat.NewClient(provider, openAICompatibleAnalysisRuntime)
+	if err != nil {
+		return nil, err
 	}
 
 	return &openAICompatibleAnalysisProvider{
-		model:      strings.TrimSpace(provider.Model),
-		endpoint:   strings.TrimRight(strings.TrimSpace(provider.Endpoint), "/"),
-		token:      token,
-		maxRetries: provider.MaxRetries,
-		client:     client,
+		client: client,
 	}, nil
 }
 
@@ -231,120 +185,25 @@ func (p *openAICompatibleAnalysisProvider) completeJSON(ctx context.Context, sys
 		return fmt.Errorf("encode runtime.analysis prompt: %w", err)
 	}
 
-	requestBody, err := json.Marshal(openAICompatibleChatRequest{
-		Model: p.model,
-		Messages: []openAICompatibleChatMessage{
-			{Role: "system", Content: systemPrompt},
-			{Role: "user", Content: string(body)},
-		},
-		Temperature: 0,
+	responseBody, err := p.requestChatCompletion(ctx, []openaicompat.ChatMessage{
+		{Role: "system", Content: systemPrompt},
+		{Role: "user", Content: string(body)},
 	})
-	if err != nil {
-		return fmt.Errorf("encode runtime.analysis request: %w", err)
-	}
-
-	responseBody, err := p.requestChatCompletion(ctx, requestBody)
 	if err != nil {
 		return err
 	}
 
 	if err := json.Unmarshal([]byte(responseBody), target); err != nil {
-		return &index.DependencyUnavailableError{
-			Runtime: openAICompatibleAnalysisRuntime,
-			Message: fmt.Sprintf("decode %s response as JSON object: %v", openAICompatibleAnalysisRuntime, err),
-		}
+		return openaicompat.NewDependencyUnavailable(openAICompatibleAnalysisRuntime, "decode %s response as JSON object: %v", openAICompatibleAnalysisRuntime, err)
 	}
 	return nil
 }
 
-func (p *openAICompatibleAnalysisProvider) requestChatCompletion(ctx context.Context, body []byte) (string, error) {
-	var lastErr error
-
-	for attempt := 0; attempt <= p.maxRetries; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint+"/chat/completions", bytes.NewReader(body))
-		if err != nil {
-			return "", fmt.Errorf("build runtime.analysis request: %w", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		if p.token != "" {
-			req.Header.Set("Authorization", "Bearer "+p.token)
-		}
-
-		resp, err := p.client.Do(req)
-		if err != nil {
-			if errors.Is(err, context.Canceled) || (errors.Is(err, context.DeadlineExceeded) && ctx.Err() != nil) {
-				return "", err
-			}
-			lastErr = &index.DependencyUnavailableError{
-				Runtime: openAICompatibleAnalysisRuntime,
-				Message: fmt.Sprintf("call %s endpoint %s: %v", openAICompatibleAnalysisRuntime, p.endpoint, err),
-			}
-			if shouldRetryOpenAICompatibleAnalysisRequest(err, 0) && attempt < p.maxRetries {
-				if waitErr := waitBeforeAnalysisRetry(ctx, attempt, 0); waitErr != nil {
-					return "", waitErr
-				}
-				continue
-			}
-			return "", lastErr
-		}
-
-		retryAfter := retryAfterDuration(resp.Header.Get("Retry-After"))
-		payload, err := readOpenAICompatibleChatResponse(resp)
-		resp.Body.Close()
-		if err == nil {
-			return payload, nil
-		}
-		lastErr = err
-		if shouldRetryOpenAICompatibleAnalysisRequest(err, resp.StatusCode) && attempt < p.maxRetries {
-			if waitErr := waitBeforeAnalysisRetry(ctx, attempt, retryAfter); waitErr != nil {
-				return "", waitErr
-			}
-			continue
-		}
+func (p *openAICompatibleAnalysisProvider) requestChatCompletion(ctx context.Context, messages []openaicompat.ChatMessage) (string, error) {
+	text, err := p.client.ChatCompletionText(ctx, messages, 0)
+	if err != nil {
 		return "", err
 	}
-
-	if lastErr == nil {
-		lastErr = analysisDependencyUnavailable("%s request failed", openAICompatibleAnalysisRuntime)
-	}
-	return "", lastErr
-}
-
-func readOpenAICompatibleChatResponse(resp *http.Response) (string, error) {
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return "", analysisDependencyUnavailable("read %s response: %v", openAICompatibleAnalysisRuntime, err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		message := openaicompat.ExtractErrorMessage(body)
-		if message == "" {
-			message = strings.TrimSpace(string(body))
-		}
-		if message == "" {
-			message = http.StatusText(resp.StatusCode)
-		}
-		return "", &index.DependencyUnavailableError{
-			Runtime: openAICompatibleAnalysisRuntime,
-			Message: fmt.Sprintf("%s endpoint %s returned %s: %s", openAICompatibleAnalysisRuntime, resp.Request.URL, resp.Status, message),
-		}
-	}
-
-	var payload openAICompatibleChatResponse
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return "", analysisDependencyUnavailable("decode %s response: %v", openAICompatibleAnalysisRuntime, err)
-	}
-	if message := openaicompat.ExtractErrorValue(payload.Err); message != "" {
-		return "", &index.DependencyUnavailableError{
-			Runtime: openAICompatibleAnalysisRuntime,
-			Message: fmt.Sprintf("%s endpoint %s returned an error: %s", openAICompatibleAnalysisRuntime, resp.Request.URL, message),
-		}
-	}
-	if len(payload.Choices) == 0 {
-		return "", analysisDependencyUnavailable("%s returned no choices", openAICompatibleAnalysisRuntime)
-	}
-
-	text := extractOpenAICompatibleMessageText(payload.Choices[0].Message.Content)
 	if text == "" {
 		return "", analysisDependencyUnavailable("%s returned an empty message", openAICompatibleAnalysisRuntime)
 	}
@@ -353,33 +212,6 @@ func readOpenAICompatibleChatResponse(resp *http.Response) (string, error) {
 		return "", analysisDependencyUnavailable("%s returned no JSON object", openAICompatibleAnalysisRuntime)
 	}
 	return text, nil
-}
-
-func extractOpenAICompatibleMessageText(raw json.RawMessage) string {
-	var text string
-	if err := json.Unmarshal(raw, &text); err == nil {
-		return strings.TrimSpace(text)
-	}
-
-	var parts []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	}
-	if err := json.Unmarshal(raw, &parts); err == nil {
-		var builder strings.Builder
-		for _, part := range parts {
-			if strings.TrimSpace(part.Text) == "" {
-				continue
-			}
-			if builder.Len() > 0 {
-				builder.WriteString("\n")
-			}
-			builder.WriteString(strings.TrimSpace(part.Text))
-		}
-		return strings.TrimSpace(builder.String())
-	}
-
-	return strings.TrimSpace(string(raw))
 }
 
 func normalizeJSONResponseText(text string) string {
@@ -405,29 +237,8 @@ func normalizeJSONResponseText(text string) string {
 	return ""
 }
 
-func analysisDependencyUnavailable(format string, args ...any) *index.DependencyUnavailableError {
-	return &index.DependencyUnavailableError{
-		Runtime: openAICompatibleAnalysisRuntime,
-		Message: fmt.Sprintf(format, args...),
-	}
-}
-
-func shouldRetryOpenAICompatibleAnalysisRequest(err error, statusCode int) bool {
-	if statusCode == http.StatusTooManyRequests || statusCode >= 500 {
-		return true
-	}
-
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return netErr.Timeout() || netErr.Temporary()
-	}
-	if err == nil {
-		return false
-	}
-	lower := strings.ToLower(err.Error())
-	return strings.Contains(lower, "connection refused") ||
-		strings.Contains(lower, "connection reset") ||
-		strings.Contains(lower, "broken pipe")
+func analysisDependencyUnavailable(format string, args ...any) *openaicompat.DependencyUnavailableError {
+	return openaicompat.NewDependencyUnavailable(openAICompatibleAnalysisRuntime, format, args...)
 }
 
 func analysisSpecsFromMap(specs map[string]specDocument, orderedRefs []string) []analysisSpecPrompt {
@@ -536,48 +347,6 @@ func safePromptPrefix(text string, byteLimit int) string {
 func looksLikeJSONObject(text string) bool {
 	text = strings.TrimSpace(text)
 	return strings.HasPrefix(text, "{") && strings.HasSuffix(text, "}")
-}
-
-func retryAfterDuration(value string) time.Duration {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return 0
-	}
-	if seconds, err := strconv.Atoi(value); err == nil {
-		if seconds > 0 {
-			return time.Duration(seconds) * time.Second
-		}
-		return 0
-	}
-	if when, err := http.ParseTime(value); err == nil {
-		if delay := time.Until(when); delay > 0 {
-			return delay
-		}
-	}
-	return 0
-}
-
-func waitBeforeAnalysisRetry(ctx context.Context, attempt int, retryAfter time.Duration) error {
-	delay := retryAfter
-	if delay <= 0 {
-		delay = 200 * time.Millisecond
-		for i := 0; i < attempt; i++ {
-			delay *= 2
-			if delay >= 2*time.Second {
-				delay = 2 * time.Second
-				break
-			}
-		}
-	}
-
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
 }
 
 func normalizeProvidedComparison(base, provided Comparison, orderedRefs []string, specs map[string]specDocument) Comparison {

--- a/internal/app/operations.go
+++ b/internal/app/operations.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -37,22 +38,45 @@ type operationExecutionPolicy struct {
 	DefaultCode string
 }
 
-func executeWithFreshConfig[Req any, Res any](ctx context.Context, configPath string, request Req, policy operationExecutionPolicy, run func(*config.Config) (*Res, error)) Response[Req, Res] {
+type issueError struct {
+	issue *Issue
+}
+
+func (e *issueError) Error() string {
+	if e == nil || e.issue == nil {
+		return ""
+	}
+	return e.issue.Message
+}
+
+func executeWithConfig[Req any, Res any](ctx context.Context, configPath string, request Req, run func(*config.Config) (*Res, error), classify func(*config.Config, error) *Issue) Response[Req, Res] {
 	cfg, issue := loadConfig(configPath)
 	if issue != nil {
-		return failure[Req, Res](request, issue.Code, issue.Message, issue.ExitCode)
-	}
-	if issue := ensureFreshIndex(ctx, cfg); issue != nil {
 		return failure[Req, Res](request, issue.Code, issue.Message, issue.ExitCode)
 	}
 
 	result, err := run(cfg)
 	if err != nil {
-		issue := classifyExecutionError(cfg, err, policy)
+		issue := classify(cfg, err)
 		return failure[Req, Res](request, issue.Code, issue.Message, issue.ExitCode)
 	}
 
 	return success(request, result)
+}
+
+func executeWithFreshConfig[Req any, Res any](ctx context.Context, configPath string, request Req, policy operationExecutionPolicy, run func(*config.Config) (*Res, error)) Response[Req, Res] {
+	return executeWithConfig(ctx, configPath, request, func(cfg *config.Config) (*Res, error) {
+		if issue := ensureFreshIndex(ctx, cfg); issue != nil {
+			return nil, &issueError{issue: issue}
+		}
+		return run(cfg)
+	}, func(cfg *config.Config, err error) *Issue {
+		var wrapped *issueError
+		if errors.As(err, &wrapped) && wrapped != nil && wrapped.issue != nil {
+			return wrapped.issue
+		}
+		return classifyExecutionError(cfg, err, policy)
+	})
 }
 
 func classifyExecutionError(cfg *config.Config, err error, policy operationExecutionPolicy) *Issue {

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"context"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/runtimeprobe"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+// StatusRequest captures normalized status input.
+type StatusRequest struct {
+	CheckRuntime runtimeprobe.Scope
+}
+
+// StatusResult captures transport-agnostic status details for one workspace.
+type StatusResult struct {
+	WorkspaceRoot string
+	ConfigPath    string
+	Index         *index.Status
+	Freshness     *index.FreshnessStatus
+	RelationGraph *index.RelationGraphStatus
+	Runtime       *runtimeprobe.Result
+}
+
+// Status loads config, inspects the current index, and optionally probes runtime dependencies.
+func Status(ctx context.Context, configPath string, request StatusRequest) Response[StatusRequest, StatusResult] {
+	return executeWithConfig(ctx, configPath, request, func(cfg *config.Config) (*StatusResult, error) {
+		records, err := source.LoadFromConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		status, err := index.ReadStatusContext(ctx, cfg.Workspace.ResolvedIndexPath)
+		if err != nil {
+			return nil, err
+		}
+		freshness, err := index.InspectFreshnessContext(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		var runtimeResult *runtimeprobe.Result
+		if request.CheckRuntime != runtimeprobe.ScopeNone {
+			runtimeResult, err = runtimeprobe.Run(ctx, cfg, request.CheckRuntime)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return &StatusResult{
+			WorkspaceRoot: cfg.Workspace.RootPath,
+			ConfigPath:    cfg.ConfigPath,
+			Index:         status,
+			Freshness:     freshness,
+			RelationGraph: index.InspectRelationGraph(records.Specs),
+			Runtime:       runtimeResult,
+		}, nil
+	}, classifyStatusError)
+}
+
+func classifyStatusError(cfg *config.Config, err error) *Issue {
+	switch {
+	case index.IsDependencyUnavailable(err):
+		return &Issue{
+			Code:     CodeDependencyUnavailable,
+			Message:  FormatDependencyUnavailableMessage(cfg, err),
+			ExitCode: 3,
+		}
+	default:
+		return &Issue{
+			Code:     CodeInternalError,
+			Message:  err.Error(),
+			ExitCode: 2,
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,8 +99,8 @@ type rawRuntimeProvider struct {
 	model      string
 	endpoint   string
 	apiKeyEnv  string
-	timeoutMS  int
-	maxRetries int
+	timeoutMS  *int
+	maxRetries *int
 }
 
 type validationErrors struct {
@@ -163,16 +163,16 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 				Model:      raw.runtimeEmbedder.model,
 				Endpoint:   raw.runtimeEmbedder.endpoint,
 				APIKeyEnv:  raw.runtimeEmbedder.apiKeyEnv,
-				TimeoutMS:  defaultInt(raw.runtimeEmbedder.timeoutMS, 1000),
-				MaxRetries: raw.runtimeEmbedder.maxRetries,
+				TimeoutMS:  defaultOptionalInt(raw.runtimeEmbedder.timeoutMS, 1000),
+				MaxRetries: defaultOptionalInt(raw.runtimeEmbedder.maxRetries, 0),
 			},
 			Analysis: RuntimeProvider{
 				Provider:   defaultString(raw.runtimeAnalysis.provider, RuntimeProviderDisabled),
 				Model:      raw.runtimeAnalysis.model,
 				Endpoint:   raw.runtimeAnalysis.endpoint,
 				APIKeyEnv:  raw.runtimeAnalysis.apiKeyEnv,
-				TimeoutMS:  defaultInt(raw.runtimeAnalysis.timeoutMS, 1000),
-				MaxRetries: raw.runtimeAnalysis.maxRetries,
+				TimeoutMS:  defaultOptionalInt(raw.runtimeAnalysis.timeoutMS, 1000),
+				MaxRetries: defaultOptionalInt(raw.runtimeAnalysis.maxRetries, 0),
 			},
 		},
 		Sources: make([]Source, 0, len(raw.sources)),
@@ -479,9 +479,9 @@ func parseRuntimeField(runtime *rawRuntimeProvider, key, value string, lineNo in
 			return fmt.Errorf("line %d: %s.%s: expected integer", lineNo, section, key)
 		}
 		if key == "timeout_ms" {
-			runtime.timeoutMS = parsed
+			runtime.timeoutMS = intPtr(parsed)
 		} else {
-			runtime.maxRetries = parsed
+			runtime.maxRetries = intPtr(parsed)
 		}
 		return nil
 	default:
@@ -835,9 +835,13 @@ func defaultString(value, fallback string) string {
 	return value
 }
 
-func defaultInt(value, fallback int) int {
-	if value == 0 {
+func defaultOptionalInt(value *int, fallback int) int {
+	if value == nil {
 		return fallback
 	}
-	return value
+	return *value
+}
+
+func intPtr(value int) *int {
+	return &value
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -607,6 +607,48 @@ path = "specs"
 	}
 }
 
+func TestLoadPreservesExplicitZeroRuntimeTimeouts(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "openai_compatible"
+model = "pituitary-embed"
+endpoint = "http://127.0.0.1:1234/v1"
+timeout_ms = 0
+
+[runtime.analysis]
+provider = "openai_compatible"
+model = "pituitary-analysis"
+endpoint = "http://127.0.0.1:1234/v1"
+timeout_ms = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got, want := cfg.Runtime.Embedder.TimeoutMS, 0; got != want {
+		t.Fatalf("runtime.embedder.timeout_ms = %d, want %d", got, want)
+	}
+	if got, want := cfg.Runtime.Analysis.TimeoutMS, 0; got != want {
+		t.Fatalf("runtime.analysis.timeout_ms = %d, want %d", got, want)
+	}
+}
+
 func TestLoadRejectsOpenAIAnalysisProviderWithoutEndpoint(t *testing.T) {
 	t.Parallel()
 

--- a/internal/index/embedder.go
+++ b/internal/index/embedder.go
@@ -23,20 +23,30 @@ func (e *DependencyUnavailableError) Error() string {
 	return e.Message
 }
 
+func (e *DependencyUnavailableError) RuntimeName() string {
+	return strings.TrimSpace(e.Runtime)
+}
+
 // IsDependencyUnavailable reports whether err wraps a dependency-unavailable failure.
 func IsDependencyUnavailable(err error) bool {
-	var target *DependencyUnavailableError
+	var target interface {
+		error
+		RuntimeName() string
+	}
 	return errors.As(err, &target)
 }
 
 // DependencyUnavailableRuntime reports the runtime surface associated with a
 // dependency-unavailable failure, if one was recorded.
 func DependencyUnavailableRuntime(err error) string {
-	var target *DependencyUnavailableError
+	var target interface {
+		error
+		RuntimeName() string
+	}
 	if !errors.As(err, &target) {
 		return ""
 	}
-	return strings.TrimSpace(target.Runtime)
+	return strings.TrimSpace(target.RuntimeName())
 }
 
 // Embedder generates embeddings for rebuild and query-time retrieval.

--- a/internal/index/openai_embedder.go
+++ b/internal/index/openai_embedder.go
@@ -1,18 +1,10 @@
 package index
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/openaicompat"
@@ -25,53 +17,24 @@ const (
 )
 
 type openAICompatibleEmbedder struct {
-	model      string
-	endpoint   string
-	token      string
-	maxRetries int
-	strategy   string
-	client     *http.Client
+	model    string
+	strategy string
+	client   *openaicompat.Client
 
 	mu        sync.Mutex
 	dimension int
 }
 
-type openAICompatibleEmbeddingsRequest struct {
-	Model string   `json:"model"`
-	Input []string `json:"input"`
-}
-
-type openAICompatibleEmbeddingsResponse struct {
-	Data []openAICompatibleEmbedding `json:"data"`
-	Err  json.RawMessage             `json:"error,omitempty"`
-}
-
-type openAICompatibleEmbedding struct {
-	Embedding []float64 `json:"embedding"`
-	Index     int       `json:"index"`
-}
-
 func newOpenAICompatibleEmbedder(provider config.RuntimeProvider) (Embedder, error) {
-	token := ""
-	if envVar := strings.TrimSpace(provider.APIKeyEnv); envVar != "" {
-		token = strings.TrimSpace(os.Getenv(envVar))
-		if token == "" {
-			return nil, embedderDependencyUnavailable("missing API key for %s", openAICompatibleEmbedderRuntime)
-		}
-	}
-
-	client := &http.Client{}
-	if provider.TimeoutMS > 0 {
-		client.Timeout = time.Duration(provider.TimeoutMS) * time.Millisecond
+	client, err := openaicompat.NewClient(provider, openAICompatibleEmbedderRuntime)
+	if err != nil {
+		return nil, err
 	}
 
 	return &openAICompatibleEmbedder{
-		model:      strings.TrimSpace(provider.Model),
-		endpoint:   strings.TrimRight(strings.TrimSpace(provider.Endpoint), "/"),
-		token:      token,
-		maxRetries: provider.MaxRetries,
-		strategy:   embeddingStrategyForModel(provider.Model),
-		client:     client,
+		model:    strings.TrimSpace(provider.Model),
+		strategy: embeddingStrategyForModel(provider.Model),
+		client:   client,
 	}, nil
 }
 
@@ -118,20 +81,12 @@ func (e *openAICompatibleEmbedder) embedTexts(ctx context.Context, purpose strin
 		input = append(input, prepareEmbeddingInput(e.strategy, purpose, text))
 	}
 
-	body, err := json.Marshal(openAICompatibleEmbeddingsRequest{
-		Model: e.model,
-		Input: input,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("encode runtime.embedder request: %w", err)
-	}
-
-	payload, err := e.requestEmbeddings(ctx, body)
+	payload, err := e.client.Embeddings(ctx, input)
 	if err != nil {
 		return nil, err
 	}
 	if len(payload.Data) != len(input) {
-		return nil, &DependencyUnavailableError{
+		return nil, &openaicompat.DependencyUnavailableError{
 			Runtime: openAICompatibleEmbedderRuntime,
 			Message: fmt.Sprintf("%s returned %d embedding(s) for %d input(s)", openAICompatibleEmbedderRuntime, len(payload.Data), len(input)),
 		}
@@ -144,7 +99,7 @@ func (e *openAICompatibleEmbedder) embedTexts(ctx context.Context, purpose strin
 			index = i
 		}
 		if len(item.Embedding) == 0 {
-			return nil, &DependencyUnavailableError{
+			return nil, &openaicompat.DependencyUnavailableError{
 				Runtime: openAICompatibleEmbedderRuntime,
 				Message: fmt.Sprintf("%s returned an empty embedding for input %d", openAICompatibleEmbedderRuntime, index),
 			}
@@ -156,109 +111,13 @@ func (e *openAICompatibleEmbedder) embedTexts(ctx context.Context, purpose strin
 	}
 	for i, vector := range vectors {
 		if len(vector) == 0 {
-			return nil, &DependencyUnavailableError{
+			return nil, &openaicompat.DependencyUnavailableError{
 				Runtime: openAICompatibleEmbedderRuntime,
 				Message: fmt.Sprintf("%s omitted embedding for input %d", openAICompatibleEmbedderRuntime, i),
 			}
 		}
 	}
 	return vectors, nil
-}
-
-func (e *openAICompatibleEmbedder) requestEmbeddings(ctx context.Context, body []byte) (*openAICompatibleEmbeddingsResponse, error) {
-	var lastErr error
-
-	for attempt := 0; attempt <= e.maxRetries; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint+"/embeddings", bytes.NewReader(body))
-		if err != nil {
-			return nil, fmt.Errorf("build runtime.embedder request: %w", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		if e.token != "" {
-			req.Header.Set("Authorization", "Bearer "+e.token)
-		}
-
-		resp, err := e.client.Do(req)
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) && ctx.Err() != nil {
-				return nil, err
-			}
-			lastErr = &DependencyUnavailableError{
-				Runtime: openAICompatibleEmbedderRuntime,
-				Message: fmt.Sprintf("call %s endpoint %s: %v", openAICompatibleEmbedderRuntime, e.endpoint, err),
-			}
-			if shouldRetryOpenAICompatibleRequest(err, 0) && attempt < e.maxRetries {
-				continue
-			}
-			return nil, lastErr
-		}
-
-		payload, err := readOpenAICompatibleEmbeddingsResponse(resp)
-		resp.Body.Close()
-		if err == nil {
-			return payload, nil
-		}
-		lastErr = err
-		if shouldRetryOpenAICompatibleRequest(err, resp.StatusCode) && attempt < e.maxRetries {
-			continue
-		}
-		return nil, err
-	}
-
-	if lastErr == nil {
-		lastErr = embedderDependencyUnavailable("%s request failed", openAICompatibleEmbedderRuntime)
-	}
-	return nil, lastErr
-}
-
-func readOpenAICompatibleEmbeddingsResponse(resp *http.Response) (*openAICompatibleEmbeddingsResponse, error) {
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return nil, embedderDependencyUnavailable("read %s response: %v", openAICompatibleEmbedderRuntime, err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		message := openaicompat.ExtractErrorMessage(body)
-		if message == "" {
-			message = strings.TrimSpace(string(body))
-		}
-		if message == "" {
-			message = http.StatusText(resp.StatusCode)
-		}
-		return nil, &DependencyUnavailableError{
-			Runtime: openAICompatibleEmbedderRuntime,
-			Message: fmt.Sprintf("%s endpoint %s returned %s: %s", openAICompatibleEmbedderRuntime, resp.Request.URL, resp.Status, message),
-		}
-	}
-
-	var payload openAICompatibleEmbeddingsResponse
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return nil, embedderDependencyUnavailable("decode %s response: %v", openAICompatibleEmbedderRuntime, err)
-	}
-	if message := openaicompat.ExtractErrorValue(payload.Err); message != "" {
-		return nil, &DependencyUnavailableError{
-			Runtime: openAICompatibleEmbedderRuntime,
-			Message: fmt.Sprintf("%s endpoint %s returned an error: %s", openAICompatibleEmbedderRuntime, resp.Request.URL, message),
-		}
-	}
-	return &payload, nil
-}
-
-func shouldRetryOpenAICompatibleRequest(err error, statusCode int) bool {
-	if statusCode == http.StatusTooManyRequests || statusCode >= 500 {
-		return true
-	}
-
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return netErr.Timeout() || netErr.Temporary()
-	}
-	if err == nil {
-		return false
-	}
-	return strings.Contains(strings.ToLower(err.Error()), "connection refused") ||
-		strings.Contains(strings.ToLower(err.Error()), "connection reset") ||
-		strings.Contains(strings.ToLower(err.Error()), "broken pipe")
 }
 
 func embeddingStrategyForModel(model string) string {
@@ -300,7 +159,7 @@ func (e *openAICompatibleEmbedder) cacheDimension(dimension int) error {
 		return nil
 	}
 	if e.dimension != dimension {
-		return &DependencyUnavailableError{
+		return &openaicompat.DependencyUnavailableError{
 			Runtime: openAICompatibleEmbedderRuntime,
 			Message: fmt.Sprintf("%s changed embedding dimension from %d to %d", openAICompatibleEmbedderRuntime, e.dimension, dimension),
 		}
@@ -308,9 +167,6 @@ func (e *openAICompatibleEmbedder) cacheDimension(dimension int) error {
 	return nil
 }
 
-func embedderDependencyUnavailable(format string, args ...any) *DependencyUnavailableError {
-	return &DependencyUnavailableError{
-		Runtime: openAICompatibleEmbedderRuntime,
-		Message: fmt.Sprintf(format, args...),
-	}
+func embedderDependencyUnavailable(format string, args ...any) *openaicompat.DependencyUnavailableError {
+	return openaicompat.NewDependencyUnavailable(openAICompatibleEmbedderRuntime, format, args...)
 }

--- a/internal/openaicompat/client.go
+++ b/internal/openaicompat/client.go
@@ -1,0 +1,297 @@
+package openaicompat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+const responseSizeLimit = 4 << 20
+
+type Client struct {
+	Runtime    string
+	Model      string
+	Endpoint   string
+	Token      string
+	MaxRetries int
+	HTTPClient *http.Client
+}
+
+type EmbeddingsRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type EmbeddingsResponse struct {
+	Data []Embedding     `json:"data"`
+	Err  json.RawMessage `json:"error,omitempty"`
+}
+
+type Embedding struct {
+	Embedding []float64 `json:"embedding"`
+	Index     int       `json:"index"`
+}
+
+type ChatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	Temperature float64       `json:"temperature"`
+}
+
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatResponse struct {
+	Choices []chatChoice    `json:"choices"`
+	Err     json.RawMessage `json:"error,omitempty"`
+}
+
+type chatChoice struct {
+	Message chatChoiceMessage `json:"message"`
+}
+
+type chatChoiceMessage struct {
+	Content json.RawMessage `json:"content"`
+}
+
+func NewClient(provider config.RuntimeProvider, runtime string) (*Client, error) {
+	token := ""
+	if envVar := strings.TrimSpace(provider.APIKeyEnv); envVar != "" {
+		token = strings.TrimSpace(os.Getenv(envVar))
+		if token == "" {
+			return nil, NewDependencyUnavailable(runtime, "missing API key for %s", runtime)
+		}
+	}
+
+	httpClient := &http.Client{}
+	if provider.TimeoutMS > 0 {
+		httpClient.Timeout = time.Duration(provider.TimeoutMS) * time.Millisecond
+	}
+
+	return &Client{
+		Runtime:    strings.TrimSpace(runtime),
+		Model:      strings.TrimSpace(provider.Model),
+		Endpoint:   strings.TrimRight(strings.TrimSpace(provider.Endpoint), "/"),
+		Token:      token,
+		MaxRetries: provider.MaxRetries,
+		HTTPClient: httpClient,
+	}, nil
+}
+
+func (c *Client) Embeddings(ctx context.Context, input []string) (*EmbeddingsResponse, error) {
+	body, err := json.Marshal(EmbeddingsRequest{
+		Model: c.Model,
+		Input: input,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode %s request: %w", c.Runtime, err)
+	}
+
+	return doWithRetries(ctx, c, "/embeddings", body, func(resp *http.Response, responseBody []byte) (*EmbeddingsResponse, error) {
+		var payload EmbeddingsResponse
+		if err := json.Unmarshal(responseBody, &payload); err != nil {
+			return nil, NewDependencyUnavailable(c.Runtime, "decode %s response: %v", c.Runtime, err)
+		}
+		if message := ExtractErrorValue(payload.Err); message != "" {
+			return nil, NewDependencyUnavailable(c.Runtime, "%s endpoint %s returned an error: %s", c.Runtime, resp.Request.URL, message)
+		}
+		return &payload, nil
+	})
+}
+
+func (c *Client) ChatCompletionText(ctx context.Context, messages []ChatMessage, temperature float64) (string, error) {
+	body, err := json.Marshal(ChatRequest{
+		Model:       c.Model,
+		Messages:    messages,
+		Temperature: temperature,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode %s request: %w", c.Runtime, err)
+	}
+
+	return doWithRetries(ctx, c, "/chat/completions", body, func(resp *http.Response, responseBody []byte) (string, error) {
+		var payload chatResponse
+		if err := json.Unmarshal(responseBody, &payload); err != nil {
+			return "", NewDependencyUnavailable(c.Runtime, "decode %s response: %v", c.Runtime, err)
+		}
+		if message := ExtractErrorValue(payload.Err); message != "" {
+			return "", NewDependencyUnavailable(c.Runtime, "%s endpoint %s returned an error: %s", c.Runtime, resp.Request.URL, message)
+		}
+		if len(payload.Choices) == 0 {
+			return "", NewDependencyUnavailable(c.Runtime, "%s returned no choices", c.Runtime)
+		}
+
+		text := ExtractMessageText(payload.Choices[0].Message.Content)
+		if text == "" {
+			return "", NewDependencyUnavailable(c.Runtime, "%s returned an empty message", c.Runtime)
+		}
+		return text, nil
+	})
+}
+
+func ExtractMessageText(raw json.RawMessage) string {
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return strings.TrimSpace(text)
+	}
+
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var builder strings.Builder
+		for _, part := range parts {
+			if strings.TrimSpace(part.Text) == "" {
+				continue
+			}
+			if builder.Len() > 0 {
+				builder.WriteString("\n")
+			}
+			builder.WriteString(strings.TrimSpace(part.Text))
+		}
+		return strings.TrimSpace(builder.String())
+	}
+
+	return strings.TrimSpace(string(raw))
+}
+
+func doWithRetries[T any](ctx context.Context, client *Client, path string, body []byte, decode func(*http.Response, []byte) (T, error)) (T, error) {
+	var zero T
+	var lastErr error
+
+	for attempt := 0; attempt <= client.MaxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, client.Endpoint+path, bytes.NewReader(body))
+		if err != nil {
+			return zero, fmt.Errorf("build %s request: %w", client.Runtime, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if client.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+client.Token)
+		}
+
+		resp, err := client.HTTPClient.Do(req)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || (errors.Is(err, context.DeadlineExceeded) && ctx.Err() != nil) {
+				return zero, err
+			}
+			lastErr = NewDependencyUnavailable(client.Runtime, "call %s endpoint %s: %v", client.Runtime, client.Endpoint, err)
+			if shouldRetry(err, 0) && attempt < client.MaxRetries {
+				if waitErr := waitBeforeRetry(ctx, attempt, 0); waitErr != nil {
+					return zero, waitErr
+				}
+				continue
+			}
+			return zero, lastErr
+		}
+
+		retryAfter := retryAfterDuration(resp.Header.Get("Retry-After"))
+		responseBody, readErr := io.ReadAll(io.LimitReader(resp.Body, responseSizeLimit))
+		resp.Body.Close()
+		if readErr != nil {
+			err = NewDependencyUnavailable(client.Runtime, "read %s response: %v", client.Runtime, readErr)
+		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			message := ExtractErrorMessage(responseBody)
+			if message == "" {
+				message = strings.TrimSpace(string(responseBody))
+			}
+			if message == "" {
+				message = http.StatusText(resp.StatusCode)
+			}
+			err = NewDependencyUnavailable(client.Runtime, "%s endpoint %s returned %s: %s", client.Runtime, resp.Request.URL, resp.Status, message)
+		} else {
+			value, decodeErr := decode(resp, responseBody)
+			if decodeErr == nil {
+				return value, nil
+			}
+			err = decodeErr
+		}
+
+		lastErr = err
+		if shouldRetry(err, resp.StatusCode) && attempt < client.MaxRetries {
+			if waitErr := waitBeforeRetry(ctx, attempt, retryAfter); waitErr != nil {
+				return zero, waitErr
+			}
+			continue
+		}
+		return zero, err
+	}
+
+	if lastErr == nil {
+		lastErr = NewDependencyUnavailable(client.Runtime, "%s request failed", client.Runtime)
+	}
+	return zero, lastErr
+}
+
+func shouldRetry(err error, statusCode int) bool {
+	if statusCode == http.StatusTooManyRequests || statusCode >= 500 {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout() || netErr.Temporary()
+	}
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "connection refused") ||
+		strings.Contains(lower, "connection reset") ||
+		strings.Contains(lower, "broken pipe")
+}
+
+func retryAfterDuration(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		return 0
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(when); delay > 0 {
+			return delay
+		}
+	}
+	return 0
+}
+
+func waitBeforeRetry(ctx context.Context, attempt int, retryAfter time.Duration) error {
+	delay := retryAfter
+	if delay <= 0 {
+		delay = 200 * time.Millisecond
+		for i := 0; i < attempt; i++ {
+			delay *= 2
+			if delay >= 2*time.Second {
+				delay = 2 * time.Second
+				break
+			}
+		}
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/openaicompat/errors.go
+++ b/internal/openaicompat/errors.go
@@ -2,8 +2,33 @@ package openaicompat
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
+
+// DependencyUnavailableError indicates that an OpenAI-compatible runtime could
+// not satisfy the current request.
+type DependencyUnavailableError struct {
+	Runtime string
+	Message string
+}
+
+func (e *DependencyUnavailableError) Error() string {
+	return e.Message
+}
+
+// RuntimeName returns the associated runtime surface.
+func (e *DependencyUnavailableError) RuntimeName() string {
+	return strings.TrimSpace(e.Runtime)
+}
+
+// NewDependencyUnavailable formats a dependency-unavailable runtime error.
+func NewDependencyUnavailable(runtime, format string, args ...any) *DependencyUnavailableError {
+	return &DependencyUnavailableError{
+		Runtime: runtime,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
 
 // ExtractErrorMessage returns a human-readable error message from a full
 // OpenAI-compatible response body.

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -347,56 +347,64 @@ func isValidSpecStatus(status string) bool {
 
 func loadMarkdownDocs(workspaceRoot string, source config.Source) ([]model.DocRecord, error) {
 	var records []model.DocRecord
-	err := filepath.WalkDir(source.ResolvedPath, func(path string, d os.DirEntry, err error) error {
+	matches, err := enumerateSelectedMarkdownPaths(workspaceRoot, source, "doc")
+	if err != nil {
+		return nil, err
+	}
+	for _, match := range matches {
+		bodyBytes, err := os.ReadFile(match.AbsolutePath)
 		if err != nil {
-			return err
+			return nil, fmt.Errorf("source %q doc %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
 		}
-		if d.IsDir() || filepath.Ext(path) != ".md" {
-			return nil
-		}
-		relPath, err := filepath.Rel(source.ResolvedPath, path)
+		docRef, err := docRefForPath(source.ResolvedPath, match.AbsolutePath)
 		if err != nil {
-			return fmt.Errorf("source %q doc %q: resolve relative path: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-		}
-		allowed, err := sourcePathAllowed(source, relPath)
-		if err != nil {
-			return fmt.Errorf("source %q doc %q: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-		}
-		if !allowed {
-			return nil
-		}
-
-		bodyBytes, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("source %q doc %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-		}
-		docRef, err := docRefForPath(source.ResolvedPath, path)
-		if err != nil {
-			return fmt.Errorf("source %q doc %q: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
+			return nil, fmt.Errorf("source %q doc %q: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
 		}
 		records = append(records, model.DocRecord{
 			Ref:         docRef,
 			Kind:        model.ArtifactKindDoc,
-			Title:       docTitle(path, bodyBytes),
-			SourceRef:   fileSourceRef(workspaceRoot, path),
+			Title:       docTitle(match.AbsolutePath, bodyBytes),
+			SourceRef:   fileSourceRef(workspaceRoot, match.AbsolutePath),
 			BodyFormat:  model.BodyFormatMarkdown,
 			BodyText:    string(bodyBytes),
 			ContentHash: contentHash(bodyBytes),
 			Metadata: map[string]string{
 				"source_name": source.Name,
-				"path":        workspaceRelative(workspaceRoot, path),
+				"path":        workspaceRelative(workspaceRoot, match.AbsolutePath),
 			},
 		})
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 	return records, nil
 }
 
 func loadMarkdownContracts(workspaceRoot string, source config.Source) ([]model.SpecRecord, error) {
 	var records []model.SpecRecord
+	matches, err := enumerateSelectedMarkdownPaths(workspaceRoot, source, "contract")
+	if err != nil {
+		return nil, err
+	}
+	for _, match := range matches {
+		bodyBytes, err := os.ReadFile(match.AbsolutePath)
+		if err != nil {
+			return nil, fmt.Errorf("source %q contract %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
+		}
+
+		record, err := inferMarkdownContract(workspaceRoot, source, match.AbsolutePath, bodyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("source %q contract %q: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+type selectedMarkdownPath struct {
+	AbsolutePath string
+	RelativePath string
+}
+
+func enumerateSelectedMarkdownPaths(workspaceRoot string, source config.Source, label string) ([]selectedMarkdownPath, error) {
+	matches := make([]selectedMarkdownPath, 0)
 	err := filepath.WalkDir(source.ResolvedPath, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -406,32 +414,26 @@ func loadMarkdownContracts(workspaceRoot string, source config.Source) ([]model.
 		}
 		relPath, err := filepath.Rel(source.ResolvedPath, path)
 		if err != nil {
-			return fmt.Errorf("source %q contract %q: resolve relative path: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
+			return fmt.Errorf("source %q %s %q: resolve relative path: %w", source.Name, label, workspaceRelative(workspaceRoot, path), err)
 		}
 		allowed, err := sourcePathAllowed(source, relPath)
 		if err != nil {
-			return fmt.Errorf("source %q contract %q: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
+			return fmt.Errorf("source %q %s %q: %w", source.Name, label, workspaceRelative(workspaceRoot, path), err)
 		}
 		if !allowed {
 			return nil
 		}
 
-		bodyBytes, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("source %q contract %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-		}
-
-		record, err := inferMarkdownContract(workspaceRoot, source, path, bodyBytes)
-		if err != nil {
-			return fmt.Errorf("source %q contract %q: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-		}
-		records = append(records, record)
+		matches = append(matches, selectedMarkdownPath{
+			AbsolutePath: path,
+			RelativePath: filepath.ToSlash(relPath),
+		})
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return records, nil
+	return matches, nil
 }
 
 func sourcePathAllowed(source config.Source, relPath string) (bool, error) {

--- a/internal/source/preview.go
+++ b/internal/source/preview.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/dusk-network/pituitary/internal/config"
@@ -74,64 +73,26 @@ func previewSource(workspaceRoot string, source config.Source) (SourcePreview, e
 			})
 		}
 	case config.SourceKindMarkdownDocs:
-		err := filepath.WalkDir(source.ResolvedPath, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if d.IsDir() || filepath.Ext(path) != ".md" {
-				return nil
-			}
-
-			relPath, err := filepath.Rel(source.ResolvedPath, path)
-			if err != nil {
-				return fmt.Errorf("source %q doc %q: resolve relative path: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-			}
-			allowed, err := sourcePathAllowed(source, relPath)
-			if err != nil {
-				return fmt.Errorf("source %q doc %q: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-			}
-			if !allowed {
-				return nil
-			}
-
-			preview.Items = append(preview.Items, PreviewItem{
-				ArtifactKind: "doc",
-				Path:         workspaceRelative(workspaceRoot, path),
-			})
-			return nil
-		})
+		matches, err := enumerateSelectedMarkdownPaths(workspaceRoot, source, "doc")
 		if err != nil {
 			return SourcePreview{}, err
 		}
-	case config.SourceKindMarkdownContract:
-		err := filepath.WalkDir(source.ResolvedPath, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if d.IsDir() || filepath.Ext(path) != ".md" {
-				return nil
-			}
-
-			relPath, err := filepath.Rel(source.ResolvedPath, path)
-			if err != nil {
-				return fmt.Errorf("source %q contract %q: resolve relative path: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-			}
-			allowed, err := sourcePathAllowed(source, relPath)
-			if err != nil {
-				return fmt.Errorf("source %q contract %q: %w", source.Name, workspaceRelative(workspaceRoot, path), err)
-			}
-			if !allowed {
-				return nil
-			}
-
+		for _, match := range matches {
 			preview.Items = append(preview.Items, PreviewItem{
-				ArtifactKind: "spec",
-				Path:         workspaceRelative(workspaceRoot, path),
+				ArtifactKind: "doc",
+				Path:         workspaceRelative(workspaceRoot, match.AbsolutePath),
 			})
-			return nil
-		})
+		}
+	case config.SourceKindMarkdownContract:
+		matches, err := enumerateSelectedMarkdownPaths(workspaceRoot, source, "contract")
 		if err != nil {
 			return SourcePreview{}, err
+		}
+		for _, match := range matches {
+			preview.Items = append(preview.Items, PreviewItem{
+				ArtifactKind: "spec",
+				Path:         workspaceRelative(workspaceRoot, match.AbsolutePath),
+			})
 		}
 	default:
 		return SourcePreview{}, fmt.Errorf("source %q: unsupported kind %q", source.Name, source.Kind)


### PR DESCRIPTION
## Summary
- unify command metadata and format capabilities behind one command registry
- move status onto the internal/app boundary and preserve its current surface
- share OpenAI-compatible client logic across embedder and analysis, and share markdown source enumeration across load and preview
- preserve explicit timeout_ms = 0 in config parsing

Closes #116
Closes #117
Closes #118
Closes #119