### PR TITLE
Add Smithery and MCPB configs for MCP registry distribution

### DIFF
--- a/.mcpb/manifest.json
+++ b/.mcpb/manifest.json
@@ -1,11 +1,11 @@
 {
   "name": "io.github.dusk-network/pituitary",
-  "version": "1.0.0-beta",
+  "version": "0.0.0-dev",
   "description": "Catch spec drift before it catches you. Indexes your specs, docs, and decision records, then detects overlap, contradictions, stale docs, and code that drifts from what was decided.",
   "server": {
     "type": "binary",
     "command": "pituitary",
-    "args": ["serve", "--config", ".pituitary/pituitary.toml"],
+    "args": ["serve"],
     "transport": "stdio"
   },
   "tools": [

--- a/.mcpb/manifest.json
+++ b/.mcpb/manifest.json
@@ -1,0 +1,44 @@
+{
+  "name": "io.github.dusk-network/pituitary",
+  "version": "1.0.0-beta",
+  "description": "Catch spec drift before it catches you. Indexes your specs, docs, and decision records, then detects overlap, contradictions, stale docs, and code that drifts from what was decided.",
+  "server": {
+    "type": "binary",
+    "command": "pituitary",
+    "args": ["serve", "--config", ".pituitary/pituitary.toml"],
+    "transport": "stdio"
+  },
+  "tools": [
+    {
+      "name": "search_specs",
+      "description": "Semantic search across indexed spec sections. Filter by domain and status."
+    },
+    {
+      "name": "check_overlap",
+      "description": "Detect specs that cover overlapping ground. Returns similarity scores and relationship classification."
+    },
+    {
+      "name": "compare_specs",
+      "description": "Side-by-side tradeoff analysis of two specs."
+    },
+    {
+      "name": "analyze_impact",
+      "description": "Trace which specs, code refs, and docs are affected when a spec changes."
+    },
+    {
+      "name": "check_doc_drift",
+      "description": "Find docs that have gone stale relative to accepted specs, with cited evidence."
+    },
+    {
+      "name": "review_spec",
+      "description": "Full composite review: overlap + comparison + impact + drift + remediation."
+    }
+  ],
+  "repository": "https://github.com/dusk-network/pituitary",
+  "license": "MIT",
+  "platforms": [
+    "linux/amd64",
+    "darwin/arm64",
+    "windows/amd64"
+  ]
+}

--- a/Dockerfile.smithery
+++ b/Dockerfile.smithery
@@ -1,0 +1,24 @@
+# Runtime Dockerfile for Smithery MCP server distribution
+# Builds the pituitary binary and serves it over stdio.
+
+FROM golang:1.25-bookworm AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential libsqlite3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=1 go build -trimpath -o /usr/local/bin/pituitary .
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libsqlite3-0 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/pituitary /usr/local/bin/pituitary
+
+ENTRYPOINT ["pituitary"]

--- a/Dockerfile.smithery
+++ b/Dockerfile.smithery
@@ -1,7 +1,9 @@
 # Runtime Dockerfile for Smithery MCP server distribution
 # Builds the pituitary binary and serves it over stdio.
 
-FROM golang:1.25-bookworm AS builder
+# Use latest stable Go. The go.mod language version directive
+# ensures the correct language features are available.
+FROM golang:1.24-bookworm AS builder
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential libsqlite3-dev && \
@@ -22,3 +24,4 @@ RUN apt-get update && \
 COPY --from=builder /usr/local/bin/pituitary /usr/local/bin/pituitary
 
 ENTRYPOINT ["pituitary"]
+CMD ["serve"]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,22 @@
+# Smithery.ai MCP server configuration
+# See: https://smithery.ai/docs
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      configPath:
+        type: string
+        description: "Path to pituitary.toml config file"
+        default: ".pituitary/pituitary.toml"
+    required: []
+  commandFunction: |-
+    (config) => ({
+      command: "pituitary",
+      args: ["serve", "--config", config.configPath || ".pituitary/pituitary.toml"]
+    })
+
+build:
+  dockerfile: Dockerfile.smithery
+  dockerBuildContext: .

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -12,10 +12,16 @@ startCommand:
         default: ".pituitary/pituitary.toml"
     required: []
   commandFunction: |-
-    (config) => ({
-      command: "pituitary",
-      args: ["serve", "--config", config.configPath || ".pituitary/pituitary.toml"]
-    })
+    (config) => {
+      const args = ["serve"];
+      if (config.configPath) {
+        args.push("--config", config.configPath);
+      }
+      return {
+        command: "pituitary",
+        args,
+      };
+    }
 
 build:
   dockerfile: Dockerfile.smithery


### PR DESCRIPTION
## Summary

Adds configuration files for distributing Pituitary on two MCP registries.

### Smithery.ai

- `smithery.yaml` with stdio transport config and configurable path
- `Dockerfile.smithery` multi-stage build (separate from contributor Dockerfile)
- Next step: `smithery mcp publish` once Smithery CLI is installed

### Official MCP Registry (registry.modelcontextprotocol.io)

- `.mcpb/manifest.json` declaring binary server type, 6 tools, 3 platforms
- The official registry supports Go binaries via the MCPB bundle format
- Next step: use `mcpb-pack` GitHub Action or `mcp-publisher` CLI to publish

### Already submitted

- mcp.so: listing submitted manually

## Test plan

- [x] No code changes, config files only
- [ ] Test Smithery build: `docker build -f Dockerfile.smithery .`
- [ ] Verify MCPB manifest schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)