### PR TITLE
Update install docs for public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tar xzf pituitary_*_*.tar.gz
 sudo install pituitary /usr/local/bin/
 ```
 
-**Windows**: download the `.zip` from [GitHub Releases](https://github.com/dusk-network/pituitary/releases), extract `pituitary.exe`, and add its location to your PATH.
+**Windows**: download `pituitary_<version>_windows_amd64.zip` from [GitHub Releases](https://github.com/dusk-network/pituitary/releases), extract `pituitary.exe`, and add its location to your PATH.
 
 **Build from source** (contributors): see [docs/development/prerequisites.md](docs/development/prerequisites.md).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,15 +21,15 @@ If you prefer a user-level install: `install pituitary ~/.local/bin/` (make sure
 
 ## Windows
 
-Download the `.zip` from [GitHub Releases](https://github.com/dusk-network/pituitary/releases), extract `pituitary.exe`, and add its location to your PATH.
+Download `pituitary_<version>_windows_amd64.zip` from [GitHub Releases](https://github.com/dusk-network/pituitary/releases), extract `pituitary.exe`, and add its location to your PATH.
 
 ## Manual Releases
 
 Prebuilt archives are published on [GitHub Releases](https://github.com/dusk-network/pituitary/releases) for:
 
-- `linux/amd64`
-- `darwin/arm64`
-- `windows/amd64`
+- `pituitary_<version>_linux_amd64.tar.gz`
+- `pituitary_<version>_macOS_arm64.tar.gz`
+- `pituitary_<version>_windows_amd64.zip`
 
 If you need a different platform or want full manual control, download and extract the matching archive from Releases directly.
 


### PR DESCRIPTION
## Summary

Replaces private-repo install paths with public paths, aligning `docs/install.md` with the README. Required before tagging v1.0.0-beta since the repo will be public.

### Changes

- Homebrew: removed `HOMEBREW_GITHUB_API_TOKEN` export (not needed for public repos)
- Install: replaced `gh api` one-liner with `curl` from GitHub Releases (matching README)
- Added explicit Windows section
- Added prerequisites link for build-from-source
- Removed `gh`-dependent installer pinning example

## Test plan

- [x] `python3 scripts/check-doc-links.py docs/install.md` — OK
- [x] Install commands match README exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)