### PR TITLE
[feature] Add one-shot init onboarding

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -584,6 +584,9 @@ CLI exit codes should stay simple:
 
 #### V1 JSON command contracts
 
+- `init` (`pituitary init`)
+  - Request: `{ "path": ".", "config_path": "...", "dry_run": false }`
+  - Result: `{ "workspace_root": "...", "config_path": "...", "config_action": "preview" | "wrote", "discover": { ... discovered config proposal ... }, "index": { ... } | null, "status": { ... } | null }`
 - `status` (`pituitary status`)
   - Request: `{ "check_runtime": "none" | "embedder" | "analysis" | "all" }`
   - Result: `{ "workspace_root": "...", "config_path": "...", "config_resolution": { "selected_by": "command_flag" | "global_flag" | "env" | "discovered_local", "reason": "...", "candidates": [{ "precedence": 1, "source": "...", "path": "...", "status": "selected" | "shadowed" | "not_set" | "missing", "detail": "..." }] }, "index_path": "...", "index_exists": true, "freshness": { "state": "missing" | "fresh" | "stale" | "incompatible", "action": "run `pituitary index --rebuild`", "issues": [{ "kind": "...", "message": "...", "indexed": "...", "current": "..." }] }, "spec_count": N, "doc_count": N, "chunk_count": N, "artifact_locations": { "index_dir": "...", "discover_config_path": "...", "canonicalize_bundle_root": "...", "ignore_patterns": [".pituitary/"], "relocation_hints": ["..."] }, "runtime": { ... } | null }`

--- a/README.md
+++ b/README.md
@@ -52,17 +52,23 @@ The repo ships with a small example workspace under `specs/` and curated fixture
 
 ### Existing repo onboarding
 
-For a repo that does not already have a hand-written `pituitary.toml`, start with discovery before you index:
+For a repo that does not already have a hand-written `pituitary.toml`, the fastest onboarding path is:
 
 ```sh
-./pituitary discover --path .
-./pituitary discover --path . --write
-./pituitary preview-sources
-./pituitary explain-file README.md
-./pituitary index --rebuild
+./pituitary init --path .
 ```
 
-`discover` proposes a conservative local config, `preview-sources` shows exactly what will be indexed, and `explain-file` helps you diagnose why an important file is or is not in scope before you pay for a rebuild.
+`init` discovers conservative sources, writes a local config, rebuilds the index, and finishes with a status summary so you get useful feedback on the first run.
+
+If you want to preview before writing or indexing, use:
+
+```sh
+./pituitary init --path . --dry-run
+./pituitary preview-sources
+./pituitary explain-file README.md
+```
+
+`discover` remains the lower-level building block when you want to inspect or hand-edit the generated config before committing to a rebuild.
 
 ### Retrieval mode matters
 
@@ -184,11 +190,10 @@ Selectors narrow what gets indexed; they do not rewrite refs. For example, a doc
 For an existing repo without a hand-written config yet, the default onboarding flow is:
 
 ```sh
-./pituitary discover --path .
-./pituitary discover --path . --write
-./pituitary preview-sources
-./pituitary index --rebuild
+./pituitary init --path .
 ```
+
+Use `pituitary init --dry-run` when you want to preview the generated config and discovered sources before writing anything.
 
 If you still have a legacy config shaped like `[project]` with `specs_dir = "specs"`, migrate it with:
 
@@ -202,6 +207,7 @@ Every command supports `--format json` for machine-readable output. `search-spec
 
 | Command | What it does |
 |---|---|
+| `init --path .` | One-shot onboarding: discover sources, write a local config, rebuild the index, and report status |
 | `discover --path .` | Scan a repo, propose conservative sources for specs, contracts, guides, runbooks, and reference docs, and show the generated local config |
 | `migrate-config --path pituitary.toml --write` | Rewrite a legacy or unversioned config into the current schema |
 | `preview-sources` | Show which files each configured source will index |

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -10,6 +10,7 @@ func TestRunCommandHelpAcrossSurface(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string][]string{
+		"init":              {"usage: pituitary init [--path PATH] [--config-path PATH] [--dry-run] [--format FORMAT]", "--path VALUE", "--config-path VALUE", "--dry-run"},
 		"index":             {"usage: pituitary [--config PATH] index (--rebuild | --dry-run) [--full] [--format FORMAT]", "shared config resolution:", "PITUITARY_CONFIG", "--rebuild", "--dry-run", "--full", "--verbose"},
 		"migrate-config":    {"usage: pituitary migrate-config [--path PATH] [--write] [--format FORMAT]", "--path VALUE", "--write"},
 		"status":            {"usage: pituitary [--config PATH] status [--format FORMAT] [--check-runtime SCOPE]", "shared config resolution:", "--format VALUE", "--check-runtime VALUE"},

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/app"
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+type initRequest struct {
+	Path       string `json:"path"`
+	ConfigPath string `json:"config_path,omitempty"`
+	DryRun     bool   `json:"dry_run,omitempty"`
+}
+
+type initResult struct {
+	WorkspaceRoot string                 `json:"workspace_root"`
+	ConfigPath    string                 `json:"config_path"`
+	ConfigAction  string                 `json:"config_action"`
+	Discover      *source.DiscoverResult `json:"discover,omitempty"`
+	Index         *index.RebuildResult   `json:"index,omitempty"`
+	Status        *statusResult          `json:"status,omitempty"`
+}
+
+func runInit(args []string, stdout, stderr io.Writer) int {
+	return runInitContext(context.Background(), args, stdout, stderr)
+}
+
+func runInitContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	help := newStandaloneCommandHelp("init", "pituitary init [--path PATH] [--config-path PATH] [--dry-run] [--format FORMAT]")
+
+	var (
+		path       string
+		configPath string
+		dryRun     bool
+		format     string
+	)
+	fs.StringVar(&path, "path", ".", "workspace path to initialize")
+	fs.StringVar(&configPath, "config-path", "", "where init should place the generated config")
+	fs.BoolVar(&dryRun, "dry-run", false, "preview the generated config and discovered sources without writing or indexing")
+	fs.StringVar(&format, "format", "text", "output format")
+
+	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
+		return writeCLIError(stdout, stderr, format, "init", nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	} else if handled {
+		return 0
+	}
+	if fs.NArg() != 0 {
+		return writeCLIError(stdout, stderr, format, "init", nil, cliIssue{
+			Code:    "validation_error",
+			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
+		}, 2)
+	}
+	if err := validateCLIFormat("init", format); err != nil {
+		return writeCLIError(stdout, stderr, format, "init", initRequest{Path: path, ConfigPath: strings.TrimSpace(configPath), DryRun: dryRun}, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	request := initRequest{
+		Path:       path,
+		ConfigPath: strings.TrimSpace(configPath),
+		DryRun:     dryRun,
+	}
+	discovered, err := source.DiscoverWorkspace(source.DiscoverOptions{
+		RootPath:   path,
+		ConfigPath: request.ConfigPath,
+		Write:      false,
+	})
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+			Code:    "discovery_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	if dryRun {
+		return writeCLISuccess(stdout, stderr, format, "init", request, &initResult{
+			WorkspaceRoot: discovered.WorkspaceRoot,
+			ConfigPath:    discovered.ConfigPath,
+			ConfigAction:  "preview",
+			Discover:      discovered,
+		}, nil)
+	}
+
+	if err := ensureInitConfigAbsent(discovered.ConfigPath); err != nil {
+		return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+	if err := source.WriteDiscoveredConfig(discovered.ConfigPath, discovered.Config); err != nil {
+		return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	cfg, err := config.Load(discovered.ConfigPath)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+			Code:    "config_error",
+			Message: "invalid config:\n" + err.Error(),
+		}, 2)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+			Code:    "source_error",
+			Message: "source load failed:\n" + err.Error(),
+		}, 2)
+	}
+
+	var rebuild *index.RebuildResult
+	if format == commandFormatText {
+		rebuild, err = index.RebuildWithProgressContextAndOptions(ctx, cfg, records, index.RebuildOptions{}, func(event index.RebuildProgressEvent) {
+			fmt.Fprintf(stderr, "pituitary init: %s %d/%d %s %s (%d chunk(s))\n", event.Phase, event.Current, event.Total, event.ArtifactKind, event.ArtifactRef, event.ChunkCount)
+		})
+	} else {
+		rebuild, err = index.RebuildContextWithOptions(ctx, cfg, records, index.RebuildOptions{})
+	}
+	if err != nil {
+		switch {
+		case index.IsGraphValidationError(err):
+			return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+				Code:    "validation_error",
+				Message: "relation graph invalid:\n" + err.Error(),
+			}, 2)
+		case index.IsDependencyUnavailable(err):
+			return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+				Code:    "dependency_unavailable",
+				Message: "dependency unavailable:\n" + err.Error(),
+			}, 3)
+		default:
+			return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+				Code:    "internal_error",
+				Message: "rebuild failed:\n" + err.Error(),
+			}, 2)
+		}
+	}
+
+	statusResponse := app.Status(ctx, discovered.ConfigPath, app.StatusRequest{})
+	if statusResponse.Issue != nil {
+		return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
+			Code:    statusResponse.Issue.Code,
+			Message: statusResponse.Issue.Message,
+		}, statusResponse.Issue.ExitCode)
+	}
+
+	return writeCLISuccess(stdout, stderr, format, "init", request, &initResult{
+		WorkspaceRoot: discovered.WorkspaceRoot,
+		ConfigPath:    discovered.ConfigPath,
+		ConfigAction:  "wrote",
+		Discover:      discovered,
+		Index:         rebuild,
+		Status:        newStatusResult(statusResponse.Result, nil),
+	}, nil)
+}
+
+func ensureInitConfigAbsent(path string) error {
+	info, err := os.Stat(path)
+	switch {
+	case err == nil && info.IsDir():
+		return fmt.Errorf("config path %s is a directory; choose a file path with --config-path", path)
+	case err == nil:
+		return fmt.Errorf("config already exists at %s; use `pituitary status` or `pituitary index --rebuild`, or choose a different --config-path", path)
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return fmt.Errorf("stat config path: %w", err)
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunInitDryRunJSON(t *testing.T) {
+	repo := writeDiscoveryWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runInit([]string{"--path", ".", "--dry-run", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runInit(--dry-run) exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runInit(--dry-run) wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request initRequest `json:"request"`
+		Result  struct {
+			ConfigAction string `json:"config_action"`
+			Index        any    `json:"index"`
+			Status       any    `json:"status"`
+			Discover     struct {
+				ConfigPath string        `json:"config_path"`
+				Sources    []interface{} `json:"sources"`
+			} `json:"discover"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal init payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if !payload.Request.DryRun || payload.Request.Path != "." {
+		t.Fatalf("request = %+v, want dry-run path request", payload.Request)
+	}
+	if got, want := payload.Result.ConfigAction, "preview"; got != want {
+		t.Fatalf("config_action = %q, want %q", got, want)
+	}
+	if got, want := len(payload.Result.Discover.Sources), 3; got != want {
+		t.Fatalf("discover sources = %d, want %d", got, want)
+	}
+	if payload.Result.Index != nil {
+		t.Fatalf("index = %+v, want nil in dry-run", payload.Result.Index)
+	}
+	if payload.Result.Status != nil {
+		t.Fatalf("status = %+v, want nil in dry-run", payload.Result.Status)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".pituitary", "pituitary.toml")); !os.IsNotExist(err) {
+		t.Fatalf("config unexpectedly exists after dry-run: %v", err)
+	}
+}
+
+func TestRunInitWritesConfigRebuildsAndSummarizes(t *testing.T) {
+	repo := writeDiscoveryWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runInit([]string{"--path", "."}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runInit() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "pituitary init: ") {
+			t.Fatalf("runInit() wrote unexpected stderr line %q (full stderr: %q)", line, stderr.String())
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(repo, ".pituitary", "pituitary.toml")); err != nil {
+		t.Fatalf("discovered config missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".pituitary", "pituitary.db")); err != nil {
+		t.Fatalf("rebuilt index missing: %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"pituitary init: discover, write, index, and summarize a workspace",
+		"config action: wrote",
+		"index: 4 artifact(s), 4 chunk(s), 2 edge(s)",
+		"status: fresh | specs: 2 | docs: 2 | chunks: 4",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("runInit() output %q does not contain %q", output, want)
+		}
+	}
+}
+
+func TestRunInitRejectsExistingConfig(t *testing.T) {
+	repo := writeDiscoveryWorkspace(t)
+	mustMkdirAllCmd(t, filepath.Join(repo, ".pituitary"))
+	mustWriteFileCmd(t, filepath.Join(repo, ".pituitary", "pituitary.toml"), "schema_version = 2\n")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runInit([]string{"--path", "."}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runInit() exit code = %d, want 2", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("runInit() wrote unexpected stdout: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "config already exists") {
+		t.Fatalf("runInit() stderr %q does not contain existing-config message", stderr.String())
+	}
+}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -24,6 +24,8 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 		renderCanonicalizeResult(w, typed)
 	case *source.DiscoverResult:
 		renderDiscoverResult(w, typed)
+	case *initResult:
+		renderInitResult(w, typed)
 	case *migrateConfigResult:
 		renderMigrateConfigResult(w, typed)
 	case *index.RebuildResult:
@@ -163,6 +165,28 @@ func renderCanonicalizeResult(w io.Writer, result *source.CanonicalizeResult) {
 		if !strings.HasSuffix(file.Content, "\n") {
 			fmt.Fprintln(w)
 		}
+	}
+}
+
+func renderInitResult(w io.Writer, result *initResult) {
+	fmt.Fprintf(w, "workspace: %s\n", result.WorkspaceRoot)
+	fmt.Fprintf(w, "config path: %s\n", result.ConfigPath)
+	fmt.Fprintf(w, "config action: %s\n", result.ConfigAction)
+	if result.Discover != nil {
+		fmt.Fprintf(w, "discovered sources: %d\n", len(result.Discover.Sources))
+	}
+	if result.Index != nil {
+		fmt.Fprintf(w, "index: %d artifact(s), %d chunk(s), %d edge(s)\n", result.Index.ArtifactCount, result.Index.ChunkCount, result.Index.EdgeCount)
+	}
+	if result.Status != nil {
+		status := "unknown"
+		if result.Status.Freshness != nil && result.Status.Freshness.State != "" {
+			status = result.Status.Freshness.State
+		}
+		fmt.Fprintf(w, "status: %s | specs: %d | docs: %d | chunks: %d\n", status, result.Status.SpecCount, result.Status.DocCount, result.Status.ChunkCount)
+	}
+	if result.ConfigAction == "preview" {
+		fmt.Fprintln(w, "next: run `pituitary init` without --dry-run to write the config and build the index")
 	}
 }
 

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -201,6 +201,44 @@ func TestRenderCommandTableSearchSpecs(t *testing.T) {
 	}
 }
 
+func TestRenderInitResultSummarizesOnboarding(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	renderInitResult(&stdout, &initResult{
+		WorkspaceRoot: "/tmp/repo",
+		ConfigPath:    "/tmp/repo/.pituitary/pituitary.toml",
+		ConfigAction:  "wrote",
+		Discover: &source.DiscoverResult{
+			Sources: []source.DiscoveredSource{{}, {}, {}},
+		},
+		Index: &index.RebuildResult{
+			ArtifactCount: 5,
+			ChunkCount:    17,
+			EdgeCount:     8,
+		},
+		Status: &statusResult{
+			Freshness:  &index.FreshnessStatus{State: "fresh"},
+			SpecCount:  3,
+			DocCount:   2,
+			ChunkCount: 17,
+		},
+	})
+
+	output := stdout.String()
+	for _, want := range []string{
+		"workspace: /tmp/repo",
+		"config action: wrote",
+		"discovered sources: 3",
+		"index: 5 artifact(s), 17 chunk(s), 8 edge(s)",
+		"status: fresh | specs: 3 | docs: 2 | chunks: 17",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("renderInitResult() output %q does not contain %q", output, want)
+		}
+	}
+}
+
 func TestRenderTerminologyAuditResultIncludesEvidence(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ func commandRegistry() map[string]commandSpec {
 	return map[string]commandSpec{
 		"canonicalize":      {Description: "promote an inferred contract into a spec bundle", Formats: commandFormats(), Run: runCanonicalizeContext},
 		"discover":          {Description: "scan a repo and propose a local config", Formats: commandFormats(), Run: runDiscoverContext},
+		"init":              {Description: "discover, write, index, and summarize a workspace", Formats: commandFormats(), Run: runInitContext},
 		"migrate-config":    {Description: "rewrite a legacy config into the current schema", Formats: commandFormats(), Run: runMigrateConfigContext},
 		"index":             {Description: "rebuild or validate the local Pituitary index", Formats: commandFormats(), Run: runIndexContext},
 		"status":            {Description: "show current index status", Formats: commandFormats(), Run: runStatusContext},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -32,9 +32,9 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 				return
 			}
 
-			if name == "canonicalize" || name == "discover" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "review-spec" {
+			if name == "canonicalize" || name == "discover" || name == "init" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "review-spec" {
 				repoRoot := writeSearchWorkspace(t)
-				if name == "discover" || name == "canonicalize" {
+				if name == "discover" || name == "init" || name == "canonicalize" {
 					repoRoot = writeDiscoveryWorkspace(t)
 				}
 				if name == "canonicalize" {
@@ -45,6 +45,13 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 					return
 				}
 				if name == "discover" {
+					args = []string{name, "--path", "."}
+					expectBootstrapStatus = false
+					exitCode := withWorkingDir(t, repoRoot, run)
+					assertKnownCommandResult(t, name, commandDescription(name), exitCode, stdout.String(), stderr.String(), expectBootstrapStatus)
+					return
+				}
+				if name == "init" {
 					args = []string{name, "--path", "."}
 					expectBootstrapStatus = false
 					exitCode := withWorkingDir(t, repoRoot, run)
@@ -161,11 +168,14 @@ func assertKnownCommandResult(t *testing.T, name, description string, exitCode i
 	if exitCode != 0 {
 		t.Fatalf("Run(%q) exit code = %d, want 0", name, exitCode)
 	}
-	if stderr != "" && name != "index" {
+	if stderr != "" && name != "index" && name != "init" {
 		t.Fatalf("Run(%q) wrote unexpected stderr: %q", name, stderr)
 	}
 	if name == "index" && stderr != "" && !strings.Contains(stderr, "pituitary index: chunking") {
 		t.Fatalf("Run(%q) stderr %q does not contain rebuild progress", name, stderr)
+	}
+	if name == "init" && stderr != "" && !strings.Contains(stderr, "pituitary init: chunking") {
+		t.Fatalf("Run(%q) stderr %q does not contain init progress", name, stderr)
 	}
 
 	if !strings.Contains(stdout, description) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -110,7 +110,14 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 	}
 	result := response.Result
 
-	return writeCLISuccess(stdout, stderr, format, "status", request, &statusResult{
+	return writeCLISuccess(stdout, stderr, format, "status", request, newStatusResult(result, resolution), nil)
+}
+
+func newStatusResult(result *app.StatusResult, resolution *configResolution) *statusResult {
+	if result == nil || result.Index == nil {
+		return nil
+	}
+	return &statusResult{
 		WorkspaceRoot:     result.WorkspaceRoot,
 		ConfigPath:        result.ConfigPath,
 		ConfigResolution:  resolution,
@@ -123,7 +130,7 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 		ArtifactLocations: buildStatusArtifactLocations(result.WorkspaceRoot, result.Index.IndexPath),
 		RelationGraph:     result.RelationGraph,
 		Runtime:           result.Runtime,
-	}, nil)
+	}
 }
 
 func buildStatusArtifactLocations(workspaceRoot, indexPath string) *statusArtifactLocation {

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -134,6 +134,11 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 	return result, nil
 }
 
+// WriteDiscoveredConfig writes a rendered discovery config to disk.
+func WriteDiscoveredConfig(path, content string) error {
+	return writeDiscoveredConfig(path, content)
+}
+
 func discoverSpecBundleCandidates(workspaceRoot string) ([]discoveredCandidate, map[string]struct{}, error) {
 	var candidates []discoveredCandidate
 	bundleDirs := make(map[string]struct{})


### PR DESCRIPTION
## Summary
- add `pituitary init` as a one-shot onboarding command
- write the discovered config, rebuild the index, and finish with a status summary
- document the new onboarding flow and add regression coverage

Closes #123
Follow-ups: #121, #122, #124