### PR TITLE
[feature] Add semantic color support to terminal output

### DIFF
--- a/cmd/check_doc_drift_test.go
+++ b/cmd/check_doc_drift_test.go
@@ -204,14 +204,12 @@ func TestRunCheckDocDriftTextIncludesRemediation(t *testing.T) {
 
 	out := stdout.String()
 	for _, want := range []string{
-		"status: drift",
-		"status: aligned",
-		"confidence:",
-		"rationale:",
-		"spec evidence:",
-		"doc evidence:",
-		"remediation:",
-		"suggested edit:",
+		"━━◈ check-doc-drift",
+		"██ DRIFT",
+		"██ OK",
+		"default limit mismatch",
+		"pituitary fix --path",
+		"review-spec --format html",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("runCheckDocDrift() output %q does not contain %q", out, want)

--- a/cmd/config_path.go
+++ b/cmd/config_path.go
@@ -15,6 +15,10 @@ const (
 	localConfigDirName = ".pituitary"
 	configEnvVar       = "PITUITARY_CONFIG"
 
+	colorModeAuto   = "auto"
+	colorModeAlways = "always"
+	colorModeNever  = "never"
+
 	configSourceCommandFlag = "command_flag"
 	configSourceGlobalFlag  = "global_flag"
 	configSourceEnv         = "env"
@@ -23,6 +27,7 @@ const (
 
 type cliGlobalOptions struct {
 	ConfigPath string
+	ColorMode  string
 }
 
 type configPathOption struct {
@@ -53,12 +58,22 @@ func parseGlobalCLIOptions(args []string) (cliGlobalOptions, []string, error) {
 
 	var options cliGlobalOptions
 	fs.StringVar(&options.ConfigPath, "config", "", "path to workspace config")
+	fs.StringVar(&options.ColorMode, "color", colorModeAuto, "terminal color: auto, always, or never")
 
 	if err := fs.Parse(args); err != nil {
 		return cliGlobalOptions{}, nil, err
 	}
 
 	options.ConfigPath = strings.TrimSpace(options.ConfigPath)
+	options.ColorMode = strings.TrimSpace(strings.ToLower(options.ColorMode))
+	if options.ColorMode == "" {
+		options.ColorMode = colorModeAuto
+	}
+	switch options.ColorMode {
+	case colorModeAuto, colorModeAlways, colorModeNever:
+	default:
+		return cliGlobalOptions{}, nil, fmt.Errorf("invalid --color value %q; expected auto, always, or never", options.ColorMode)
+	}
 	return options, fs.Args(), nil
 }
 

--- a/cmd/config_path_test.go
+++ b/cmd/config_path_test.go
@@ -158,6 +158,30 @@ path = "specs"
 	}
 }
 
+func TestParseGlobalCLIOptionsSupportsColorMode(t *testing.T) {
+	t.Parallel()
+
+	options, remaining, err := parseGlobalCLIOptions([]string{"--color", "always", "status"})
+	if err != nil {
+		t.Fatalf("parseGlobalCLIOptions() error = %v, want nil", err)
+	}
+	if got, want := options.ColorMode, colorModeAlways; got != want {
+		t.Fatalf("color mode = %q, want %q", got, want)
+	}
+	if len(remaining) != 1 || remaining[0] != "status" {
+		t.Fatalf("remaining args = %#v, want [status]", remaining)
+	}
+}
+
+func TestParseGlobalCLIOptionsRejectsInvalidColorMode(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseGlobalCLIOptions([]string{"--color", "violet", "status"})
+	if err == nil || !strings.Contains(err.Error(), "invalid --color value") {
+		t.Fatalf("parseGlobalCLIOptions() error = %v, want invalid --color value", err)
+	}
+}
+
 func TestResolveCommandConfigPathPrefersCommandFlagAndExplainsCandidates(t *testing.T) {
 	repo := t.TempDir()
 	commandConfigPath := filepath.Join(repo, "configs", "pituitary.local.toml")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -93,10 +93,10 @@ func TestRunInitWritesConfigRebuildsAndSummarizes(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
-		"pituitary init: discover, write, index, and summarize a workspace",
-		"config action: wrote",
-		"index: 4 artifact(s), 4 chunk(s), 2 edge(s)",
-		"status: fresh | specs: 2 | docs: 2 | chunks: 4",
+		"━━◈ init",
+		"config: ",
+		"action: wrote",
+		"index: 2 specs · 2 docs",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("runInit() output %q does not contain %q", output, want)
@@ -120,7 +120,7 @@ func TestRunInitReportsFixtureGuidanceForLargerCorpus(t *testing.T) {
 	}
 
 	output := stdout.String()
-	if !strings.Contains(output, `guidance: runtime.embedder is still "fixture" on 5 indexed artifact(s)`) {
+	if !strings.Contains(output, `runtime.embedder is still "fixture" on 5 indexed artifact(s)`) {
 		t.Fatalf("runInit() output %q does not contain fixture guidance", output)
 	}
 	if !strings.Contains(output, "`pituitary status --check-runtime embedder`") {

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -100,7 +100,8 @@ func writeCLIError(stdout, stderr io.Writer, format, command string, request any
 		}
 		return exitCode
 	}
-	fmt.Fprintf(stderr, "pituitary %s: %s\n", command, issue.Message)
+	p := presentationForWriter(stderr)
+	fmt.Fprintf(stderr, "%s %s\n", p.red("pituitary "+command+":"), issue.Message)
 	return exitCode
 }
 
@@ -143,7 +144,8 @@ func warningsToCLIIssues(warnings []analysis.Warning) []cliIssue {
 }
 
 func writeCLIWarnings(stderr io.Writer, command string, warnings []cliIssue) {
+	p := presentationForWriter(stderr)
 	for _, warning := range warnings {
-		fmt.Fprintf(stderr, "pituitary %s: warning: %s\n", command, warning.Message)
+		fmt.Fprintf(stderr, "%s %s\n", p.yellow("pituitary "+command+": warning:"), warning.Message)
 	}
 }

--- a/cmd/presentation.go
+++ b/cmd/presentation.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"strings"
+)
+
+type cliPresentationWriter interface {
+	io.Writer
+	cliColorMode() string
+	cliUnderlyingWriter() io.Writer
+}
+
+type wrappedCLIWriter struct {
+	io.Writer
+	colorMode string
+}
+
+func wrapCLIWriter(w io.Writer, colorMode string) io.Writer {
+	if w == nil {
+		return nil
+	}
+	return wrappedCLIWriter{Writer: w, colorMode: colorMode}
+}
+
+func (w wrappedCLIWriter) cliColorMode() string {
+	return w.colorMode
+}
+
+func (w wrappedCLIWriter) cliUnderlyingWriter() io.Writer {
+	return w.Writer
+}
+
+type renderPresentation struct {
+	color bool
+	utf8  bool
+}
+
+func presentationForWriter(w io.Writer) renderPresentation {
+	mode := colorModeAuto
+	target := w
+	if wrapped, ok := w.(cliPresentationWriter); ok {
+		mode = wrapped.cliColorMode()
+		target = wrapped.cliUnderlyingWriter()
+	}
+	return renderPresentation{
+		color: shouldColorize(target, mode),
+		utf8:  supportsUTF8(),
+	}
+}
+
+func shouldColorize(w io.Writer, mode string) bool {
+	switch mode {
+	case colorModeAlways:
+		return true
+	case colorModeNever:
+		return false
+	}
+
+	if strings.TrimSpace(os.Getenv("NO_COLOR")) != "" {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("TERM")), "dumb") {
+		return false
+	}
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+func supportsUTF8() bool {
+	for _, name := range []string{"LC_ALL", "LC_CTYPE", "LANG"} {
+		value := strings.ToUpper(strings.TrimSpace(os.Getenv(name)))
+		if value == "" {
+			continue
+		}
+		return strings.Contains(value, "UTF-8") || strings.Contains(value, "UTF8")
+	}
+	return true
+}
+
+func (p renderPresentation) apply(code, value string) string {
+	if !p.color || value == "" {
+		return value
+	}
+	return "\033[" + code + "m" + value + "\033[0m"
+}
+
+func (p renderPresentation) bold(value string) string   { return p.apply("1", value) }
+func (p renderPresentation) dim(value string) string    { return p.apply("2", value) }
+func (p renderPresentation) red(value string) string    { return p.apply("1;31", value) }
+func (p renderPresentation) green(value string) string  { return p.apply("1;32", value) }
+func (p renderPresentation) yellow(value string) string { return p.apply("1;33", value) }
+func (p renderPresentation) cyan(value string) string   { return p.apply("0;36", value) }
+func (p renderPresentation) white(value string) string  { return p.apply("1;37", value) }
+func (p renderPresentation) headerMark() string {
+	if p.utf8 {
+		return p.bold("━━◈")
+	}
+	return p.bold("---*")
+}
+func (p renderPresentation) cross() string {
+	if p.utf8 {
+		return p.red("✗")
+	}
+	return p.red("x")
+}
+func (p renderPresentation) check() string {
+	if p.utf8 {
+		return p.green("✓")
+	}
+	return p.green("+")
+}
+func (p renderPresentation) arrow() string {
+	if p.utf8 {
+		return p.yellow("→")
+	}
+	return p.yellow("->")
+}
+func (p renderPresentation) info() string {
+	if p.utf8 {
+		return p.dim("ℹ")
+	}
+	return p.dim("i")
+}
+func (p renderPresentation) treeMid() string {
+	if p.utf8 {
+		return p.dim("├─")
+	}
+	return p.dim("|-")
+}
+func (p renderPresentation) treeLast() string {
+	if p.utf8 {
+		return p.dim("└─")
+	}
+	return p.dim("\\-")
+}
+func (p renderPresentation) blockHigh() string {
+	if p.utf8 {
+		return p.red("██")
+	}
+	return p.red("[!]")
+}
+func (p renderPresentation) blockMedium() string {
+	if p.utf8 {
+		return p.yellow("▒▒")
+	}
+	return p.yellow("[~]")
+}
+func (p renderPresentation) blockOK() string {
+	if p.utf8 {
+		return p.green("██")
+	}
+	return p.green("[+]")
+}
+func (p renderPresentation) okBadge() string {
+	if p.utf8 {
+		return p.green("██ OK")
+	}
+	return p.green("[OK]")
+}
+func (p renderPresentation) driftBadge() string {
+	if p.utf8 {
+		return p.red("██ DRIFT")
+	}
+	return p.red("[DRIFT]")
+}
+func (p renderPresentation) reviewBadge() string {
+	if p.utf8 {
+		return p.yellow("▒▒ REVIEW")
+	}
+	return p.yellow("[REVIEW]")
+}
+func (p renderPresentation) conflictBadge() string {
+	if p.utf8 {
+		return p.red("██ CONFLICT")
+	}
+	return p.red("[CONFLICT]")
+}
+func (p renderPresentation) compliantBadge() string {
+	if p.utf8 {
+		return p.green("██ OK")
+	}
+	return p.green("[OK]")
+}
+func (p renderPresentation) unspecifiedBadge() string {
+	if p.utf8 {
+		return p.yellow("▒▒ UNSPEC")
+	}
+	return p.yellow("[UNSPEC]")
+}
+func (p renderPresentation) headerLine(command, suffix string) string {
+	line := p.headerMark() + " " + p.white(command)
+	if suffix != "" {
+		line += suffix
+	}
+	return line
+}

--- a/cmd/relation_graph_test.go
+++ b/cmd/relation_graph_test.go
@@ -99,7 +99,7 @@ func TestRunStatusTextIncludesRelationGraphFindings(t *testing.T) {
 	}
 	for _, want := range []string{
 		"relation graph: invalid",
-		"relation issue: depends_on cycle detected:",
+		"depends_on cycle detected:",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("runStatus() output %q does not contain %q", stdout.String(), want)

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -18,7 +18,9 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 		return fmt.Errorf("unknown command %q", command)
 	}
 
-	fmt.Fprintf(w, "pituitary %s: %s\n", command, description)
+	if !usesSemanticTextRendering(command) {
+		fmt.Fprintf(w, "pituitary %s: %s\n", command, description)
+	}
 
 	switch typed := result.(type) {
 	case *source.CanonicalizeResult:
@@ -60,6 +62,15 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 	}
 
 	return nil
+}
+
+func usesSemanticTextRendering(command string) bool {
+	switch command {
+	case "check-doc-drift", "check-overlap", "review-spec", "check-compliance", "status", "init":
+		return true
+	default:
+		return false
+	}
 }
 
 func renderCommandTable(w io.Writer, command string, result any) error {
@@ -183,27 +194,53 @@ func renderCanonicalizeResult(w io.Writer, result *source.CanonicalizeResult) {
 }
 
 func renderInitResult(w io.Writer, result *initResult) {
-	fmt.Fprintf(w, "workspace: %s\n", result.WorkspaceRoot)
-	fmt.Fprintf(w, "config path: %s\n", result.ConfigPath)
-	fmt.Fprintf(w, "config action: %s\n", result.ConfigAction)
+	p := presentationForWriter(w)
+	fmt.Fprintln(w, p.headerLine("init", ""))
+	fmt.Fprintln(w)
+
+	sourceCount := 0
 	if result.Discover != nil {
-		fmt.Fprintf(w, "discovered sources: %d\n", len(result.Discover.Sources))
+		sourceCount = len(result.Discover.Sources)
 	}
+	artifactCount := 0
+	chunkCount := 0
 	if result.Index != nil {
-		fmt.Fprintf(w, "index: %d artifact(s), %d chunk(s), %d edge(s)\n", result.Index.ArtifactCount, result.Index.ChunkCount, result.Index.EdgeCount)
+		artifactCount = result.Index.ArtifactCount
+		chunkCount = result.Index.ChunkCount
 	}
+	specCount := 0
+	docCount := 0
+	freshness := "unknown"
+	embedderProvider := ""
 	if result.Status != nil {
-		status := "unknown"
+		specCount = result.Status.SpecCount
+		docCount = result.Status.DocCount
 		if result.Status.Freshness != nil && result.Status.Freshness.State != "" {
-			status = result.Status.Freshness.State
+			freshness = result.Status.Freshness.State
 		}
-		fmt.Fprintf(w, "status: %s | specs: %d | docs: %d | chunks: %d\n", status, result.Status.SpecCount, result.Status.DocCount, result.Status.ChunkCount)
+		embedderProvider = result.Status.EmbedderProvider
+	}
+	fmt.Fprintf(
+		w,
+		"  %s sources  %s artifacts  %s chunks  %s  %s\n",
+		p.bold(fmt.Sprintf("%d", sourceCount)),
+		p.bold(fmt.Sprintf("%d", artifactCount)),
+		p.bold(fmt.Sprintf("%d", chunkCount)),
+		renderFreshnessLabel(p, freshness),
+		p.dim(statusEmbedderSummary(embedderProvider)),
+	)
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  %s %s\n", p.dim("workspace:"), result.WorkspaceRoot)
+	fmt.Fprintf(w, "  %s %s\n", p.dim("config:"), result.ConfigPath)
+	fmt.Fprintf(w, "  %s %s\n", p.dim("action:"), result.ConfigAction)
+	fmt.Fprintf(w, "  %s %d specs · %d docs\n", p.dim("index:"), specCount, docCount)
+	if result.Status != nil {
 		for _, guidance := range result.Status.Guidance {
-			fmt.Fprintf(w, "guidance: %s\n", guidance)
+			fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
 		}
 	}
 	if result.ConfigAction == "preview" {
-		fmt.Fprintln(w, "next: run `pituitary init` without --dry-run to write the config and build the index")
+		fmt.Fprintf(w, "  %s %s\n", p.arrow(), "run `pituitary init` without --dry-run to write the config and build the index")
 	}
 }
 
@@ -237,67 +274,83 @@ func renderIndexSourceSummaries(w io.Writer, sources []source.LoadSourceSummary)
 }
 
 func renderStatusResult(w io.Writer, result *statusResult) {
-	if result.WorkspaceRoot != "" {
-		fmt.Fprintf(w, "workspace: %s\n", result.WorkspaceRoot)
+	p := presentationForWriter(w)
+	fmt.Fprintln(w, p.headerLine("status", ""))
+	fmt.Fprintln(w)
+
+	freshnessState := "unknown"
+	if result.Freshness != nil && result.Freshness.State != "" {
+		freshnessState = result.Freshness.State
 	}
-	fmt.Fprintf(w, "config: %s\n", result.ConfigPath)
+	fmt.Fprintf(
+		w,
+		"  %s specs  %s docs  %s chunks  %s  %s\n",
+		p.bold(fmt.Sprintf("%d", result.SpecCount)),
+		p.bold(fmt.Sprintf("%d", result.DocCount)),
+		p.bold(fmt.Sprintf("%d", result.ChunkCount)),
+		renderFreshnessLabel(p, freshnessState),
+		p.dim(statusEmbedderSummary(result.EmbedderProvider)),
+	)
+	fmt.Fprintln(w)
+
+	if result.WorkspaceRoot != "" {
+		fmt.Fprintf(w, "  %s %s\n", p.dim("workspace:"), result.WorkspaceRoot)
+	}
+	fmt.Fprintf(w, "  %s %s\n", p.dim("config:"), result.ConfigPath)
 	if result.ConfigResolution != nil {
 		if result.ConfigResolution.Reason != "" {
-			fmt.Fprintf(w, "config resolution: %s\n", result.ConfigResolution.Reason)
+			fmt.Fprintf(w, "  %s %s\n", p.dim("config resolution:"), result.ConfigResolution.Reason)
 		}
 		if len(result.ConfigResolution.Candidates) > 0 {
-			fmt.Fprintln(w, "config candidates:")
+			fmt.Fprintf(w, "  %s\n", p.white("CONFIG CANDIDATES"))
 			for _, candidate := range result.ConfigResolution.Candidates {
-				fmt.Fprintf(w, "  %d. %s | %s", candidate.Precedence, configSourceLabel(candidate.Source), candidate.Status)
+				fmt.Fprintf(w, "  %s %d. %s | %s", p.treeItem(candidate.Precedence == len(result.ConfigResolution.Candidates)), candidate.Precedence, configSourceLabel(candidate.Source), candidate.Status)
 				if candidate.Path != "" {
 					fmt.Fprintf(w, " | %s", candidate.Path)
 				}
 				fmt.Fprintln(w)
 				if candidate.Detail != "" {
-					fmt.Fprintf(w, "     %s\n", candidate.Detail)
+					fmt.Fprintf(w, "     %s\n", p.dim(candidate.Detail))
 				}
 			}
 		}
 	}
-	fmt.Fprintf(w, "index path: %s\n", result.IndexPath)
+	fmt.Fprintf(w, "  %s %s\n", p.dim("index path:"), result.IndexPath)
 	if result.IndexExists {
-		fmt.Fprintln(w, "index: present")
+		fmt.Fprintf(w, "  %s %s\n", p.dim("index:"), p.green("present"))
 	} else {
-		fmt.Fprintln(w, "index: missing")
+		fmt.Fprintf(w, "  %s %s\n", p.dim("index:"), p.red("missing"))
 	}
 	if result.Freshness != nil {
-		fmt.Fprintf(w, "index freshness: %s\n", result.Freshness.State)
+		fmt.Fprintf(w, "  %s %s\n", p.dim("index freshness:"), renderFreshnessLabel(p, result.Freshness.State))
 		for _, issue := range result.Freshness.Issues {
-			fmt.Fprintf(w, "freshness: %s\n", issue.Message)
+			fmt.Fprintf(w, "  %s %s\n", p.cross(), issue.Message)
 		}
 		if result.Freshness.Action != "" {
-			fmt.Fprintf(w, "freshness action: %s\n", result.Freshness.Action)
+			fmt.Fprintf(w, "  %s %s\n", p.arrow(), result.Freshness.Action)
 		}
 	}
-	fmt.Fprintf(w, "indexed specs: %d\n", result.SpecCount)
-	fmt.Fprintf(w, "indexed docs: %d\n", result.DocCount)
-	fmt.Fprintf(w, "indexed chunks: %d\n", result.ChunkCount)
 	if result.RelationGraph != nil {
-		fmt.Fprintf(w, "relation graph: %s\n", result.RelationGraph.State)
+		fmt.Fprintf(w, "  %s %s\n", p.dim("relation graph:"), result.RelationGraph.State)
 		for _, finding := range result.RelationGraph.Findings {
-			fmt.Fprintf(w, "relation issue: %s\n", finding.Message)
+			fmt.Fprintf(w, "  %s %s\n", p.cross(), finding.Message)
 		}
 	}
 	if result.ArtifactLocations != nil {
-		fmt.Fprintf(w, "artifact index dir: %s\n", result.ArtifactLocations.IndexDir)
-		fmt.Fprintf(w, "artifact discover --write default: %s\n", result.ArtifactLocations.DiscoverConfigPath)
-		fmt.Fprintf(w, "artifact canonicalize default: %s\n", result.ArtifactLocations.CanonicalizeBundleRoot)
+		fmt.Fprintf(w, "  %s %s\n", p.dim("artifact index dir:"), result.ArtifactLocations.IndexDir)
+		fmt.Fprintf(w, "  %s %s\n", p.dim("artifact discover --write default:"), result.ArtifactLocations.DiscoverConfigPath)
+		fmt.Fprintf(w, "  %s %s\n", p.dim("artifact canonicalize default:"), result.ArtifactLocations.CanonicalizeBundleRoot)
 		if len(result.ArtifactLocations.IgnorePatterns) > 0 {
-			fmt.Fprintf(w, "artifact ignore patterns: %s\n", strings.Join(result.ArtifactLocations.IgnorePatterns, ", "))
+			fmt.Fprintf(w, "  %s %s\n", p.dim("artifact ignore patterns:"), strings.Join(result.ArtifactLocations.IgnorePatterns, ", "))
 		}
 		for _, hint := range result.ArtifactLocations.RelocationHints {
-			fmt.Fprintf(w, "artifact relocation: %s\n", hint)
+			fmt.Fprintf(w, "  %s %s\n", p.arrow(), hint)
 		}
 	}
 	if result.Runtime != nil {
-		fmt.Fprintf(w, "runtime probe: %s\n", result.Runtime.Scope)
+		fmt.Fprintf(w, "  %s %s\n", p.dim("runtime probe:"), result.Runtime.Scope)
 		for _, check := range result.Runtime.Checks {
-			fmt.Fprintf(w, "runtime: %s | %s | provider: %s", check.Name, check.Status, check.Provider)
+			fmt.Fprintf(w, "  %s %s %s | %s | provider: %s", p.dim("runtime:"), runtimeCheckGlyph(p, check.Status), check.Name, check.Status, check.Provider)
 			if check.Model != "" {
 				fmt.Fprintf(w, " | model: %s", check.Model)
 			}
@@ -306,12 +359,12 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 			}
 			fmt.Fprintln(w)
 			if check.Message != "" {
-				fmt.Fprintf(w, "runtime note: %s\n", check.Message)
+				fmt.Fprintf(w, "     %s %s\n", p.dim("runtime note:"), check.Message)
 			}
 		}
 	}
 	for _, guidance := range result.Guidance {
-		fmt.Fprintf(w, "guidance: %s\n", guidance)
+		fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
 	}
 }
 
@@ -481,15 +534,30 @@ func renderTableValue(value string, maxWidth int) string {
 }
 
 func renderOverlapResult(w io.Writer, result *analysis.OverlapResult) {
-	fmt.Fprintf(w, "candidate: %s | %s\n", result.Candidate.Ref, result.Candidate.Title)
+	p := presentationForWriter(w)
+	fmt.Fprintln(w, p.headerLine("check-overlap", " · "+p.cyan(result.Candidate.Ref)))
+	if strings.TrimSpace(result.Candidate.Title) != "" {
+		fmt.Fprintf(w, "    %s\n", p.dim(result.Candidate.Title))
+	}
+	fmt.Fprintln(w)
+
 	if len(result.Overlaps) == 0 {
-		fmt.Fprintln(w, "no overlaps")
+		fmt.Fprintf(w, "  %s no overlaps\n", p.check())
 		renderOverlapRecommendation(w, result.Recommendation)
 		return
 	}
-	for i, overlap := range result.Overlaps {
-		fmt.Fprintf(w, "%d. %s | %s | %.3f | %s | %s | %s\n", i+1, overlap.Ref, overlap.Title, overlap.Score, overlap.OverlapDegree, overlap.Relationship, humanizeOverlapGuidance(overlap.Guidance))
+	for _, overlap := range result.Overlaps {
+		fmt.Fprintf(
+			w,
+			"  %s %s  %s  %s  %s\n",
+			overlapBlock(p, overlap),
+			p.cyan(overlap.Ref),
+			p.bold(fmt.Sprintf("%.3f", overlap.Score)),
+			p.dim(overlap.Title),
+			overlapDisplaySummary(overlap),
+		)
 	}
+	fmt.Fprintln(w)
 	renderOverlapRecommendation(w, result.Recommendation)
 }
 
@@ -509,37 +577,44 @@ func renderAnalyzeImpactResult(w io.Writer, result *analysis.AnalyzeImpactResult
 }
 
 func renderComplianceResult(w io.Writer, result *analysis.ComplianceResult) {
-	fmt.Fprintf(w, "paths: %s\n", strings.Join(result.Paths, ", "))
-	fmt.Fprintf(w, "relevant specs: %d\n", len(result.RelevantSpecs))
+	p := presentationForWriter(w)
+	fmt.Fprintln(w, p.headerLine("check-compliance", ""))
+	fmt.Fprintln(w)
+	if len(result.Paths) > 0 {
+		fmt.Fprintf(w, "  %s %s\n", p.dim("paths:"), strings.Join(result.Paths, ", "))
+	}
+	fmt.Fprintf(w, "  %s %d\n", p.dim("relevant specs:"), len(result.RelevantSpecs))
+	fmt.Fprintln(w)
 	renderComplianceFindingGroup(w, "conflicts", result.Conflicts)
 	renderComplianceFindingGroup(w, "compliant", result.Compliant)
 	renderComplianceFindingGroup(w, "unspecified", result.Unspecified)
 }
 
 func renderComplianceFindingGroup(w io.Writer, label string, findings []analysis.ComplianceFinding) {
+	p := presentationForWriter(w)
 	if len(findings) == 0 {
-		fmt.Fprintf(w, "%s: none\n", label)
+		fmt.Fprintf(w, "  %s none\n", p.dim(label+":"))
 		return
 	}
 
-	fmt.Fprintf(w, "%s: %d\n", label, len(findings))
+	fmt.Fprintf(w, "  %s %d\n", p.white(strings.ToUpper(label)+":"), len(findings))
 	for _, item := range findings {
-		fmt.Fprintf(w, "- %s", item.Path)
+		fmt.Fprintf(w, "  %s %s", complianceBadge(p, label), item.Path)
 		if item.SpecRef != "" {
-			fmt.Fprintf(w, " | %s", item.SpecRef)
+			fmt.Fprintf(w, " | %s", p.cyan(item.SpecRef))
 		}
 		if item.SectionHeading != "" {
 			fmt.Fprintf(w, " | %s", item.SectionHeading)
 		}
 		fmt.Fprintf(w, " | %s\n", item.Message)
 		if item.Traceability != "" {
-			fmt.Fprintf(w, "  traceability: %s\n", item.Traceability)
+			fmt.Fprintf(w, "     %s %s\n", p.dim("traceability"), item.Traceability)
 		}
 		if item.LimitingFactor != "" {
-			fmt.Fprintf(w, "  limiting factor: %s\n", item.LimitingFactor)
+			fmt.Fprintf(w, "     %s %s\n", p.dim("limiting factor"), item.LimitingFactor)
 		}
 		if item.Suggestion != "" {
-			fmt.Fprintf(w, "  suggestion: %s\n", item.Suggestion)
+			fmt.Fprintf(w, "     %s %s\n", p.arrow(), item.Suggestion)
 		}
 	}
 }
@@ -592,8 +667,12 @@ func renderTerminologyAuditResult(w io.Writer, result *analysis.TerminologyAudit
 }
 
 func renderDocDriftResult(w io.Writer, result *analysis.DocDriftResult) {
+	p := presentationForWriter(w)
+	fmt.Fprintln(w, p.headerLine("check-doc-drift", ""))
+	fmt.Fprintln(w)
+
 	if len(result.DriftItems) == 0 && len(result.Assessments) == 0 {
-		fmt.Fprintln(w, "no drift items")
+		fmt.Fprintf(w, "  %s no drift items\n", p.check())
 		return
 	}
 
@@ -604,62 +683,38 @@ func renderDocDriftResult(w io.Writer, result *analysis.DocDriftResult) {
 	driftItems := driftItemsByDocRef(result.DriftItems)
 	remediation := remediationItemsByDocRef(result.Remediation)
 	for i, assessment := range assessments {
-		fmt.Fprintf(w, "%d. %s | %s | status: %s", i+1, assessment.DocRef, assessment.Title, assessment.Status)
-		if assessment.Confidence != nil && assessment.Confidence.Level != "" {
-			fmt.Fprintf(w, " | confidence: %s", assessment.Confidence.Level)
-			if assessment.Confidence.Score > 0 {
-				fmt.Fprintf(w, " (%.3f)", assessment.Confidence.Score)
-			}
+		if i > 0 {
+			fmt.Fprintln(w)
 		}
-		if item, ok := driftItems[assessment.DocRef]; ok {
-			fmt.Fprintf(w, " | findings: %d", len(item.Findings))
+		docLabel := preferredDocLabel(assessment.DocRef, assessment.SourceRef)
+		fmt.Fprintf(w, "  %s", p.cyan(docLabel))
+		if padding := docDriftPadding(docLabel); padding > 0 {
+			fmt.Fprint(w, strings.Repeat(" ", padding))
+		} else {
+			fmt.Fprint(w, "  ")
 		}
-		if suggestions := remediation[assessment.DocRef]; len(suggestions) > 0 {
-			fmt.Fprintf(w, " | remediation: %d", len(suggestions))
-		}
-		fmt.Fprintln(w)
-		if assessment.Rationale != "" {
-			fmt.Fprintf(w, "   rationale: %s\n", assessment.Rationale)
-		}
-		if assessment.Evidence != nil {
-			renderDriftEvidence(w, assessment.Evidence, "   ")
-		}
-		if assessment.Confidence != nil && assessment.Confidence.Basis != "" {
-			fmt.Fprintf(w, "   confidence basis: %s\n", assessment.Confidence.Basis)
-		}
-		if item, ok := driftItems[assessment.DocRef]; ok {
+		fmt.Fprintln(w, driftAssessmentBadge(p, assessment.Status))
+		if item, ok := driftItems[assessment.DocRef]; ok && len(item.Findings) > 0 {
 			for _, finding := range item.Findings {
-				fmt.Fprintf(w, "   finding: %s", finding.Code)
-				if finding.Artifact != "" {
-					fmt.Fprintf(w, " | artifact: %s", finding.Artifact)
+				fmt.Fprintf(w, "\n    %s %s", p.cross(), p.bold(driftFindingSummary(finding)))
+				if finding.Expected != "" {
+					fmt.Fprintf(w, "  %s %s", p.yellow("expected"), finding.Expected)
 				}
-				if finding.Confidence != nil && finding.Confidence.Level != "" {
-					fmt.Fprintf(w, " | confidence: %s", finding.Confidence.Level)
+				if finding.Observed != "" {
+					fmt.Fprintf(w, "  %s %s", p.yellow("got"), finding.Observed)
 				}
 				fmt.Fprintln(w)
-				fmt.Fprintf(w, "     message: %s\n", finding.Message)
-				if finding.Rationale != "" {
-					fmt.Fprintf(w, "     rationale: %s\n", finding.Rationale)
-				}
-				if finding.Expected != "" || finding.Observed != "" {
-					fmt.Fprintf(w, "     expected: %s\n", finding.Expected)
-					fmt.Fprintf(w, "     observed: %s\n", finding.Observed)
-				}
-				if finding.Evidence != nil {
-					renderDriftEvidence(w, finding.Evidence, "     ")
-				}
-				if finding.Confidence != nil && finding.Confidence.Basis != "" {
-					fmt.Fprintf(w, "     confidence basis: %s\n", finding.Confidence.Basis)
-				}
 			}
+		} else if assessment.Rationale != "" {
+			fmt.Fprintf(w, "\n    %s %s\n", p.arrow(), assessment.Rationale)
 		}
-		for _, suggestion := range remediation[assessment.DocRef] {
-			fmt.Fprintf(w, "   remediation: %s | %s\n", suggestion.SpecRef, suggestion.Summary)
-			if suggestion.SuggestedEdit.Replace != "" || suggestion.SuggestedEdit.With != "" {
-				fmt.Fprintf(w, "   suggested edit: replace %q with %q\n", suggestion.SuggestedEdit.Replace, suggestion.SuggestedEdit.With)
-			} else if suggestion.SuggestedEdit.Note != "" {
-				fmt.Fprintf(w, "   suggested edit: %s\n", suggestion.SuggestedEdit.Note)
+		if suggestions := remediation[assessment.DocRef]; len(suggestions) > 0 {
+			pathArg := docLabel
+			if assessment.SourceRef != "" {
+				pathArg = assessment.SourceRef
 			}
+			fmt.Fprintf(w, "\n    %s pituitary fix --path %s %s\n", p.green("fix:"), pathArg, p.dim(fmt.Sprintf("(%d edits)", len(suggestions))))
+			fmt.Fprintf(w, "    %s  run review-spec --format html for the full evidence report\n", p.info())
 		}
 	}
 }
@@ -687,40 +742,56 @@ func renderDriftEvidence(w io.Writer, evidence *analysis.DriftEvidence, prefix s
 }
 
 func renderReviewResult(w io.Writer, result *analysis.ReviewResult) {
-	fmt.Fprintf(w, "spec: %s\n", result.SpecRef)
+	p := presentationForWriter(w)
+	headerSuffix := " · " + p.cyan(result.SpecRef)
+	fmt.Fprintln(w, p.headerLine("review-spec", headerSuffix))
+	if result.Overlap != nil && strings.TrimSpace(result.Overlap.Candidate.Title) != "" {
+		fmt.Fprintf(w, "    %s\n", p.dim(result.Overlap.Candidate.Title))
+	}
+	fmt.Fprintln(w)
 
 	if result.Overlap != nil {
-		fmt.Fprintf(w, "overlaps: %d | recommendation: %s", len(result.Overlap.Overlaps), result.Overlap.Recommendation)
-		if detail := humanizeOverlapRecommendation(result.Overlap.Recommendation); detail != "" {
-			fmt.Fprintf(w, " | %s", detail)
+		fmt.Fprintf(w, "  %s   %d specs · recommendation: %s\n", p.white("OVERLAP"), len(result.Overlap.Overlaps), result.Overlap.Recommendation)
+		if len(result.Overlap.Overlaps) == 0 {
+			fmt.Fprintf(w, "  %s %s\n", p.treeLast(), p.dim("no overlapping specs detected"))
+		} else {
+			for i, overlap := range result.Overlap.Overlaps {
+				fmt.Fprintf(w, "  %s %s  %s  %s\n", p.treeBranch(i == len(result.Overlap.Overlaps)-1), p.cyan(overlap.Ref), fmt.Sprintf("%.3f", overlap.Score), overlap.Relationship)
+			}
 		}
 		fmt.Fprintln(w)
-		if len(result.Overlap.Overlaps) > 0 {
-			top := result.Overlap.Overlaps[0]
-			fmt.Fprintf(w, "top overlap: %s | %s | %.3f | %s\n", top.Ref, top.Relationship, top.Score, humanizeOverlapGuidance(top.Guidance))
+	}
+
+	if result.Impact != nil {
+		fmt.Fprintf(w, "  %s    %d specs · %d refs · %d docs\n", p.white("IMPACT"), len(result.Impact.AffectedSpecs), len(result.Impact.AffectedRefs), len(result.Impact.AffectedDocs))
+		items := reviewImpactLines(result.Impact)
+		for i, item := range items {
+			fmt.Fprintf(w, "  %s %s\n", p.treeBranch(i == len(items)-1), item)
+		}
+		fmt.Fprintln(w)
+	}
+
+	driftAssessments := reviewDocDriftAssessments(result.DocDrift)
+	fmt.Fprintf(w, "  %s %d item%s · %d remediation%s\n", p.white("DOC DRIFT"), len(driftAssessments), pluralSuffix(len(driftAssessments)), reviewRemediationSuggestionCount(result.DocRemediation), pluralSuffix(reviewRemediationSuggestionCount(result.DocRemediation)))
+	if len(driftAssessments) == 0 {
+		fmt.Fprintf(w, "  %s %s\n", p.treeLast(), p.dim("no drifting docs detected"))
+	} else {
+		for i, assessment := range driftAssessments {
+			fmt.Fprintf(w, "  %s %s  %s\n", p.treeBranch(i == len(driftAssessments)-1), p.cyan(preferredDocLabel(assessment.DocRef, assessment.SourceRef)), driftAssessmentBadge(p, assessment.Status))
+			if suggestions := remediationItemsByDocRef(result.DocRemediation)[assessment.DocRef]; len(suggestions) > 0 {
+				fmt.Fprintf(w, "     %s %d suggested edits %s\n", p.arrow(), len(suggestions), p.dim("(see check-doc-drift for detail)"))
+			}
 		}
 	}
+	fmt.Fprintln(w)
+
 	if result.Comparison != nil {
-		fmt.Fprintf(w, "comparison: %s\n", result.Comparison.Comparison.Recommendation)
+		fmt.Fprintf(w, "  %s  prefer %s as the primary reference\n", p.white("COMPARISON"), p.cyan(result.SpecRef))
 	} else {
-		fmt.Fprintln(w, "comparison: none")
+		fmt.Fprintf(w, "  %s  %s\n", p.white("COMPARISON"), p.dim("none"))
 	}
-	if result.Impact != nil {
-		fmt.Fprintf(w, "impact: %d spec(s), %d ref(s), %d doc(s)\n", len(result.Impact.AffectedSpecs), len(result.Impact.AffectedRefs), len(result.Impact.AffectedDocs))
-		renderReviewImpactSummary(w, result.Impact)
-	} else {
-		fmt.Fprintln(w, "impact: none")
-	}
-	if result.DocDrift != nil {
-		fmt.Fprintf(w, "doc drift: %d item(s)\n", len(result.DocDrift.DriftItems))
-	} else {
-		fmt.Fprintln(w, "doc drift: none")
-	}
-	if result.DocRemediation != nil {
-		fmt.Fprintf(w, "doc remediation: %d item(s)\n", len(result.DocRemediation.Items))
-	} else {
-		fmt.Fprintln(w, "doc remediation: none")
-	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  %s  run review-spec --format html for the full evidence report\n", p.info())
 }
 
 func renderReviewMarkdown(w io.Writer, result *analysis.ReviewResult) {
@@ -1428,6 +1499,144 @@ func reviewRemediationSuggestionCount(result *analysis.DocRemediationResult) int
 	return count
 }
 
+func renderFreshnessLabel(p renderPresentation, state string) string {
+	switch state {
+	case "fresh":
+		return p.green(state)
+	case "stale", "incompatible":
+		return p.red(state)
+	default:
+		return p.yellow(state)
+	}
+}
+
+func statusEmbedderSummary(provider string) string {
+	if strings.TrimSpace(provider) == "" {
+		return "embedder unknown"
+	}
+	return provider + " embedder"
+}
+
+func runtimeCheckGlyph(p renderPresentation, status string) string {
+	switch status {
+	case "ready":
+		return p.check()
+	case "disabled":
+		return p.info()
+	default:
+		return p.cross()
+	}
+}
+
+func complianceBadge(p renderPresentation, label string) string {
+	switch label {
+	case "conflicts":
+		return p.conflictBadge()
+	case "compliant":
+		return p.compliantBadge()
+	default:
+		return p.unspecifiedBadge()
+	}
+}
+
+func preferredDocLabel(docRef, sourceRef string) string {
+	if strings.TrimSpace(sourceRef) != "" {
+		return sourceRef
+	}
+	return docRef
+}
+
+func docDriftPadding(label string) int {
+	width := 56 - len([]rune(label))
+	if width < 2 {
+		return 2
+	}
+	return width
+}
+
+func driftAssessmentBadge(p renderPresentation, status string) string {
+	switch status {
+	case "aligned":
+		return p.okBadge()
+	case "possible_drift":
+		return p.reviewBadge()
+	default:
+		return p.driftBadge()
+	}
+}
+
+func driftFindingSummary(finding analysis.DriftFinding) string {
+	if strings.TrimSpace(finding.Code) != "" {
+		return humanizeSymbol(finding.Code)
+	}
+	return strings.TrimSpace(finding.Message)
+}
+
+func overlapBlock(p renderPresentation, item analysis.OverlapItem) string {
+	if item.Guidance == "merge_candidate" || item.Score >= 0.85 {
+		return p.blockHigh()
+	}
+	return p.blockMedium()
+}
+
+func overlapDisplaySummary(item analysis.OverlapItem) string {
+	guidance := humanizeOverlapGuidance(item.Guidance)
+	if item.Relationship == "" {
+		return guidance
+	}
+	if guidance == "" || guidance == item.Relationship {
+		return item.Relationship
+	}
+	return guidance
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func reviewImpactLines(result *analysis.AnalyzeImpactResult) []string {
+	if result == nil {
+		return nil
+	}
+	lines := make([]string, 0, 6)
+	for _, item := range topImpactedSpecs(result.AffectedSpecs, 2) {
+		line := fmt.Sprintf("%s  %s · %s", item.Ref, item.Title, item.Relationship)
+		if item.Historical {
+			line += " · historical"
+		}
+		lines = append(lines, line)
+	}
+	for _, item := range topImpactedDocs(result.AffectedDocs, 2) {
+		line := fmt.Sprintf("%s  %.3f", item.Ref, item.Score)
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func humanizeSymbol(value string) string {
+	value = strings.ReplaceAll(value, "_", " ")
+	value = strings.ReplaceAll(value, "-", " ")
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return value
+	}
+	return value
+}
+
+func (p renderPresentation) treeBranch(last bool) string {
+	if last {
+		return p.treeLast()
+	}
+	return p.treeMid()
+}
+
+func (p renderPresentation) treeItem(last bool) string {
+	return p.treeBranch(last)
+}
+
 func renderReviewMarkdownDriftEvidence(w io.Writer, evidence *analysis.DriftEvidence) {
 	if evidence == nil {
 		return
@@ -1455,11 +1664,17 @@ func renderReviewMarkdownDriftEvidence(w io.Writer, evidence *analysis.DriftEvid
 }
 
 func renderOverlapRecommendation(w io.Writer, recommendation string) {
-	fmt.Fprintf(w, "recommendation: %s", recommendation)
-	if detail := humanizeOverlapRecommendation(recommendation); detail != "" {
-		fmt.Fprintf(w, " | %s", detail)
+	p := presentationForWriter(w)
+	switch recommendation {
+	case "proceed_with_supersedes":
+		fmt.Fprintf(w, "  %s %s\n", p.check(), "candidate already declares the replacement path — no action needed")
+	case "merge_into_existing":
+		fmt.Fprintf(w, "  %s %s\n", p.arrow(), "strong merge candidate — merge into the existing spec")
+	case "review_boundaries":
+		fmt.Fprintf(w, "  %s %s\n", p.arrow(), "real overlap detected — review scope boundaries before merging")
+	default:
+		fmt.Fprintf(w, "  %s %s\n", p.arrow(), recommendation)
 	}
-	fmt.Fprintln(w)
 }
 
 func humanizeOverlapRecommendation(recommendation string) string {

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -88,8 +88,9 @@ func TestRenderStatusResultIncludesRuntimeProbe(t *testing.T) {
 
 	var stdout bytes.Buffer
 	renderStatusResult(&stdout, &statusResult{
-		WorkspaceRoot: "/tmp/repo",
-		ConfigPath:    "/tmp/repo/pituitary.toml",
+		WorkspaceRoot:    "/tmp/repo",
+		ConfigPath:       "/tmp/repo/pituitary.toml",
+		EmbedderProvider: "fixture",
 		ConfigResolution: &configResolution{
 			SelectedBy: configSourceDiscovery,
 			Reason:     "working-directory search found /tmp/repo/pituitary.toml",
@@ -144,23 +145,25 @@ func TestRenderStatusResultIncludesRuntimeProbe(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
+		"━━◈ status",
 		"workspace: /tmp/repo",
 		"config resolution: working-directory search found /tmp/repo/pituitary.toml",
-		"config candidates:",
+		"CONFIG CANDIDATES",
 		"1. command-local --config | not_set",
 		"4. working-directory search | selected | /tmp/repo/pituitary.toml",
 		"index: present",
 		"index freshness: fresh",
+		"fixture embedder",
 		"artifact index dir: /tmp/repo/.pituitary",
 		"artifact discover --write default: /tmp/repo/.pituitary/pituitary.toml",
 		"artifact canonicalize default: /tmp/repo/.pituitary/canonicalized",
 		"artifact ignore patterns: .pituitary/",
-		"artifact relocation: set [workspace].index_path to move the SQLite index",
+		"set [workspace].index_path to move the SQLite index",
 		"runtime probe: all",
-		"runtime: runtime.embedder | ready | provider: openai_compatible | model: pituitary-embed | endpoint: http://localhost:1234/v1",
-		"runtime: runtime.analysis | disabled | provider: disabled",
+		"runtime: ✓ runtime.embedder | ready | provider: openai_compatible | model: pituitary-embed | endpoint: http://localhost:1234/v1",
+		"runtime: ℹ runtime.analysis | disabled | provider: disabled",
 		"runtime note: runtime.analysis is disabled in config",
-		`guidance: runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
+		`runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderStatusResult() output %q does not contain %q", output, want)
@@ -222,10 +225,11 @@ func TestRenderInitResultSummarizesOnboarding(t *testing.T) {
 			EdgeCount:     8,
 		},
 		Status: &statusResult{
-			Freshness:  &index.FreshnessStatus{State: "fresh"},
-			SpecCount:  3,
-			DocCount:   2,
-			ChunkCount: 17,
+			EmbedderProvider: "fixture",
+			Freshness:        &index.FreshnessStatus{State: "fresh"},
+			SpecCount:        3,
+			DocCount:         2,
+			ChunkCount:       17,
 			Guidance: []string{
 				`runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
 			},
@@ -234,12 +238,17 @@ func TestRenderInitResultSummarizesOnboarding(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
+		"━━◈ init",
+		"3 sources",
+		"5 artifacts",
+		"17 chunks",
+		"fresh",
+		"fixture embedder",
 		"workspace: /tmp/repo",
-		"config action: wrote",
-		"discovered sources: 3",
-		"index: 5 artifact(s), 17 chunk(s), 8 edge(s)",
-		"status: fresh | specs: 3 | docs: 2 | chunks: 17",
-		`guidance: runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
+		"config: /tmp/repo/.pituitary/pituitary.toml",
+		"action: wrote",
+		"index: 3 specs · 2 docs",
+		`runtime.embedder is still "fixture" on 5 indexed artifact(s); for better retrieval quality on a real corpus, switch to "openai_compatible", rebuild the index, then run ` + "`pituitary status --check-runtime embedder`",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderInitResult() output %q does not contain %q", output, want)
@@ -326,11 +335,12 @@ func TestRenderComplianceResultIncludesTraceabilityGuidance(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
+		"━━◈ check-compliance",
 		"paths: src/api/middleware/tenant_limiter.go",
-		"unspecified: 1",
-		"traceability: semantic_neighbor_without_applies_to",
-		"limiting factor: spec_metadata_gap",
-		`suggestion: If SPEC-042 governs src/api/middleware/tenant_limiter.go, add applies_to = ["code://src/api/middleware/tenant_limiter.go"] to that accepted spec and rebuild the index.`,
+		"UNSPECIFIED: 1",
+		"traceability semantic_neighbor_without_applies_to",
+		"limiting factor spec_metadata_gap",
+		`If SPEC-042 governs src/api/middleware/tenant_limiter.go, add applies_to = ["code://src/api/middleware/tenant_limiter.go"] to that accepted spec and rebuild the index.`,
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderComplianceResult() output %q does not contain %q", output, want)
@@ -440,14 +450,15 @@ func TestRenderDocDriftResultIncludesEvidenceAndConfidence(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
-		"status: drift | confidence: high (0.911)",
-		"status: aligned | confidence: medium (0.744)",
-		"rationale:",
-		"spec evidence: SPEC-042 | Defaults",
-		"doc evidence: Quickstart",
-		"finding: default_limit_mismatch | confidence: high",
-		"confidence basis:",
-		"suggested edit: replace \"100 requests per minute\" with \"200 requests per minute\"",
+		"━━◈ check-doc-drift",
+		"docs/guides/api-rate-limits.md",
+		"██ DRIFT",
+		"default limit mismatch",
+		"expected 200",
+		"got 100",
+		"pituitary fix --path docs/guides/api-rate-limits.md",
+		"docs/runbooks/rate-limit-rollout.md",
+		"██ OK",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderDocDriftResult() output %q does not contain %q", output, want)
@@ -475,12 +486,11 @@ func TestRenderReviewResultIncludesTopImpactSummaries(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
-		"impact: 2 spec(s), 0 ref(s), 2 doc(s)",
-		"top impacted specs:",
-		"- SPEC-055 | Tenant Overrides Rollout | depends_on",
-		"- SPEC-008 | Legacy Rate Limiting | supersedes | historical",
-		"top impacted docs:",
-		"- doc://guides/api-rate-limits | API Rate Limits | 0.912 | file://docs/guides/api-rate-limits.md",
+		"━━◈ review-spec · SPEC-042",
+		"IMPACT    2 specs · 0 refs · 2 docs",
+		"SPEC-055  Tenant Overrides Rollout · depends_on",
+		"SPEC-008  Legacy Rate Limiting · supersedes · historical",
+		"doc://guides/api-rate-limits  0.912",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderReviewResult() output %q does not contain %q", output, want)
@@ -509,9 +519,13 @@ func TestRenderOverlapResultShowsBoundaryReviewGuidance(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
-		"candidate: SPEC-055 | Burst Handling",
-		"SPEC-042 | Per-Tenant Rate Limiting | 0.811 | high | adjacent | boundary review",
-		"recommendation: review_boundaries | real overlap, but clarify boundaries before merging",
+		"━━◈ check-overlap · SPEC-055",
+		"Burst Handling",
+		"SPEC-042",
+		"0.811",
+		"Per-Tenant Rate Limiting",
+		"boundary review",
+		"real overlap detected — review scope boundaries before merging",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderOverlapResult() output %q does not contain %q", output, want)
@@ -535,8 +549,9 @@ func TestRenderReviewResultShowsOverlapGuidance(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
-		"overlaps: 1 | recommendation: review_boundaries | real overlap, but clarify boundaries before merging",
-		"top overlap: SPEC-042 | adjacent | 0.811 | boundary review",
+		"━━◈ review-spec · SPEC-055",
+		"OVERLAP   1 specs · recommendation: review_boundaries",
+		"SPEC-042  0.811  adjacent",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderReviewResult() output %q does not contain %q", output, want)
@@ -674,5 +689,43 @@ func TestRenderCommandMarkdownReviewSpecWithNoFollowUp(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("renderCommandMarkdown() output %q does not contain %q", output, want)
 		}
+	}
+}
+
+func TestRenderDocDriftResultColorAlwaysEmitsANSI(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	renderDocDriftResult(wrapCLIWriter(&stdout, colorModeAlways), &analysis.DocDriftResult{
+		Assessments: []analysis.DocDriftAssessment{
+			{DocRef: "doc://guides/api-rate-limits", SourceRef: "docs/guides/api-rate-limits.md", Status: "drift"},
+		},
+	})
+
+	if !strings.Contains(stdout.String(), "\x1b[") {
+		t.Fatalf("renderDocDriftResult() output %q does not contain ANSI escapes in --color=always mode", stdout.String())
+	}
+}
+
+func TestWriteCLISuccessJSONNeverEmitsANSI(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := writeCLISuccess(
+		wrapCLIWriter(&stdout, colorModeAlways),
+		wrapCLIWriter(&stderr, colorModeAlways),
+		commandFormatJSON,
+		"status",
+		struct{}{},
+		&statusResult{ConfigPath: "/tmp/repo/pituitary.toml"},
+		nil,
+	)
+	if exitCode != 0 {
+		t.Fatalf("writeCLISuccess() exit code = %d, want 0", exitCode)
+	}
+	if strings.Contains(stdout.String(), "\x1b[") {
+		t.Fatalf("writeCLISuccess() JSON output %q unexpectedly contains ANSI escapes", stdout.String())
 	}
 }

--- a/cmd/review_spec_test.go
+++ b/cmd/review_spec_test.go
@@ -246,10 +246,9 @@ func TestRunReviewSpecTextIncludesTopImpactSummaries(t *testing.T) {
 
 	out := stdout.String()
 	for _, want := range []string{
-		"impact: 2 spec(s), 2 ref(s), 2 doc(s)",
-		"top impacted specs:",
+		"━━◈ review-spec · SPEC-042",
+		"IMPACT    2 specs · 2 refs · 2 docs",
 		"SPEC-055",
-		"top impacted docs:",
 		"doc://guides/api-rate-limits",
 	} {
 		if !strings.Contains(out, want) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,8 @@ func RunContext(ctx context.Context, args []string, stdout, stderr io.Writer) in
 		printHelp(stderr)
 		return 2
 	}
+	stdout = wrapCLIWriter(stdout, options.ColorMode)
+	stderr = wrapCLIWriter(stderr, options.ColorMode)
 	if len(remainingArgs) == 0 {
 		printHelp(stdout)
 		return 1
@@ -126,6 +128,7 @@ func printHelp(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "global options:")
 	fmt.Fprintln(w, "  --config PATH     path to workspace config")
+	fmt.Fprintln(w, "  --color MODE      terminal color: auto, always, or never")
 	fmt.Fprintln(w)
 	printSharedConfigResolution(w)
 	fmt.Fprintln(w)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -178,7 +178,11 @@ func assertKnownCommandResult(t *testing.T, name, description string, exitCode i
 		t.Fatalf("Run(%q) stderr %q does not contain init progress", name, stderr)
 	}
 
-	if !strings.Contains(stdout, description) {
+	if usesSemanticTextRendering(name) {
+		if !strings.Contains(stdout, name) {
+			t.Fatalf("Run(%q) output %q does not contain command header %q", name, stdout, name)
+		}
+	} else if !strings.Contains(stdout, description) {
 		t.Fatalf("Run(%q) output %q does not contain description %q", name, stdout, description)
 	}
 	if expectBootstrapStatus && !strings.Contains(stdout, "status: bootstrap only, not implemented yet") {
@@ -206,5 +210,20 @@ func TestRunHelpIncludesCommandSurface(t *testing.T) {
 		if !strings.Contains(out, name) {
 			t.Fatalf("help output %q does not include command %q", out, name)
 		}
+	}
+}
+
+func TestRunHelpIncludesColorGlobalOption(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"help"}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("Run(help) exit code = %d, want 0", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "--color MODE") {
+		t.Fatalf("help output %q does not include --color global option", stdout.String())
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -21,6 +21,8 @@ type statusRequest struct {
 type statusResult struct {
 	WorkspaceRoot     string                     `json:"workspace_root"`
 	ConfigPath        string                     `json:"config_path"`
+	EmbedderProvider  string                     `json:"embedder_provider,omitempty"`
+	AnalysisProvider  string                     `json:"analysis_provider,omitempty"`
 	ConfigResolution  *configResolution          `json:"config_resolution,omitempty"`
 	IndexPath         string                     `json:"index_path"`
 	IndexExists       bool                       `json:"index_exists"`
@@ -121,6 +123,8 @@ func newStatusResult(result *app.StatusResult, resolution *configResolution) *st
 	return &statusResult{
 		WorkspaceRoot:     result.WorkspaceRoot,
 		ConfigPath:        result.ConfigPath,
+		EmbedderProvider:  result.EmbedderProvider,
+		AnalysisProvider:  result.AnalysisProvider,
 		ConfigResolution:  resolution,
 		IndexPath:         result.Index.IndexPath,
 		IndexExists:       result.Index.Exists,

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -67,7 +67,7 @@ func TestRunStatusReportsFixtureGuidanceForLargerCorpus(t *testing.T) {
 	}
 
 	out := stdout.String()
-	if !strings.Contains(out, `guidance: runtime.embedder is still "fixture" on 5 indexed artifact(s)`) {
+	if !strings.Contains(out, `runtime.embedder is still "fixture" on 5 indexed artifact(s)`) {
 		t.Fatalf("runStatus() output %q does not contain fixture guidance", out)
 	}
 	if !strings.Contains(out, "`pituitary status --check-runtime embedder`") {
@@ -205,10 +205,10 @@ This guide changed after indexing.
 	if !strings.Contains(out, "index freshness: stale") {
 		t.Fatalf("runStatus() output %q does not report stale freshness", out)
 	}
-	if !strings.Contains(out, "freshness: index content fingerprint") {
+	if !strings.Contains(out, "index content fingerprint") {
 		t.Fatalf("runStatus() output %q does not contain content fingerprint reason", out)
 	}
-	if !strings.Contains(out, "freshness action: run `pituitary index --rebuild`") {
+	if !strings.Contains(out, "run `pituitary index --rebuild`") {
 		t.Fatalf("runStatus() output %q does not contain rebuild guidance", out)
 	}
 }

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -17,13 +17,15 @@ type StatusRequest struct {
 
 // StatusResult captures transport-agnostic status details for one workspace.
 type StatusResult struct {
-	WorkspaceRoot string
-	ConfigPath    string
-	Index         *index.Status
-	Freshness     *index.FreshnessStatus
-	RelationGraph *index.RelationGraphStatus
-	Runtime       *runtimeprobe.Result
-	Guidance      []string
+	WorkspaceRoot    string
+	ConfigPath       string
+	EmbedderProvider string
+	AnalysisProvider string
+	Index            *index.Status
+	Freshness        *index.FreshnessStatus
+	RelationGraph    *index.RelationGraphStatus
+	Runtime          *runtimeprobe.Result
+	Guidance         []string
 }
 
 // Status loads config, inspects the current index, and optionally probes runtime dependencies.
@@ -52,13 +54,15 @@ func Status(ctx context.Context, configPath string, request StatusRequest) Respo
 		}
 
 		return &StatusResult{
-			WorkspaceRoot: cfg.Workspace.RootPath,
-			ConfigPath:    cfg.ConfigPath,
-			Index:         status,
-			Freshness:     freshness,
-			RelationGraph: index.InspectRelationGraph(records.Specs),
-			Runtime:       runtimeResult,
-			Guidance:      fixtureEmbedderGuidance(cfg, status),
+			WorkspaceRoot:    cfg.Workspace.RootPath,
+			ConfigPath:       cfg.ConfigPath,
+			EmbedderProvider: cfg.Runtime.Embedder.Provider,
+			AnalysisProvider: cfg.Runtime.Analysis.Provider,
+			Index:            status,
+			Freshness:        freshness,
+			RelationGraph:    index.InspectRelationGraph(records.Specs),
+			Runtime:          runtimeResult,
+			Guidance:         fixtureEmbedderGuidance(cfg, status),
 		}, nil
 	}, classifyStatusError)
 }


### PR DESCRIPTION
## Summary
- add semantic terminal color support for the highest-signal text commands
- add global --color=auto|always|never handling with NO_COLOR/TERM/TTY guards
- keep JSON output ANSI-free and add UTF-8/ASCII fallback chrome

## Testing
- go test ./...

Closes #134
