### PR TITLE
Warn when fixture mode is used on larger corpora

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ If your repo already has a config, skip `init` and go straight to `status`, `ind
 
 The shipped default `fixture` embedder is the deterministic baseline for tests, CI, and zero-credential evaluation. It is not the recommended retrieval runtime for a real spec corpus.
 
+When `init` or `status` sees a larger indexed corpus still using `fixture`, Pituitary now emits a guidance note instead of silently treating that setup as production-quality retrieval.
+
 If you are evaluating search quality, overlap ranking, doc drift, or terminology audits on your own repo:
 
 1. Follow the local runtime setup in [AI Runtime Configuration](#ai-runtime-configuration).

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -104,6 +104,30 @@ func TestRunInitWritesConfigRebuildsAndSummarizes(t *testing.T) {
 	}
 }
 
+func TestRunInitReportsFixtureGuidanceForLargerCorpus(t *testing.T) {
+	repo := writeDiscoveryWorkspace(t)
+	mustWriteFileCmd(t, filepath.Join(repo, "docs", "guides", "additional-guide.md"), `
+# Additional Guide
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runInit([]string{"--path", "."}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runInit() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, `guidance: runtime.embedder is still "fixture" on 5 indexed artifact(s)`) {
+		t.Fatalf("runInit() output %q does not contain fixture guidance", output)
+	}
+	if !strings.Contains(output, "`pituitary status --check-runtime embedder`") {
+		t.Fatalf("runInit() output %q does not contain runtime probe guidance", output)
+	}
+}
+
 func TestRunInitRejectsExistingConfig(t *testing.T) {
 	repo := writeDiscoveryWorkspace(t)
 	mustMkdirAllCmd(t, filepath.Join(repo, ".pituitary"))

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -184,6 +184,9 @@ func renderInitResult(w io.Writer, result *initResult) {
 			status = result.Status.Freshness.State
 		}
 		fmt.Fprintf(w, "status: %s | specs: %d | docs: %d | chunks: %d\n", status, result.Status.SpecCount, result.Status.DocCount, result.Status.ChunkCount)
+		for _, guidance := range result.Status.Guidance {
+			fmt.Fprintf(w, "guidance: %s\n", guidance)
+		}
 	}
 	if result.ConfigAction == "preview" {
 		fmt.Fprintln(w, "next: run `pituitary init` without --dry-run to write the config and build the index")
@@ -292,6 +295,9 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 				fmt.Fprintf(w, "runtime note: %s\n", check.Message)
 			}
 		}
+	}
+	for _, guidance := range result.Guidance {
+		fmt.Fprintf(w, "guidance: %s\n", guidance)
 	}
 }
 

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -137,6 +137,9 @@ func TestRenderStatusResultIncludesRuntimeProbe(t *testing.T) {
 				},
 			},
 		},
+		Guidance: []string{
+			`runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
+		},
 	})
 
 	output := stdout.String()
@@ -157,6 +160,7 @@ func TestRenderStatusResultIncludesRuntimeProbe(t *testing.T) {
 		"runtime: runtime.embedder | ready | provider: openai_compatible | model: pituitary-embed | endpoint: http://localhost:1234/v1",
 		"runtime: runtime.analysis | disabled | provider: disabled",
 		"runtime note: runtime.analysis is disabled in config",
+		`guidance: runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderStatusResult() output %q does not contain %q", output, want)
@@ -222,6 +226,9 @@ func TestRenderInitResultSummarizesOnboarding(t *testing.T) {
 			SpecCount:  3,
 			DocCount:   2,
 			ChunkCount: 17,
+			Guidance: []string{
+				`runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
+			},
 		},
 	})
 
@@ -232,6 +239,7 @@ func TestRenderInitResultSummarizesOnboarding(t *testing.T) {
 		"discovered sources: 3",
 		"index: 5 artifact(s), 17 chunk(s), 8 edge(s)",
 		"status: fresh | specs: 3 | docs: 2 | chunks: 17",
+		`guidance: runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderInitResult() output %q does not contain %q", output, want)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -31,6 +31,7 @@ type statusResult struct {
 	ArtifactLocations *statusArtifactLocation    `json:"artifact_locations,omitempty"`
 	RelationGraph     *index.RelationGraphStatus `json:"relation_graph,omitempty"`
 	Runtime           *runtimeprobe.Result       `json:"runtime,omitempty"`
+	Guidance          []string                   `json:"guidance,omitempty"`
 }
 
 type statusArtifactLocation struct {
@@ -130,6 +131,7 @@ func newStatusResult(result *app.StatusResult, resolution *configResolution) *st
 		ArtifactLocations: buildStatusArtifactLocations(result.WorkspaceRoot, result.Index.IndexPath),
 		RelationGraph:     result.RelationGraph,
 		Runtime:           result.Runtime,
+		Guidance:          append([]string(nil), result.Guidance...),
 	}
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -42,6 +42,39 @@ func TestRunStatusReportsMissingIndex(t *testing.T) {
 	}
 }
 
+func TestRunStatusReportsFixtureGuidanceForLargerCorpus(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var rebuildStdout bytes.Buffer
+	var rebuildStderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &rebuildStdout, &rebuildStderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr: %q)", exitCode, rebuildStderr.String())
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode = withWorkingDir(t, repo, func() int {
+		return runStatus(nil, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runStatus() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, `guidance: runtime.embedder is still "fixture" on 5 indexed artifact(s)`) {
+		t.Fatalf("runStatus() output %q does not contain fixture guidance", out)
+	}
+	if !strings.Contains(out, "`pituitary status --check-runtime embedder`") {
+		t.Fatalf("runStatus() output %q does not contain runtime probe guidance", out)
+	}
+}
+
 func TestRunStatusJSON(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 
@@ -95,6 +128,7 @@ func TestRunStatusJSON(t *testing.T) {
 				IgnorePatterns         []string `json:"ignore_patterns"`
 				RelocationHints        []string `json:"relocation_hints"`
 			} `json:"artifact_locations"`
+			Guidance []string `json:"guidance"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
 	}
@@ -129,6 +163,9 @@ func TestRunStatusJSON(t *testing.T) {
 	}
 	if len(payload.Result.ArtifactLocations.RelocationHints) < 3 {
 		t.Fatalf("artifact_locations.relocation_hints = %v, want relocation guidance", payload.Result.ArtifactLocations.RelocationHints)
+	}
+	if len(payload.Result.Guidance) != 1 || !strings.Contains(payload.Result.Guidance[0], `runtime.embedder is still "fixture" on 5 indexed artifact(s)`) {
+		t.Fatalf("result.guidance = %v, want fixture guidance", payload.Result.Guidance)
 	}
 	if payload.Result.SpecCount != 3 || payload.Result.DocCount != 2 || payload.Result.ChunkCount != 17 {
 		t.Fatalf("result = %+v, want 3 specs, 2 docs, 17 chunks", payload.Result)

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
@@ -22,6 +23,7 @@ type StatusResult struct {
 	Freshness     *index.FreshnessStatus
 	RelationGraph *index.RelationGraphStatus
 	Runtime       *runtimeprobe.Result
+	Guidance      []string
 }
 
 // Status loads config, inspects the current index, and optionally probes runtime dependencies.
@@ -56,8 +58,30 @@ func Status(ctx context.Context, configPath string, request StatusRequest) Respo
 			Freshness:     freshness,
 			RelationGraph: index.InspectRelationGraph(records.Specs),
 			Runtime:       runtimeResult,
+			Guidance:      fixtureEmbedderGuidance(cfg, status),
 		}, nil
 	}, classifyStatusError)
+}
+
+func fixtureEmbedderGuidance(cfg *config.Config, status *index.Status) []string {
+	if cfg == nil || status == nil {
+		return nil
+	}
+	if cfg.Runtime.Embedder.Provider != config.RuntimeProviderFixture {
+		return nil
+	}
+	totalArtifacts := status.SpecCount + status.DocCount
+	if totalArtifacts < 5 {
+		return nil
+	}
+	return []string{
+		fmt.Sprintf(
+			"runtime.embedder is still %q on %d indexed artifact(s); for better retrieval quality on a real corpus, switch to %q, rebuild the index, then run `pituitary status --check-runtime embedder`",
+			config.RuntimeProviderFixture,
+			totalArtifacts,
+			config.RuntimeProviderOpenAI,
+		),
+	}
 }
 
 func classifyStatusError(cfg *config.Config, err error) *Issue {


### PR DESCRIPTION
## Summary
- add app-level guidance when a larger indexed corpus still uses the fixture embedder
- surface that guidance in both the status command and post-init summaries
- document the new runtime nudge in the README

Closes #130

## Validation
- go test ./cmd ./internal/app
