### PR TITLE
Add HTML review report output

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ If you still have a legacy config shaped like `[project]` with `specs_dir = "spe
 
 ## Commands
 
-Every command supports `--format json` for machine-readable output. `search-specs` also supports `--format table` for compact terminal summaries, and `review-spec` also supports `--format markdown` for shareable review reports with a summary, recommended next actions, and detailed evidence sections.
+Every command supports `--format json` for machine-readable output. `search-specs` also supports `--format table` for compact terminal summaries, and `review-spec` also supports `--format markdown` and `--format html` for shareable review reports with a summary, recommended next actions, and detailed evidence sections.
 
 | Command | What it does |
 |---|---|
@@ -262,7 +262,7 @@ Every command supports `--format json` for machine-readable output. `search-spec
 | `check-compliance --path PATH` | Check one or more code paths against accepted specs |
 | `check-compliance --diff-file PATH|-` | Check a unified diff against accepted specs; ideal for pre-merge and CI use |
 | `check-doc-drift --scope all` | Find docs that have gone stale relative to accepted specs, with evidence and confidence |
-| `review-spec --path specs/rate-limit-v2` | Full review: overlap + comparison + impact + drift + remediation in one report |
+| `review-spec --path specs/rate-limit-v2` | Full review: overlap + comparison + impact + drift + remediation in one report, with text/json/markdown/html output |
 
 `canonicalize` is optional high-rigor mode. It does not replace inferred-contract indexing; it helps you promote one Markdown contract into an explicit bundle when you want stronger structure without converting the whole repo at once.
 
@@ -496,7 +496,7 @@ Key design decisions:
 
 Pituitary is in active development. The v1 shipping slice is functional: all core analysis commands work end-to-end. See the [GitHub issue queue](https://github.com/dusk-network/pituitary/issues) for active priorities and planned follow-up work.
 
-**What works today:** indexing, incremental rebuild reuse, semantic search, overlap detection, spec comparison, impact analysis, terminology audits, code compliance, doc drift detection, composite review, JSON output, table output for `search-specs`, markdown output for `review-spec`, MCP server.
+**What works today:** indexing, incremental rebuild reuse, semantic search, overlap detection, spec comparison, impact analysis, terminology audits, code compliance, doc drift detection, composite review, JSON output, table output for `search-specs`, markdown and HTML output for `review-spec`, MCP server.
 
 **Product boundary:** Pituitary remains specification-first; compliance is a supporting bridge feature rather than a general code-analysis pivot. See [docs/rfcs/0001-spec-centric-compliance-direction.md](docs/rfcs/0001-spec-centric-compliance-direction.md).
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -22,7 +22,7 @@ type cliEnvelope struct {
 }
 
 func isSupportedFormat(format string) bool {
-	return format == commandFormatText || format == commandFormatJSON || format == commandFormatTable || format == commandFormatMarkdown
+	return format == commandFormatText || format == commandFormatJSON || format == commandFormatTable || format == commandFormatMarkdown || format == commandFormatHTML
 }
 
 func validateCLIFormat(command, format string) error {
@@ -34,6 +34,8 @@ func validateCLIFormat(command, format string) error {
 		case commandFormatTable:
 			return fmt.Errorf("format %q is only supported for search-specs", format)
 		case commandFormatMarkdown:
+			return fmt.Errorf("format %q is only supported for review-spec", format)
+		case commandFormatHTML:
 			return fmt.Errorf("format %q is only supported for review-spec", format)
 		default:
 			return fmt.Errorf("format %q is not supported for %s", format, command)
@@ -65,6 +67,14 @@ func writeCLISuccess(stdout, stderr io.Writer, format, command string, request, 
 	if format == commandFormatMarkdown {
 		writeCLIWarnings(stderr, command, warnings)
 		if err := renderCommandMarkdown(stdout, command, result); err != nil {
+			fmt.Fprintf(stderr, "pituitary %s: %s\n", command, err)
+			return 2
+		}
+		return 0
+	}
+	if format == commandFormatHTML {
+		writeCLIWarnings(stderr, command, warnings)
+		if err := renderCommandHTML(stdout, command, result); err != nil {
 			fmt.Fprintf(stderr, "pituitary %s: %s\n", command, err)
 			return 2
 		}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	htemplate "html/template"
 	"io"
 	"strings"
 	"text/tabwriter"
@@ -88,6 +89,19 @@ func renderCommandMarkdown(w io.Writer, command string, result any) error {
 		return nil
 	default:
 		return fmt.Errorf("format %q is only supported for review-spec", "markdown")
+	}
+}
+
+func renderCommandHTML(w io.Writer, command string, result any) error {
+	switch typed := result.(type) {
+	case *analysis.ReviewResult:
+		if command != "review-spec" {
+			return fmt.Errorf("format %q is only supported for review-spec", "html")
+		}
+		renderReviewHTML(w, typed)
+		return nil
+	default:
+		return fmt.Errorf("format %q is only supported for review-spec", "html")
 	}
 }
 
@@ -898,6 +912,419 @@ func renderReviewMarkdown(w io.Writer, result *analysis.ReviewResult) {
 		}
 		fmt.Fprintln(w)
 	}
+}
+
+func renderReviewHTML(w io.Writer, result *analysis.ReviewResult) {
+	escape := htemplate.HTMLEscapeString
+
+	fmt.Fprint(w, "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n")
+	fmt.Fprintf(w, "<title>Pituitary Review Report: %s</title>\n", escape(result.SpecRef))
+	fmt.Fprint(w, `<style>
+:root {
+  color-scheme: light;
+  --bg: #f5f1e8;
+  --paper: #fffdf8;
+  --ink: #1f2933;
+  --muted: #52606d;
+  --accent: #0b6e4f;
+  --accent-soft: #dff3ea;
+  --line: #d9cbb2;
+  --warn: #9c4221;
+  --warn-soft: #fef3e6;
+  --shadow: rgba(31, 41, 51, 0.08);
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font: 16px/1.55 "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top right, rgba(11, 110, 79, 0.08), transparent 28rem),
+    linear-gradient(180deg, #f9f7f2, var(--bg));
+}
+main {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 4rem;
+}
+h1, h2, h3 { line-height: 1.2; margin: 0 0 0.75rem; }
+h1 { font-size: 2.4rem; letter-spacing: -0.03em; }
+h2 { font-size: 1.35rem; margin-top: 0; }
+h3 { font-size: 1rem; }
+p, ul, ol { margin: 0 0 1rem; }
+code {
+  font-family: "SFMono-Regular", "Cascadia Code", "Menlo", monospace;
+  background: #f3eee4;
+  border: 1px solid #eadfca;
+  border-radius: 0.35rem;
+  padding: 0.08rem 0.35rem;
+}
+.hero, .section, details {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px var(--shadow);
+}
+.hero {
+  padding: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font: 600 0.92rem/1.2 system-ui, sans-serif;
+}
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+@media (min-width: 60rem) {
+  .grid.two { grid-template-columns: 1.05fr 0.95fr; }
+}
+.section {
+  padding: 1.2rem 1.25rem;
+}
+.muted { color: var(--muted); }
+.compact-list li + li { margin-top: 0.45rem; }
+.stats {
+  display: grid;
+  gap: 0.75rem;
+}
+@media (min-width: 40rem) {
+  .stats { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+.stat {
+  padding: 0.9rem 1rem;
+  border-radius: 0.8rem;
+  background: #f8f4eb;
+  border: 1px solid #ebdecb;
+}
+.stat strong {
+  display: block;
+  font: 700 1.45rem/1.1 system-ui, sans-serif;
+}
+details {
+  padding: 0.95rem 1rem;
+  margin-top: 0.9rem;
+}
+summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+.subtle {
+  margin-top: 0.35rem;
+  color: var(--muted);
+}
+.warning {
+  border-color: #ebc39c;
+  background: var(--warn-soft);
+}
+.key-value {
+  display: grid;
+  gap: 0.45rem;
+}
+.key-value div {
+  padding-left: 0.9rem;
+  border-left: 3px solid #eadfca;
+}
+</style>`+"\n</head>\n<body>\n<main>\n")
+
+	fmt.Fprint(w, "<section class=\"hero\">\n")
+	fmt.Fprint(w, "<p class=\"muted\">Pituitary review report</p>\n")
+	fmt.Fprintf(w, "<h1>%s</h1>\n", escape(result.SpecRef))
+	if result.SpecInference != nil && result.SpecInference.Level != "" {
+		fmt.Fprintf(w, "<div class=\"meta\"><span class=\"pill\">Inference %s", escape(result.SpecInference.Level))
+		if result.SpecInference.Score > 0 {
+			fmt.Fprintf(w, " (%.3f)", result.SpecInference.Score)
+		}
+		fmt.Fprint(w, "</span></div>\n")
+	}
+	fmt.Fprint(w, "</section>\n")
+
+	fmt.Fprint(w, "<div class=\"grid two\">\n")
+
+	fmt.Fprint(w, "<section class=\"section\"><h2>Summary</h2><ul class=\"compact-list\">\n")
+	for _, line := range reviewMarkdownSummary(result) {
+		fmt.Fprintf(w, "<li>%s</li>\n", escape(line))
+	}
+	fmt.Fprint(w, "</ul></section>\n")
+
+	fmt.Fprint(w, "<section class=\"section\"><h2>Recommended Next Actions</h2>\n")
+	actions := reviewMarkdownActions(result)
+	if len(actions) == 0 {
+		fmt.Fprint(w, "<p class=\"muted\">No immediate follow-up identified from the current review.</p>\n")
+	} else {
+		fmt.Fprint(w, "<ol class=\"compact-list\">\n")
+		for _, action := range actions {
+			fmt.Fprintf(w, "<li>%s</li>\n", escape(action))
+		}
+		fmt.Fprint(w, "</ol>\n")
+	}
+	fmt.Fprint(w, "</section>\n")
+
+	fmt.Fprint(w, "</div>\n")
+
+	fmt.Fprint(w, "<div class=\"stats\">\n")
+	if result.Overlap != nil {
+		fmt.Fprintf(w, "<div class=\"stat\"><span class=\"muted\">Overlaps</span><strong>%d</strong><span>%s</span></div>\n", len(result.Overlap.Overlaps), escape(result.Overlap.Recommendation))
+	}
+	if result.Impact != nil {
+		fmt.Fprintf(w, "<div class=\"stat\"><span class=\"muted\">Impacted specs</span><strong>%d</strong><span>%d docs, %d refs</span></div>\n", len(result.Impact.AffectedSpecs), len(result.Impact.AffectedDocs), len(result.Impact.AffectedRefs))
+	}
+	driftAssessments := reviewDocDriftAssessments(result.DocDrift)
+	fmt.Fprintf(w, "<div class=\"stat\"><span class=\"muted\">Docs needing follow-up</span><strong>%d</strong><span>%d remediation item(s)</span></div>\n", len(driftAssessments), reviewRemediationSuggestionCount(result.DocRemediation))
+	fmt.Fprint(w, "</div>\n")
+
+	fmt.Fprint(w, "<section class=\"section\"><h2>Overlap</h2>\n")
+	if result.Overlap == nil {
+		fmt.Fprint(w, "<p class=\"muted\">No overlap analysis was generated.</p>\n")
+	} else if len(result.Overlap.Overlaps) == 0 {
+		fmt.Fprintf(w, "<p>No overlapping specs detected. Review posture: <code>%s</code>.</p>\n", escape(result.Overlap.Recommendation))
+	} else {
+		fmt.Fprintf(w, "<p>Review posture: <code>%s</code>", escape(result.Overlap.Recommendation))
+		if detail := humanizeOverlapRecommendation(result.Overlap.Recommendation); detail != "" {
+			fmt.Fprintf(w, " <span class=\"muted\">(%s)</span>", escape(detail))
+		}
+		fmt.Fprint(w, "</p><ul class=\"compact-list\">\n")
+		for _, item := range result.Overlap.Overlaps {
+			fmt.Fprintf(w, "<li><strong><code>%s</code></strong> %s <span class=\"muted\">(%s, %.3f, %s)</span></li>\n",
+				escape(item.Ref),
+				escape(item.Title),
+				escape(item.Relationship),
+				item.Score,
+				escape(humanizeOverlapGuidance(item.Guidance)),
+			)
+		}
+		fmt.Fprint(w, "</ul>\n")
+	}
+	fmt.Fprint(w, "</section>\n")
+
+	fmt.Fprint(w, "<section class=\"section\"><h2>Comparison</h2>\n")
+	if result.Comparison == nil {
+		fmt.Fprint(w, "<p class=\"muted\">No primary comparison target was shortlisted.</p>\n")
+	} else {
+		fmt.Fprintf(w, "<p>Recommendation: <code>%s</code></p>\n", escape(result.Comparison.Comparison.Recommendation))
+		if compatibility := result.Comparison.Comparison.Compatibility; compatibility.Level != "" || compatibility.Summary != "" {
+			fmt.Fprintf(w, "<p class=\"subtle\">Compatibility: <code>%s</code>", escape(compatibility.Level))
+			if compatibility.Summary != "" {
+				fmt.Fprintf(w, " (%s)", escape(compatibility.Summary))
+			}
+			fmt.Fprint(w, "</p>\n")
+		}
+		if len(result.Comparison.Comparison.SharedScope) > 0 {
+			fmt.Fprintf(w, "<p class=\"subtle\">Shared scope: %s</p>\n", escape(strings.Join(result.Comparison.Comparison.SharedScope, ", ")))
+		}
+		if len(result.Comparison.Comparison.Tradeoffs) > 0 {
+			fmt.Fprint(w, "<ul class=\"compact-list\">\n")
+			for _, tradeoff := range result.Comparison.Comparison.Tradeoffs {
+				fmt.Fprintf(w, "<li><strong>%s:</strong> %s</li>\n", escape(tradeoff.Topic), escape(tradeoff.Summary))
+			}
+			fmt.Fprint(w, "</ul>\n")
+		}
+	}
+	fmt.Fprint(w, "</section>\n")
+
+	fmt.Fprint(w, "<section class=\"section\"><h2>Impact</h2>\n")
+	if result.Impact == nil {
+		fmt.Fprint(w, "<p class=\"muted\">No impact analysis generated.</p>\n")
+	} else {
+		fmt.Fprintf(w, "<p>Summary: %d impacted spec(s), %d governed ref(s), %d impacted doc(s).</p>\n", len(result.Impact.AffectedSpecs), len(result.Impact.AffectedRefs), len(result.Impact.AffectedDocs))
+		fmt.Fprint(w, "<div class=\"grid two\">")
+		fmt.Fprint(w, "<div><h3>Top impacted specs</h3>")
+		specs := topImpactedSpecs(result.Impact.AffectedSpecs, 5)
+		if len(specs) == 0 {
+			fmt.Fprint(w, "<p class=\"muted\">None.</p>")
+		} else {
+			fmt.Fprint(w, "<ul class=\"compact-list\">")
+			for _, item := range specs {
+				fmt.Fprintf(w, "<li><strong><code>%s</code></strong> %s <span class=\"muted\">(%s", escape(item.Ref), escape(item.Title), escape(item.Relationship))
+				if item.Historical {
+					fmt.Fprint(w, ", historical")
+				}
+				fmt.Fprint(w, ")</span></li>")
+			}
+			fmt.Fprint(w, "</ul>")
+		}
+		fmt.Fprint(w, "</div>")
+		fmt.Fprint(w, "<div><h3>Top impacted docs</h3>")
+		docs := topImpactedDocs(result.Impact.AffectedDocs, 5)
+		if len(docs) == 0 {
+			fmt.Fprint(w, "<p class=\"muted\">None.</p>")
+		} else {
+			fmt.Fprint(w, "<ul class=\"compact-list\">")
+			for _, item := range docs {
+				fmt.Fprintf(w, "<li><strong><code>%s</code></strong> %s <span class=\"muted\">(score %.3f", escape(item.Ref), escape(item.Title), item.Score)
+				if item.SourceRef != "" {
+					fmt.Fprintf(w, ", %s", escape(item.SourceRef))
+				}
+				fmt.Fprint(w, ")</span></li>")
+			}
+			fmt.Fprint(w, "</ul>")
+		}
+		fmt.Fprint(w, "</div></div>")
+	}
+	fmt.Fprint(w, "</section>\n")
+
+	fmt.Fprint(w, "<section class=\"section\"><h2>Doc Drift</h2>\n")
+	if len(driftAssessments) == 0 {
+		fmt.Fprint(w, "<p class=\"muted\">No drifting docs detected.</p>\n")
+	} else {
+		fmt.Fprintf(w, "<p>%d doc(s) need follow-up.</p>\n", len(driftAssessments))
+		driftItems := driftItemsByDocRef(result.DocDrift.DriftItems)
+		for _, assessment := range driftAssessments {
+			detailClass := "warning"
+			if assessment.Status == "possible_drift" {
+				detailClass = ""
+			}
+			fmt.Fprintf(w, "<details class=\"%s\" open><summary><code>%s</code>", detailClass, escape(assessment.DocRef))
+			if assessment.Title != "" {
+				fmt.Fprintf(w, " — %s", escape(assessment.Title))
+			}
+			fmt.Fprintf(w, " <span class=\"muted\">(%s)</span></summary>\n", escape(assessment.Status))
+			fmt.Fprint(w, "<div class=\"key-value\">")
+			if assessment.SourceRef != "" {
+				fmt.Fprintf(w, "<div><strong>Source</strong><br>%s</div>", escape(assessment.SourceRef))
+			}
+			if assessment.Rationale != "" {
+				fmt.Fprintf(w, "<div><strong>Why it matters</strong><br>%s</div>", escape(assessment.Rationale))
+			}
+			if assessment.Evidence != nil {
+				fmt.Fprintf(w, "<div><strong>Evidence</strong><br>%s</div>", reviewHTMLDriftEvidence(assessment.Evidence))
+			}
+			item, ok := driftItems[assessment.DocRef]
+			if ok {
+				for _, finding := range item.Findings {
+					fmt.Fprintf(w, "<div><strong>%s</strong><br>%s", escape(finding.Code), escape(finding.Message))
+					if finding.Expected != "" || finding.Observed != "" {
+						fmt.Fprintf(w, "<br><span class=\"subtle\">expected %s | observed %s</span>", escape(finding.Expected), escape(finding.Observed))
+					}
+					if finding.Rationale != "" {
+						fmt.Fprintf(w, "<br><span class=\"subtle\">%s</span>", escape(finding.Rationale))
+					}
+					if finding.Evidence != nil {
+						fmt.Fprintf(w, "<br>%s", reviewHTMLDriftEvidence(finding.Evidence))
+					}
+					fmt.Fprint(w, "</div>")
+				}
+			}
+			fmt.Fprint(w, "</div></details>\n")
+		}
+	}
+	fmt.Fprint(w, "</section>\n")
+
+	fmt.Fprint(w, "<section class=\"section\"><h2>Doc Remediation</h2>\n")
+	if result.DocRemediation == nil || len(result.DocRemediation.Items) == 0 {
+		fmt.Fprint(w, "<p class=\"muted\">No remediation guidance.</p>\n")
+	} else {
+		fmt.Fprintf(w, "<p>%d suggested update(s).</p>\n", reviewRemediationSuggestionCount(result.DocRemediation))
+		for _, item := range result.DocRemediation.Items {
+			fmt.Fprintf(w, "<details open><summary><code>%s</code>", escape(item.DocRef))
+			if item.Title != "" {
+				fmt.Fprintf(w, " — %s", escape(item.Title))
+			}
+			fmt.Fprint(w, "</summary><div class=\"key-value\">")
+			if item.SourceRef != "" {
+				fmt.Fprintf(w, "<div><strong>Source</strong><br>%s</div>", escape(item.SourceRef))
+			}
+			for _, suggestion := range item.Suggestions {
+				fmt.Fprintf(w, "<div><strong>%s</strong><br>%s", escape(suggestion.Code), escape(suggestion.Summary))
+				if suggestion.Evidence.SpecExcerpt != "" || suggestion.Evidence.DocExcerpt != "" {
+					fmt.Fprintf(w, "<br>%s", reviewHTMLRemediationEvidence(suggestion.Evidence))
+				}
+				switch {
+				case suggestion.SuggestedEdit.Replace != "" || suggestion.SuggestedEdit.With != "":
+					fmt.Fprintf(w, "<br><span class=\"subtle\">Replace %s with %s</span>", escape(suggestion.SuggestedEdit.Replace), escape(suggestion.SuggestedEdit.With))
+				case suggestion.SuggestedEdit.Note != "":
+					fmt.Fprintf(w, "<br><span class=\"subtle\">%s</span>", escape(suggestion.SuggestedEdit.Note))
+				}
+				fmt.Fprint(w, "</div>")
+			}
+			fmt.Fprint(w, "</div></details>\n")
+		}
+	}
+	fmt.Fprint(w, "</section>\n")
+
+	if len(result.Warnings) > 0 {
+		fmt.Fprint(w, "<section class=\"section warning\"><h2>Warnings</h2><ul class=\"compact-list\">")
+		for _, warning := range result.Warnings {
+			fmt.Fprintf(w, "<li><strong>%s</strong>: %s</li>", escape(warning.Code), escape(warning.Message))
+		}
+		fmt.Fprint(w, "</ul></section>\n")
+	}
+
+	fmt.Fprint(w, "</main>\n</body>\n</html>\n")
+}
+
+func reviewHTMLDriftEvidence(evidence *analysis.DriftEvidence) string {
+	if evidence == nil {
+		return ""
+	}
+	escape := htemplate.HTMLEscapeString
+	parts := make([]string, 0, 4)
+	if evidence.SpecRef != "" {
+		spec := "<strong>Spec</strong> " + escape(evidence.SpecRef)
+		if evidence.SpecSection != "" {
+			spec += " | " + escape(evidence.SpecSection)
+		}
+		if evidence.SpecExcerpt != "" {
+			spec += "<br><span class=\"subtle\">" + escape(evidence.SpecExcerpt) + "</span>"
+		}
+		parts = append(parts, spec)
+	}
+	if evidence.DocSection != "" || evidence.DocExcerpt != "" {
+		doc := "<strong>Doc</strong> "
+		if evidence.DocSection != "" {
+			doc += escape(evidence.DocSection)
+		} else {
+			doc += "matching section"
+		}
+		if evidence.DocExcerpt != "" {
+			doc += "<br><span class=\"subtle\">" + escape(evidence.DocExcerpt) + "</span>"
+		}
+		parts = append(parts, doc)
+	}
+	return strings.Join(parts, "<br>")
+}
+
+func reviewHTMLRemediationEvidence(evidence analysis.DocRemediationEvidence) string {
+	escape := htemplate.HTMLEscapeString
+	parts := make([]string, 0, 2)
+	if evidence.SpecSection != "" || evidence.SpecExcerpt != "" {
+		spec := "<strong>Spec</strong> "
+		if evidence.SpecSection != "" {
+			spec += escape(evidence.SpecSection)
+		} else {
+			spec += "matched section"
+		}
+		if evidence.SpecExcerpt != "" {
+			spec += "<br><span class=\"subtle\">" + escape(evidence.SpecExcerpt) + "</span>"
+		}
+		parts = append(parts, spec)
+	}
+	if evidence.DocSection != "" || evidence.DocExcerpt != "" {
+		doc := "<strong>Doc</strong> "
+		if evidence.DocSection != "" {
+			doc += escape(evidence.DocSection)
+		} else {
+			doc += "matched section"
+		}
+		if evidence.DocExcerpt != "" {
+			doc += "<br><span class=\"subtle\">" + escape(evidence.DocExcerpt) + "</span>"
+		}
+		parts = append(parts, doc)
+	}
+	return strings.Join(parts, "<br>")
 }
 
 func reviewMarkdownSummary(result *analysis.ReviewResult) []string {

--- a/cmd/review_spec_test.go
+++ b/cmd/review_spec_test.go
@@ -190,6 +190,41 @@ func TestRunReviewSpecMarkdown(t *testing.T) {
 	}
 }
 
+func TestRunReviewSpecHTML(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runReviewSpec([]string{"--spec-ref", "SPEC-042", "--format", "html"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runReviewSpec(--format html) exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runReviewSpec(--format html) wrote unexpected stderr: %q", stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"<!doctype html>",
+		"<title>Pituitary Review Report: SPEC-042</title>",
+		"<h2>Summary</h2>",
+		"<h2>Recommended Next Actions</h2>",
+		"<h2>Doc Drift</h2>",
+		"<h2>Doc Remediation</h2>",
+		"doc://guides/api-rate-limits",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("runReviewSpec(--format html) output %q does not contain %q", out, want)
+		}
+	}
+}
+
 func TestRunReviewSpecTextIncludesTopImpactSummaries(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ const (
 	commandFormatJSON     = "json"
 	commandFormatTable    = "table"
 	commandFormatMarkdown = "markdown"
+	commandFormatHTML     = "html"
 )
 
 type commandSpec struct {
@@ -39,7 +40,7 @@ func commandRegistry() map[string]commandSpec {
 		"check-terminology": {Description: "audit terminology consistency after conceptual changes", Formats: commandFormats(), Run: runCheckTerminologyContext},
 		"check-compliance":  {Description: "check code paths and diffs against accepted specs", Formats: commandFormats(), Run: runCheckComplianceContext},
 		"check-doc-drift":   {Description: "find docs that drift from specs", Formats: commandFormats(), Run: runCheckDocDriftContext},
-		"review-spec":       {Description: "run the common spec-review workflow", Formats: commandFormats(commandFormatMarkdown), Run: runReviewSpecContext},
+		"review-spec":       {Description: "run the common spec-review workflow", Formats: commandFormats(commandFormatMarkdown, commandFormatHTML), Run: runReviewSpecContext},
 		"serve":             {Description: "run the optional MCP server transport", Formats: commandFormats(), Run: runServeContext},
 	}
 }


### PR DESCRIPTION
## Summary
- add a review-spec-only HTML output format
- render a self-contained HTML review report with summary, actions, overlap, impact, drift, and remediation sections
- document the new HTML report surface in the README

Closes #129

## Validation
- go test ./cmd
