### PR TITLE
[feature] Add deterministic doc-drift fixer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -611,6 +611,9 @@ CLI exit codes should stay simple:
 - `check_doc_drift` (`pituitary check-doc-drift`)
   - Request: exactly one of `{ "doc_ref": "doc://guides/api-rate-limits" }`, `{ "doc_refs": ["doc://guides/api-rate-limits"] }`, or `{ "scope": "all" }`
   - Result: `{ "scope": { "mode": "doc_ref" | "doc_refs" | "all", "doc_refs": [...] }, "drift_items": [{ "doc_ref": "...", "findings": [{ "spec_ref": "SPEC-042", "code": "...", "message": "...", "rationale": "...", "evidence": { "spec_ref": "SPEC-042", "spec_section": "...", "doc_section": "..." }, "confidence": { "level": "high" | "medium" | "low", "score": 0.0 } }] }], "assessments": [{ "doc_ref": "...", "status": "drift" | "aligned" | "possible_drift", "rationale": "...", "evidence": { ... }, "confidence": { ... } }], "remediation": { ... } }`
+- `fix` (`pituitary fix`)
+  - Request: exactly one of `{ "path": "docs/guides/api-rate-limits.md", "dry_run": true }`, `{ "scope": "all", "dry_run": true }`, or `{ "doc_refs": ["doc://guides/api-rate-limits"], "apply": true }`
+  - Result: `{ "selector": "docs/guides/api-rate-limits.md" | "all" | "doc_refs", "applied": false, "files": [{ "doc_ref": "...", "path": "...", "status": "planned" | "applied" | "skipped", "reason": "...", "warnings": ["..."], "edits": [{ "code": "...", "action": "replace_claim", "replace": "...", "with": "...", "line": N, "start_byte": N, "end_byte": N, "before": "...", "after": "..." }] }], "planned_file_count": N, "planned_edit_count": N, "applied_file_count": N, "applied_edit_count": N, "guidance": ["..."] }`
 - `review_spec` (`pituitary review-spec`)
   - Request: `{ "spec_ref": "SPEC-042" }` or `{ "spec_record": { ... canonical spec record ... } }`
   - Result: `{ "spec_ref": "SPEC-042", "overlap": { ... }, "comparison": { ... } | null, "impact": { ... }, "doc_drift": { ... } }`

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ If you are evaluating search quality, overlap ranking, doc drift, or terminology
 ```sh
 pituitary status --check-runtime embedder
 pituitary index --rebuild
+pituitary check-doc-drift --scope all
+pituitary fix --scope all --dry-run
 ```
 
 ### Build from source when contributing
@@ -297,6 +299,7 @@ Every command supports `--format json` for machine-readable output. `search-spec
 | `check-compliance --path PATH` | Check one or more code paths against accepted specs |
 | `check-compliance --diff-file PATH|-` | Check a unified diff against accepted specs; ideal for pre-merge and CI use |
 | `check-doc-drift --scope all` | Find docs that have gone stale relative to accepted specs, with evidence and confidence |
+| `fix --path docs/guides/api-rate-limits.md --dry-run` | Preview deterministic doc-drift remediations before writing changes |
 | `review-spec --path specs/rate-limit-v2` | Full review: overlap + comparison + impact + drift + remediation in one report, with text/json/markdown/html output |
 
 `canonicalize` is optional high-rigor mode. It does not replace inferred-contract indexing; it helps you promote one Markdown contract into an explicit bundle when you want stronger structure without converting the whole repo at once.
@@ -308,6 +311,8 @@ By default, `search-specs` down-ranks sections that look like historical provena
 `index --rebuild` now keeps the atomic staging-DB swap, but it also reuses unchanged chunk embeddings by default when the current index has a matching schema, embedder fingerprint, and source fingerprint. Use `--full` to disable reuse and force a complete re-embed.
 
 `index --rebuild` and `index --dry-run` also validate the spec relation graph before touching SQLite. Cycles in `depends_on` or `supersedes`, plus contradictory `depends_on`/`supersedes` combinations, fail fast with the exact refs involved. `pituitary status` reports the same graph-health findings without requiring a rebuild.
+
+`fix` is intentionally narrow: it only applies deterministic `replace_claim` remediations that `check-doc-drift` can justify from accepted specs and exact document evidence. Use `--dry-run` to preview the edit plan, then rerun with `--yes` when the replacements look correct. After any successful apply, rebuild the index before the next analysis command.
 
 ### Example: CI-friendly compliance diff
 

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/app"
+)
+
+type fixCLIRequest struct {
+	Path   string `json:"path,omitempty"`
+	Scope  string `json:"scope,omitempty"`
+	DryRun bool   `json:"dry_run,omitempty"`
+	Yes    bool   `json:"yes,omitempty"`
+}
+
+func runFix(args []string, stdout, stderr io.Writer) int {
+	return runFixContext(context.Background(), args, stdout, stderr)
+}
+
+func runFixContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fix", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	help := newCommandHelp("fix", "pituitary [--config PATH] fix (--path PATH | --scope VALUE) [--dry-run] [--yes] [--format FORMAT]")
+
+	var (
+		path       string
+		scope      string
+		dryRun     bool
+		yes        bool
+		format     string
+		configPath string
+	)
+	fs.StringVar(&path, "path", "", "target doc path to remediate")
+	fs.StringVar(&scope, "scope", "", "target scope: accepted spec ref or all")
+	fs.BoolVar(&dryRun, "dry-run", false, "plan deterministic edits without writing files")
+	fs.BoolVar(&yes, "yes", false, "apply all planned edits without prompting")
+	fs.StringVar(&format, "format", "text", "output format")
+	fs.StringVar(&configPath, "config", "", "path to workspace config")
+
+	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
+		return writeCLIError(stdout, stderr, format, "fix", nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	} else if handled {
+		return 0
+	}
+	if fs.NArg() != 0 {
+		return writeCLIError(stdout, stderr, format, "fix", nil, cliIssue{
+			Code:    "validation_error",
+			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
+		}, 2)
+	}
+
+	request := fixCLIRequest{
+		Path:   strings.TrimSpace(path),
+		Scope:  strings.TrimSpace(scope),
+		DryRun: dryRun,
+		Yes:    yes,
+	}
+	if err := validateCLIFormat("fix", format); err != nil {
+		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+	if request.Path == "" && request.Scope == "" {
+		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+			Code:    "validation_error",
+			Message: "exactly one of --path or --scope is required",
+		}, 2)
+	}
+	if request.Path != "" && request.Scope != "" {
+		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+			Code:    "validation_error",
+			Message: "exactly one of --path or --scope is required",
+		}, 2)
+	}
+
+	if format != commandFormatText && !request.DryRun && !request.Yes {
+		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+			Code:    "validation_error",
+			Message: "non-text fix runs require either --dry-run or --yes",
+		}, 2)
+	}
+
+	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	if request.DryRun || request.Yes || format != commandFormatText {
+		response := app.FixDocDrift(ctx, resolvedConfigPath, app.FixRequest{
+			Path:  request.Path,
+			Scope: request.Scope,
+			Apply: request.Yes && !request.DryRun,
+		})
+		if response.Issue != nil {
+			return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+				Code:    response.Issue.Code,
+				Message: response.Issue.Message,
+			}, response.Issue.ExitCode)
+		}
+		return writeCLISuccess(stdout, stderr, format, "fix", request, response.Result, nil)
+	}
+
+	if !stdinIsTTY() {
+		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+			Code:    "validation_error",
+			Message: "interactive fix confirmation requires a TTY; rerun with --yes or --dry-run",
+		}, 2)
+	}
+
+	planResponse := app.FixDocDrift(ctx, resolvedConfigPath, app.FixRequest{
+		Path:  request.Path,
+		Scope: request.Scope,
+		Apply: false,
+	})
+	if planResponse.Issue != nil {
+		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+			Code:    planResponse.Issue.Code,
+			Message: planResponse.Issue.Message,
+		}, planResponse.Issue.ExitCode)
+	}
+	plan := planResponse.Result
+	if plan == nil {
+		return 0
+	}
+
+	selectedDocRefs := make([]string, 0, len(plan.Files))
+	for _, file := range plan.Files {
+		renderFixPromptFile(stdout, plan.Selector, file)
+		applyFile, err := promptFixConfirmation(stdout, func() {
+			fmt.Fprintln(stdout)
+			renderFixPromptFile(stdout, plan.Selector, file)
+		})
+		if err != nil {
+			return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+				Code:    "validation_error",
+				Message: err.Error(),
+			}, 2)
+		}
+		if applyFile {
+			selectedDocRefs = append(selectedDocRefs, file.DocRef)
+		}
+	}
+	if len(selectedDocRefs) == 0 {
+		plan.Guidance = append(plan.Guidance, "No files selected; nothing was changed.")
+		return writeCLISuccess(stdout, stderr, format, "fix", request, plan, nil)
+	}
+
+	applyResponse := app.FixDocDrift(ctx, resolvedConfigPath, app.FixRequest{
+		DocRefs: selectedDocRefs,
+		Apply:   true,
+	})
+	if applyResponse.Issue != nil {
+		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
+			Code:    applyResponse.Issue.Code,
+			Message: applyResponse.Issue.Message,
+		}, applyResponse.Issue.ExitCode)
+	}
+	return writeCLISuccess(stdout, stderr, format, "fix", request, applyResponse.Result, nil)
+}
+
+func stdinIsTTY() bool {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+func promptFixConfirmation(stdout io.Writer, renderDiff func()) (bool, error) {
+	p := presentationForWriter(stdout)
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Fprintf(stdout, "  %s %s ", p.yellow("apply these edits?"), p.bold("[y/n/diff]"))
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return false, fmt.Errorf("read confirmation: %w", err)
+		}
+		answer := strings.ToLower(strings.TrimSpace(line))
+		switch answer {
+		case "y", "yes":
+			fmt.Fprintln(stdout)
+			return true, nil
+		case "n", "no", "":
+			fmt.Fprintln(stdout)
+			return false, nil
+		case "d", "diff":
+			fmt.Fprintln(stdout)
+			if renderDiff != nil {
+				renderDiff()
+			}
+			continue
+		default:
+			fmt.Fprintln(stdout)
+		}
+	}
+}

--- a/cmd/fix_test.go
+++ b/cmd/fix_test.go
@@ -1,0 +1,230 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunFixDryRunJSONPlansDeterministicEdits(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runFix([]string{"--path", "docs/guides/api-rate-limits.md", "--dry-run", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runFix() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runFix() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request struct {
+			Path   string `json:"path"`
+			DryRun bool   `json:"dry_run"`
+		} `json:"request"`
+		Result struct {
+			Selector         string `json:"selector"`
+			Applied          bool   `json:"applied"`
+			PlannedFileCount int    `json:"planned_file_count"`
+			PlannedEditCount int    `json:"planned_edit_count"`
+			Files            []struct {
+				DocRef string `json:"doc_ref"`
+				Path   string `json:"path"`
+				Status string `json:"status"`
+				Edits  []struct {
+					Code   string `json:"code"`
+					Action string `json:"action"`
+					After  string `json:"after"`
+				} `json:"edits"`
+				Reason string `json:"reason"`
+			} `json:"files"`
+			Guidance []string `json:"guidance"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if payload.Request.Path != "docs/guides/api-rate-limits.md" || !payload.Request.DryRun {
+		t.Fatalf("request = %+v, want path+dry_run", payload.Request)
+	}
+	if payload.Result.Selector != "docs/guides/api-rate-limits.md" {
+		t.Fatalf("result.selector = %q, want doc path selector", payload.Result.Selector)
+	}
+	if payload.Result.Applied {
+		t.Fatalf("result.applied = true, want false")
+	}
+	if payload.Result.PlannedFileCount != 1 {
+		t.Fatalf("result.planned_file_count = %d, want 1", payload.Result.PlannedFileCount)
+	}
+	if payload.Result.PlannedEditCount < 3 {
+		t.Fatalf("result.planned_edit_count = %d, want at least 3", payload.Result.PlannedEditCount)
+	}
+	if len(payload.Result.Files) != 1 {
+		t.Fatalf("result.files = %+v, want one file", payload.Result.Files)
+	}
+	file := payload.Result.Files[0]
+	if got, want := file.DocRef, "doc://guides/api-rate-limits"; got != want {
+		t.Fatalf("file.doc_ref = %q, want %q", got, want)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(file.Path), "docs/guides/api-rate-limits.md") {
+		t.Fatalf("file.path = %q, want docs/guides/api-rate-limits.md suffix", file.Path)
+	}
+	if file.Status != "planned" {
+		t.Fatalf("file.status = %q, want planned", file.Status)
+	}
+	if len(file.Edits) < 3 {
+		t.Fatalf("file.edits = %+v, want multiple planned edits", file.Edits)
+	}
+	var foundSliding bool
+	for _, edit := range file.Edits {
+		if edit.Action != "replace_claim" {
+			t.Fatalf("edit.action = %q, want replace_claim", edit.Action)
+		}
+		if strings.Contains(edit.After, "sliding-window") {
+			foundSliding = true
+		}
+	}
+	if !foundSliding {
+		t.Fatalf("file.edits = %+v, want sliding-window replacement", file.Edits)
+	}
+	if len(payload.Result.Guidance) == 0 || !strings.Contains(payload.Result.Guidance[0], "--yes") {
+		t.Fatalf("result.guidance = %v, want apply guidance", payload.Result.Guidance)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
+func TestRunFixAppliesEditsWithYes(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runFix([]string{"--path", "docs/guides/api-rate-limits.md", "--yes"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runFix() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runFix() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"━━◈ fix",
+		"api-rate-limits.md",
+		"applied",
+		"pituitary index --rebuild",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("runFix() output %q does not contain %q", out, want)
+		}
+	}
+
+	updatedBytes, err := os.ReadFile(filepath.Join(repo, "docs", "guides", "api-rate-limits.md"))
+	if err != nil {
+		t.Fatalf("read updated guide: %v", err)
+	}
+	updated := string(updatedBytes)
+	for _, want := range []string{
+		"sliding-window rate limiter",
+		"200 requests per minute",
+		"tenant-specific overrides are supported through configuration",
+	} {
+		if !strings.Contains(updated, want) {
+			t.Fatalf("updated guide %q does not contain %q", updated, want)
+		}
+	}
+	for _, stale := range []string{
+		"fixed-window rate limiter",
+		"100 requests per minute",
+		"tenant-specific overrides are not supported",
+	} {
+		if strings.Contains(updated, stale) {
+			t.Fatalf("updated guide %q still contains stale text %q", updated, stale)
+		}
+	}
+}
+
+func TestRunFixRejectsInteractiveRunWithoutTTY(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	_ = stdinWriter.Close()
+	oldStdin := os.Stdin
+	os.Stdin = stdinReader
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = stdinReader.Close()
+	})
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runFix([]string{"--path", "docs/guides/api-rate-limits.md"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runFix() exit code = %d, want 2", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("runFix() wrote unexpected stdout: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "requires a TTY") {
+		t.Fatalf("runFix() stderr %q does not contain TTY guidance", stderr.String())
+	}
+}
+
+func TestRunFixRejectsStaleIndex(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		mustWriteFileCmd(t, filepath.Join(repo, "docs", "guides", "api-rate-limits.md"), `
+# Public API Rate Limits
+
+This guide changed after indexing.
+`)
+		return runFix([]string{"--path", "docs/guides/api-rate-limits.md", "--dry-run"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runFix() exit code = %d, want 2", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("runFix() wrote unexpected stdout: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "index is stale") {
+		t.Fatalf("runFix() stderr %q does not contain stale-index guidance", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "pituitary index --rebuild") {
+		t.Fatalf("runFix() stderr %q does not contain rebuild guidance", stderr.String())
+	}
+}

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -23,6 +23,7 @@ func TestRunCommandHelpAcrossSurface(t *testing.T) {
 		"check-terminology": {"usage: pituitary [--config PATH] check-terminology --term TERM... [--canonical-term TERM]... [--spec-ref REF | --path PATH] [--scope SCOPE] [--format FORMAT]", "shared config resolution:", "--term VALUE", "--canonical-term VALUE", "--scope VALUE"},
 		"check-compliance":  {"usage: pituitary [--config PATH] check-compliance (--path PATH... | --diff-file PATH|-) [--format FORMAT]", "shared config resolution:", "--path VALUE", "--diff-file VALUE"},
 		"check-doc-drift":   {"usage: pituitary [--config PATH] check-doc-drift", "shared config resolution:", "--doc-ref VALUE", "--scope VALUE"},
+		"fix":               {"usage: pituitary [--config PATH] fix (--path PATH | --scope VALUE) [--dry-run] [--yes] [--format FORMAT]", "shared config resolution:", "--path VALUE", "--scope VALUE", "--dry-run", "--yes"},
 		"review-spec":       {"usage: pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|-) [--format FORMAT]", "shared config resolution:", "--path VALUE", "--spec-record-file VALUE"},
 		"serve":             {"usage: pituitary [--config PATH] serve", "shared config resolution:", "--transport VALUE"},
 	}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/dusk-network/pituitary/internal/analysis"
+	"github.com/dusk-network/pituitary/internal/app"
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/source"
 )
@@ -55,6 +56,8 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 		renderComplianceResult(w, typed)
 	case *analysis.DocDriftResult:
 		renderDocDriftResult(w, typed)
+	case *app.FixResult:
+		renderFixResult(w, typed)
 	case *analysis.ReviewResult:
 		renderReviewResult(w, typed)
 	default:
@@ -66,7 +69,7 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 
 func usesSemanticTextRendering(command string) bool {
 	switch command {
-	case "check-doc-drift", "check-overlap", "review-spec", "check-compliance", "status", "init":
+	case "check-doc-drift", "check-overlap", "review-spec", "check-compliance", "status", "init", "fix":
 		return true
 	default:
 		return false
@@ -738,6 +741,63 @@ func renderDriftEvidence(w io.Writer, evidence *analysis.DriftEvidence, prefix s
 		if evidence.DocExcerpt != "" {
 			fmt.Fprintf(w, "%s  excerpt: %s\n", prefix, evidence.DocExcerpt)
 		}
+	}
+}
+
+func renderFixResult(w io.Writer, result *app.FixResult) {
+	p := presentationForWriter(w)
+	suffix := ""
+	if strings.TrimSpace(result.Selector) != "" {
+		suffix = " " + p.dim(result.Selector)
+	}
+	fmt.Fprintln(w, p.headerLine("fix", suffix))
+	fmt.Fprintln(w)
+
+	if len(result.Files) == 0 {
+		fmt.Fprintf(w, "  %s no deterministic doc-drift edits available\n", p.info())
+		for _, guidance := range result.Guidance {
+			fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
+		}
+		return
+	}
+
+	for i, file := range result.Files {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		renderFixPromptFile(w, result.Selector, file)
+		if file.Status == "applied" {
+			fmt.Fprintf(w, "    %s applied %d edit%s\n", p.check(), len(file.Edits), pluralSuffix(len(file.Edits)))
+		}
+		if file.Reason != "" {
+			fmt.Fprintf(w, "    %s %s\n", p.arrow(), file.Reason)
+		}
+		for _, warning := range file.Warnings {
+			fmt.Fprintf(w, "    %s %s\n", p.arrow(), warning)
+		}
+	}
+	if len(result.Guidance) > 0 {
+		fmt.Fprintln(w)
+		for _, guidance := range result.Guidance {
+			fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
+		}
+	}
+}
+
+func renderFixPromptFile(w io.Writer, selector string, file app.FixFileResult) {
+	p := presentationForWriter(w)
+	fmt.Fprintf(w, "  %s\n\n", p.dim(file.Path))
+	if len(file.Edits) == 0 {
+		fmt.Fprintf(w, "    %s %s\n", p.info(), "no deterministic replace-claim edits available")
+		return
+	}
+	for _, edit := range file.Edits {
+		fmt.Fprintf(w, "    %s %s\n", p.red("-"), edit.Before)
+		fmt.Fprintf(w, "    %s %s\n", p.green("+"), edit.After)
+		if edit.Summary != "" {
+			fmt.Fprintf(w, "      %s\n", p.dim(edit.Summary))
+		}
+		fmt.Fprintln(w)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ func commandRegistry() map[string]commandSpec {
 		"check-terminology": {Description: "audit terminology consistency after conceptual changes", Formats: commandFormats(), Run: runCheckTerminologyContext},
 		"check-compliance":  {Description: "check code paths and diffs against accepted specs", Formats: commandFormats(), Run: runCheckComplianceContext},
 		"check-doc-drift":   {Description: "find docs that drift from specs", Formats: commandFormats(), Run: runCheckDocDriftContext},
+		"fix":               {Description: "apply deterministic doc-drift remediations", Formats: commandFormats(), Run: runFixContext},
 		"review-spec":       {Description: "run the common spec-review workflow", Formats: commandFormats(commandFormatMarkdown, commandFormatHTML), Run: runReviewSpecContext},
 		"serve":             {Description: "run the optional MCP server transport", Formats: commandFormats(), Run: runServeContext},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -32,7 +32,7 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 				return
 			}
 
-			if name == "canonicalize" || name == "discover" || name == "init" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "review-spec" {
+			if name == "canonicalize" || name == "discover" || name == "init" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "fix" || name == "review-spec" {
 				repoRoot := writeSearchWorkspace(t)
 				if name == "discover" || name == "init" || name == "canonicalize" {
 					repoRoot = writeDiscoveryWorkspace(t)
@@ -122,6 +122,8 @@ func buildLimiter() {}
 						args = []string{name, "--term", "tenant"}
 					} else if name == "check-compliance" {
 						args = []string{name, "--path", "src/api/middleware/ratelimiter.go"}
+					} else if name == "fix" {
+						args = []string{name, "--path", "docs/guides/api-rate-limits.md", "--dry-run"}
 					} else if name == "review-spec" {
 						args = []string{name, "--spec-ref", "SPEC-042"}
 					} else {

--- a/internal/app/fix.go
+++ b/internal/app/fix.go
@@ -1,0 +1,576 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/analysis"
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/model"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+type FixRequest struct {
+	Path    string   `json:"path,omitempty"`
+	Scope   string   `json:"scope,omitempty"`
+	DocRefs []string `json:"doc_refs,omitempty"`
+	Apply   bool     `json:"apply,omitempty"`
+}
+
+type FixEdit struct {
+	Code      string `json:"code"`
+	Summary   string `json:"summary"`
+	Action    string `json:"action"`
+	Replace   string `json:"replace,omitempty"`
+	With      string `json:"with,omitempty"`
+	Line      int    `json:"line,omitempty"`
+	StartByte int    `json:"start_byte,omitempty"`
+	EndByte   int    `json:"end_byte,omitempty"`
+	Before    string `json:"before,omitempty"`
+	After     string `json:"after,omitempty"`
+}
+
+type FixFileResult struct {
+	DocRef             string    `json:"doc_ref"`
+	SourceRef          string    `json:"source_ref,omitempty"`
+	Path               string    `json:"path"`
+	Status             string    `json:"status"`
+	Reason             string    `json:"reason,omitempty"`
+	Warnings           []string  `json:"warnings,omitempty"`
+	Edits              []FixEdit `json:"edits,omitempty"`
+	originalContent    string
+	originalContentSum string
+}
+
+type FixResult struct {
+	Selector         string          `json:"selector"`
+	Applied          bool            `json:"applied"`
+	Files            []FixFileResult `json:"files"`
+	PlannedFileCount int             `json:"planned_file_count"`
+	PlannedEditCount int             `json:"planned_edit_count"`
+	AppliedFileCount int             `json:"applied_file_count,omitempty"`
+	AppliedEditCount int             `json:"applied_edit_count,omitempty"`
+	Guidance         []string        `json:"guidance,omitempty"`
+}
+
+type plannedFixEdit struct {
+	FixEdit
+	start int
+	end   int
+}
+
+type fixNotFoundError struct {
+	message string
+}
+
+func (e *fixNotFoundError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.message
+}
+
+func FixDocDrift(ctx context.Context, configPath string, request FixRequest) Response[FixRequest, FixResult] {
+	return executeWithFreshConfig(ctx, configPath, request, operationExecutionPolicy{
+		NotFound: func(err error) bool {
+			return analysis.IsNotFound(err) || isFixNotFound(err)
+		},
+	}, func(cfg *config.Config) (*FixResult, error) {
+		return runFixDocDrift(ctx, cfg, request)
+	})
+}
+
+func runFixDocDrift(ctx context.Context, cfg *config.Config, request FixRequest) (*FixResult, error) {
+	selector, targetDocRefs, err := resolveFixTargets(ctx, cfg, request)
+	if err != nil {
+		return nil, err
+	}
+
+	driftRequest, ok := docDriftRequestForTargets(targetDocRefs, selector)
+	if !ok {
+		return &FixResult{
+			Selector: selector,
+			Applied:  request.Apply,
+			Guidance: []string{"No docs matched the selected scope."},
+		}, nil
+	}
+
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	docsByRef := docRecordsByRef(records.Docs)
+
+	drift, err := analysis.CheckDocDriftContext(ctx, cfg, driftRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &FixResult{
+		Selector: selector,
+		Applied:  request.Apply,
+		Files:    make([]FixFileResult, 0),
+	}
+
+	driftItems := make(map[string]analysis.DriftItem, len(drift.DriftItems))
+	for _, item := range drift.DriftItems {
+		driftItems[item.DocRef] = item
+	}
+
+	for _, item := range drift.Remediation.Items {
+		record, ok := docsByRef[item.DocRef]
+		if !ok {
+			continue
+		}
+		fileResult, err := buildFixFileResult(cfg, record, item, driftItems[item.DocRef], request.Apply)
+		if err != nil {
+			return nil, err
+		}
+		result.Files = append(result.Files, fileResult)
+	}
+
+	sort.Slice(result.Files, func(i, j int) bool {
+		return result.Files[i].Path < result.Files[j].Path
+	})
+
+	for _, file := range result.Files {
+		if len(file.Edits) > 0 {
+			result.PlannedFileCount++
+			result.PlannedEditCount += len(file.Edits)
+		}
+		if file.Status == "applied" {
+			result.AppliedFileCount++
+			result.AppliedEditCount += len(file.Edits)
+		}
+	}
+
+	if request.Apply {
+		result.Guidance = append(result.Guidance, "The workspace index is now stale; run `pituitary index --rebuild` before the next analysis command.")
+	} else if result.PlannedEditCount > 0 {
+		result.Guidance = append(result.Guidance, "Re-run with `--yes` to apply these deterministic edits.")
+	}
+	if len(result.Files) == 0 {
+		result.Guidance = append(result.Guidance, "No deterministic doc-drift remediations were available for the selected scope.")
+	}
+
+	return result, nil
+}
+
+func resolveFixTargets(ctx context.Context, cfg *config.Config, request FixRequest) (string, []string, error) {
+	hasPath := strings.TrimSpace(request.Path) != ""
+	hasScope := strings.TrimSpace(request.Scope) != ""
+	hasDocRefs := len(request.DocRefs) > 0
+
+	count := 0
+	if hasPath {
+		count++
+	}
+	if hasScope {
+		count++
+	}
+	if hasDocRefs {
+		count++
+	}
+	if count != 1 {
+		return "", nil, fmt.Errorf("exactly one of path, scope, or doc_refs is required")
+	}
+
+	if hasDocRefs {
+		return "doc_refs", uniqueNonEmptyStrings(request.DocRefs), nil
+	}
+
+	if hasPath {
+		records, err := source.LoadFromConfig(cfg)
+		if err != nil {
+			return "", nil, err
+		}
+		docRef, err := docRefForFixPath(cfg.Workspace.RootPath, request.Path, records.Docs)
+		if err != nil {
+			return "", nil, err
+		}
+		return request.Path, []string{docRef}, nil
+	}
+
+	scope := strings.TrimSpace(request.Scope)
+	if scope == "all" {
+		return "all", nil, nil
+	}
+
+	impact, err := analysis.AnalyzeImpactContext(ctx, cfg, analysis.AnalyzeImpactRequest{SpecRef: scope})
+	if err != nil {
+		return "", nil, err
+	}
+	docRefs := make([]string, 0, len(impact.AffectedDocs))
+	for _, item := range impact.AffectedDocs {
+		docRefs = append(docRefs, item.Ref)
+	}
+	return scope, uniqueNonEmptyStrings(docRefs), nil
+}
+
+func docDriftRequestForTargets(docRefs []string, selector string) (analysis.DocDriftRequest, bool) {
+	if selector == "all" {
+		return analysis.DocDriftRequest{Scope: "all"}, true
+	}
+	switch len(docRefs) {
+	case 0:
+		return analysis.DocDriftRequest{}, false
+	case 1:
+		return analysis.DocDriftRequest{DocRef: docRefs[0]}, true
+	default:
+		return analysis.DocDriftRequest{DocRefs: docRefs}, true
+	}
+}
+
+func docRefForFixPath(workspaceRoot, path string, docs []model.DocRecord) (string, error) {
+	normalized := normalizeFixPath(workspaceRoot, path)
+	for _, doc := range docs {
+		sourcePath := normalizeFixPath(workspaceRoot, strings.TrimPrefix(doc.SourceRef, "file://"))
+		if normalized == sourcePath {
+			return doc.Ref, nil
+		}
+	}
+	return "", &fixNotFoundError{message: fmt.Sprintf("doc path %q is not indexed by the current sources", path)}
+}
+
+func normalizeFixPath(workspaceRoot, path string) string {
+	trimmed := strings.TrimSpace(strings.TrimPrefix(path, "file://"))
+	if trimmed == "" {
+		return ""
+	}
+	if filepath.IsAbs(trimmed) {
+		if rel, err := filepath.Rel(workspaceRoot, trimmed); err == nil {
+			trimmed = rel
+		}
+	}
+	return filepath.ToSlash(filepath.Clean(trimmed))
+}
+
+func docRecordsByRef(records []model.DocRecord) map[string]model.DocRecord {
+	result := make(map[string]model.DocRecord, len(records))
+	for _, record := range records {
+		result[record.Ref] = record
+	}
+	return result
+}
+
+func buildFixFileResult(cfg *config.Config, record model.DocRecord, remediation analysis.DocRemediationItem, driftItem analysis.DriftItem, apply bool) (FixFileResult, error) {
+	path, err := resolveSourceFilePath(cfg.Workspace.RootPath, remediation.SourceRef)
+	if err != nil {
+		return FixFileResult{}, err
+	}
+	bodyBytes, err := os.ReadFile(path)
+	if err != nil {
+		return FixFileResult{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	body := string(bodyBytes)
+
+	edits, warnings := planFixEdits(body, remediation, driftItem)
+	fileResult := FixFileResult{
+		DocRef:             remediation.DocRef,
+		SourceRef:          remediation.SourceRef,
+		Path:               filepath.ToSlash(path),
+		Status:             "planned",
+		Warnings:           warnings,
+		originalContent:    body,
+		originalContentSum: contentChecksum(body),
+	}
+
+	if len(edits) == 0 {
+		fileResult.Status = "skipped"
+		fileResult.Reason = "No deterministic replace-claim edits could be planned for this file."
+		return fileResult, nil
+	}
+
+	fileResult.Edits = make([]FixEdit, 0, len(edits))
+	for _, edit := range edits {
+		fileResult.Edits = append(fileResult.Edits, edit.FixEdit)
+	}
+
+	if !apply {
+		return fileResult, nil
+	}
+
+	if err := applyFixEdits(path, body, fileResult.originalContentSum, edits); err != nil {
+		fileResult.Status = "skipped"
+		fileResult.Reason = err.Error()
+		return fileResult, nil
+	}
+	fileResult.Status = "applied"
+	return fileResult, nil
+}
+
+func resolveSourceFilePath(workspaceRoot, sourceRef string) (string, error) {
+	relative := strings.TrimSpace(strings.TrimPrefix(sourceRef, "file://"))
+	if relative == "" {
+		return "", fmt.Errorf("source_ref is empty")
+	}
+	return filepath.Join(workspaceRoot, filepath.FromSlash(relative)), nil
+}
+
+func planFixEdits(body string, remediation analysis.DocRemediationItem, driftItem analysis.DriftItem) ([]plannedFixEdit, []string) {
+	findingsByKey := make(map[string]analysis.DriftFinding, len(driftItem.Findings))
+	for _, finding := range driftItem.Findings {
+		findingsByKey[fixSuggestionKey(finding.SpecRef, finding.Code)] = finding
+	}
+
+	edits := make([]plannedFixEdit, 0, len(remediation.Suggestions))
+	warnings := make([]string, 0)
+	for _, suggestion := range remediation.Suggestions {
+		finding, ok := findingsByKey[fixSuggestionKey(suggestion.SpecRef, suggestion.Code)]
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("Skipping %s: matching drift finding is unavailable.", suggestion.Code))
+			continue
+		}
+		edit, warning := planFixEdit(body, suggestion, finding)
+		if warning != "" {
+			warnings = append(warnings, warning)
+			continue
+		}
+		edits = append(edits, *edit)
+	}
+
+	sort.Slice(edits, func(i, j int) bool {
+		return edits[i].start < edits[j].start
+	})
+	for i := 1; i < len(edits); i++ {
+		if edits[i].start < edits[i-1].end {
+			return nil, []string{"Skipping file because planned edits overlap."}
+		}
+	}
+	return edits, warnings
+}
+
+func planFixEdit(body string, suggestion analysis.DocRemediationSuggestion, finding analysis.DriftFinding) (*plannedFixEdit, string) {
+	if suggestion.SuggestedEdit.Action != "replace_claim" || suggestion.SuggestedEdit.Replace == "" || suggestion.SuggestedEdit.With == "" {
+		return nil, fmt.Sprintf("Skipping %s: remediation requires a manual section rewrite.", suggestion.Code)
+	}
+
+	start, end, replace, with, ok := locateFixSpan(body, suggestion, finding)
+	if !ok {
+		return nil, fmt.Sprintf("Skipping %s: replacement text is ambiguous or no longer present in the file.", suggestion.Code)
+	}
+
+	line := 1 + strings.Count(body[:start], "\n")
+	return &plannedFixEdit{
+		FixEdit: FixEdit{
+			Code:      suggestion.Code,
+			Summary:   suggestion.Summary,
+			Action:    suggestion.SuggestedEdit.Action,
+			Replace:   replace,
+			With:      with,
+			Line:      line,
+			StartByte: start,
+			EndByte:   end,
+			Before:    replace,
+			After:     with,
+		},
+		start: start,
+		end:   end,
+	}, ""
+}
+
+func locateFixSpan(body string, suggestion analysis.DocRemediationSuggestion, finding analysis.DriftFinding) (int, int, string, string, bool) {
+	if start, end, matched, ok := uniqueMatch(body, suggestion.SuggestedEdit.Replace); ok {
+		return start, end, matched, suggestion.SuggestedEdit.With, true
+	}
+
+	excerpt := strings.TrimSpace(suggestion.Evidence.DocExcerpt)
+	if excerpt == "" {
+		return 0, 0, "", "", false
+	}
+	excerptStart, _, excerptMatched, ok := uniqueMatch(body, excerpt)
+	if !ok {
+		return 0, 0, "", "", false
+	}
+
+	replace, with, ok := fallbackFixReplacement(excerptMatched, suggestion, finding)
+	if !ok {
+		return 0, 0, "", "", false
+	}
+	innerStart, _, matched, ok := uniqueMatch(excerptMatched, replace)
+	if !ok {
+		return 0, 0, "", "", false
+	}
+	return excerptStart + innerStart, excerptStart + innerStart + len(matched), matched, with, true
+}
+
+func fallbackFixReplacement(excerpt string, suggestion analysis.DocRemediationSuggestion, finding analysis.DriftFinding) (string, string, bool) {
+	switch finding.Code {
+	case "default_limit_mismatch":
+		if matched, ok := matchObservedVariant(excerpt, finding.Observed); ok {
+			return matched, strings.TrimSpace(finding.Expected), true
+		}
+	case "window_mismatch":
+		if matched, ok := matchObservedVariant(excerpt, finding.Observed); ok {
+			return matched, strings.TrimSpace(finding.Expected), true
+		}
+	case "subject_mismatch":
+		switch finding.Observed {
+		case "api_key":
+			if matched, ok := matchObservedVariant(excerpt, "per API key"); ok {
+				return matched, "per tenant", true
+			}
+			if matched, ok := matchObservedVariant(excerpt, "API key"); ok {
+				return matched, "tenant", true
+			}
+			if matched, ok := matchObservedVariant(excerpt, "API-key"); ok {
+				return matched, "tenant", true
+			}
+		}
+	case "override_support_mismatch":
+		if _, _, matched, ok := uniqueMatch(excerpt, suggestion.SuggestedEdit.Replace); ok {
+			return matched, suggestion.SuggestedEdit.With, true
+		}
+	}
+	return "", "", false
+}
+
+func matchObservedVariant(text, observed string) (string, bool) {
+	switch observed {
+	case "100", "200":
+		return uniqueObservedToken(text, observed)
+	case "fixed-window":
+		if matched, ok := uniqueObservedToken(text, "fixed-window"); ok {
+			return matched, true
+		}
+		return uniqueObservedToken(text, "fixed window")
+	case "sliding-window":
+		if matched, ok := uniqueObservedToken(text, "sliding-window"); ok {
+			return matched, true
+		}
+		return uniqueObservedToken(text, "sliding window")
+	case "api_key":
+		if matched, ok := uniqueObservedToken(text, "API key"); ok {
+			return matched, true
+		}
+		if matched, ok := uniqueObservedToken(text, "API-key"); ok {
+			return matched, true
+		}
+		return uniqueObservedToken(text, "per API key")
+	case "tenant":
+		if matched, ok := uniqueObservedToken(text, "tenant"); ok {
+			return matched, true
+		}
+		return uniqueObservedToken(text, "per tenant")
+	default:
+		return uniqueObservedToken(text, observed)
+	}
+}
+
+func uniqueObservedToken(text, token string) (string, bool) {
+	_, _, matched, ok := uniqueMatch(text, token)
+	return matched, ok
+}
+
+func uniqueMatch(text, needle string) (int, int, string, bool) {
+	needle = strings.TrimSpace(needle)
+	if needle == "" {
+		return 0, 0, "", false
+	}
+	indices := allMatchIndicesFold(text, needle)
+	if len(indices) != 1 {
+		return 0, 0, "", false
+	}
+	start := indices[0]
+	end := start + len(needle)
+	return start, end, text[start:end], true
+}
+
+func allMatchIndicesFold(text, needle string) []int {
+	lowerText := strings.ToLower(text)
+	lowerNeedle := strings.ToLower(needle)
+	var result []int
+	offset := 0
+	for {
+		index := strings.Index(lowerText[offset:], lowerNeedle)
+		if index < 0 {
+			break
+		}
+		start := offset + index
+		result = append(result, start)
+		offset = start + len(lowerNeedle)
+	}
+	return result
+}
+
+func applyFixEdits(path, expectedContent, expectedChecksum string, edits []plannedFixEdit) error {
+	currentBytes, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s before apply: %w", path, err)
+	}
+	current := string(currentBytes)
+	if contentChecksum(current) != expectedChecksum || current != expectedContent {
+		return fmt.Errorf("%s changed since fix planning; rerun `pituitary fix` against a fresh index", filepath.ToSlash(path))
+	}
+
+	updated := current
+	for i := len(edits) - 1; i >= 0; i-- {
+		edit := edits[i]
+		updated = updated[:edit.start] + edit.With + updated[edit.end:]
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s before apply: %w", path, err)
+	}
+	tempFile, err := os.CreateTemp(filepath.Dir(path), ".pituitary-fix-*")
+	if err != nil {
+		return fmt.Errorf("create temp file for %s: %w", path, err)
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
+
+	if _, err := tempFile.WriteString(updated); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("write temp file for %s: %w", path, err)
+	}
+	if err := tempFile.Chmod(info.Mode()); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("chmod temp file for %s: %w", path, err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close temp file for %s: %w", path, err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	return nil
+}
+
+func contentChecksum(body string) string {
+	sum := sha256.Sum256([]byte(body))
+	return hex.EncodeToString(sum[:])
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func fixSuggestionKey(specRef, code string) string {
+	return specRef + "\x00" + code
+}
+
+func isFixNotFound(err error) bool {
+	var target *fixNotFoundError
+	return errors.As(err, &target)
+}

--- a/internal/app/fix_test.go
+++ b/internal/app/fix_test.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFixDocDriftPlansDeterministicEdits(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeOperationWorkspace(t, false)
+	operation := FixDocDrift(context.Background(), configPath, FixRequest{
+		Path: "docs/guides/api-rate-limits.md",
+	})
+	if operation.Issue != nil {
+		t.Fatalf("FixDocDrift() issue = %+v, want nil", operation.Issue)
+	}
+	if operation.Result == nil {
+		t.Fatal("FixDocDrift() result = nil, want structured result")
+	}
+	if operation.Result.Applied {
+		t.Fatal("FixDocDrift() result.applied = true, want false")
+	}
+	if got, want := operation.Result.PlannedFileCount, 1; got != want {
+		t.Fatalf("planned_file_count = %d, want %d", got, want)
+	}
+	if operation.Result.PlannedEditCount < 3 {
+		t.Fatalf("planned_edit_count = %d, want at least 3", operation.Result.PlannedEditCount)
+	}
+	if len(operation.Result.Files) != 1 {
+		t.Fatalf("files = %+v, want one file", operation.Result.Files)
+	}
+	file := operation.Result.Files[0]
+	if got, want := file.DocRef, "doc://guides/api-rate-limits"; got != want {
+		t.Fatalf("file.doc_ref = %q, want %q", got, want)
+	}
+	if file.Status != "planned" {
+		t.Fatalf("file.status = %q, want planned", file.Status)
+	}
+	if len(file.Edits) < 3 {
+		t.Fatalf("file.edits = %+v, want multiple edits", file.Edits)
+	}
+	if len(operation.Result.Guidance) == 0 || !strings.Contains(operation.Result.Guidance[0], "--yes") {
+		t.Fatalf("guidance = %v, want apply guidance", operation.Result.Guidance)
+	}
+}
+
+func TestFixDocDriftAppliesEditsAndMarksIndexStale(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeOperationWorkspace(t, false)
+	operation := FixDocDrift(context.Background(), configPath, FixRequest{
+		Path:  "docs/guides/api-rate-limits.md",
+		Apply: true,
+	})
+	if operation.Issue != nil {
+		t.Fatalf("FixDocDrift() issue = %+v, want nil", operation.Issue)
+	}
+	if operation.Result == nil {
+		t.Fatal("FixDocDrift() result = nil, want structured result")
+	}
+	if !operation.Result.Applied {
+		t.Fatal("FixDocDrift() result.applied = false, want true")
+	}
+	if got, want := operation.Result.AppliedFileCount, 1; got != want {
+		t.Fatalf("applied_file_count = %d, want %d", got, want)
+	}
+	if operation.Result.AppliedEditCount < 3 {
+		t.Fatalf("applied_edit_count = %d, want at least 3", operation.Result.AppliedEditCount)
+	}
+	if len(operation.Result.Guidance) == 0 || !strings.Contains(operation.Result.Guidance[0], "pituitary index --rebuild") {
+		t.Fatalf("guidance = %v, want rebuild guidance", operation.Result.Guidance)
+	}
+
+	guidePath := filepath.Join(filepath.Dir(configPath), "docs", "guides", "api-rate-limits.md")
+	updatedBytes, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	updated := string(updatedBytes)
+	for _, want := range []string{
+		"sliding-window rate limiter",
+		"200 requests per minute",
+		"tenant-specific overrides are supported through configuration",
+	} {
+		if !strings.Contains(updated, want) {
+			t.Fatalf("updated guide %q does not contain %q", updated, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add pituitary fix to preview and apply deterministic check-doc-drift remediations
- keep planning and apply logic in internal/app with fresh-index checks and safe writes
- document the new command and lock it down with command and app tests

Closes #135