### PR TITLE
Handle duplicate refs during init discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ IMPLEMENTATION_BACKLOG.md
 docs/superpowers/
 .mcpregistry_*
 .smithery/
+.ccd.toml

--- a/cmd/discover_test.go
+++ b/cmd/discover_test.go
@@ -67,6 +67,65 @@ func TestRunDiscoverJSON(t *testing.T) {
 	}
 }
 
+func TestRunDiscoverJSONWarnsAndSkipsConflictingMarkdownRefs(t *testing.T) {
+	repo := writeDiscoveryWorkspace(t)
+	mustWriteFileCmd(t, filepath.Join(repo, "rfcs", "primary.md"), `
+# Primary Contract
+
+Ref: DUPE-001
+Status: draft
+Domain: api
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "notes.md"), `
+# Root Proposal
+
+Ref: DUPE-001
+Status: draft
+Domain: api
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runDiscover([]string{"--path", ".", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runDiscover() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runDiscover() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Config string `json:"config"`
+		} `json:"result"`
+		Warnings []cliIssue `json:"warnings"`
+		Errors   []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal discover payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if got, want := len(payload.Warnings), 1; got != want {
+		t.Fatalf("warning count = %d, want %d", got, want)
+	}
+	if got, want := payload.Warnings[0].Code, "duplicate_spec_ref_skipped"; got != want {
+		t.Fatalf("warning code = %q, want %q", got, want)
+	}
+	if got, want := payload.Warnings[0].Path, "notes.md"; got != want {
+		t.Fatalf("warning path = %q, want %q", got, want)
+	}
+	if !strings.Contains(payload.Result.Config, "primary.md") {
+		t.Fatalf("generated config %q does not include kept contract path", payload.Result.Config)
+	}
+	if strings.Contains(payload.Result.Config, "notes.md") {
+		t.Fatalf("generated config %q unexpectedly includes skipped contract path", payload.Result.Config)
+	}
+}
+
 func TestRunDiscoverWriteProducesUsableLocalConfig(t *testing.T) {
 	repo := writeDiscoveryWorkspace(t)
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -129,39 +129,61 @@ func TestRunInitReportsFixtureGuidanceForLargerCorpus(t *testing.T) {
 	}
 }
 
-func TestRunInitDoesNotWriteConfigOnSourceLoadFailure(t *testing.T) {
+func TestRunInitSkipsConflictingDiscoveredRefs(t *testing.T) {
 	repo := writeDiscoveryWorkspace(t)
 
-	// Create two markdown contracts with the same Ref: line to trigger
-	// a duplicate spec ref error during source loading.
-	conflictDir := filepath.Join(repo, "rfcs")
-	mustMkdirAllCmd(t, conflictDir)
-	mustWriteFileCmd(t, filepath.Join(conflictDir, "a.md"), "# Proposal A\n\nRef: DUPE-001\nStatus: draft\n\nFirst proposal.\n")
-	mustWriteFileCmd(t, filepath.Join(conflictDir, "b.md"), "# Proposal B\n\nRef: DUPE-001\nStatus: draft\n\nSecond proposal with same ref.\n")
+	mustWriteFileCmd(t, filepath.Join(repo, "rfcs", "primary.md"), `
+# Primary Contract
+
+Ref: DUPE-001
+Status: draft
+Domain: api
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "notes.md"), `
+# Root Proposal
+
+Ref: DUPE-001
+Status: draft
+Domain: api
+`)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	exitCode := withWorkingDir(t, repo, func() int {
 		return runInit([]string{"--path", "."}, &stdout, &stderr)
 	})
-	if exitCode != 2 {
-		t.Fatalf("runInit() exit code = %d, want 2", exitCode)
+	if exitCode != 0 {
+		t.Fatalf("runInit() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
 	}
 
-	// The config file must NOT have been written.
 	configPath := filepath.Join(repo, ".pituitary", "pituitary.toml")
-	if _, err := os.Stat(configPath); err == nil {
-		t.Fatalf("config was written at %s despite source load failure; user would be trapped", configPath)
-	} else if !os.IsNotExist(err) {
-		t.Fatalf("unexpected error checking config path: %v", err)
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("config missing after init: %v", err)
+	}
+
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	configText := string(configBytes)
+	if !strings.Contains(configText, "primary.md") {
+		t.Fatalf("generated config %q does not include kept contract path", configText)
+	}
+	if strings.Contains(configText, "notes.md") {
+		t.Fatalf("generated config %q unexpectedly includes skipped contract path", configText)
 	}
 
 	errOutput := stderr.String()
-	if !strings.Contains(errOutput, "duplicate spec ref") {
-		t.Fatalf("runInit() stderr %q does not mention duplicate spec ref", errOutput)
+	if !strings.Contains(errOutput, "warning: skipped notes.md during discovery") {
+		t.Fatalf("runInit() stderr %q does not contain duplicate-ref warning", errOutput)
 	}
-	if !strings.Contains(errOutput, "config was not written") {
-		t.Fatalf("runInit() stderr %q does not mention config was not written", errOutput)
+	if strings.Contains(errOutput, "source load failed") {
+		t.Fatalf("runInit() stderr %q unexpectedly reports source load failure", errOutput)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "index: 3 specs · 3 docs") {
+		t.Fatalf("runInit() output %q does not report the deduplicated index counts", output)
 	}
 }
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/dusk-network/pituitary/internal/analysis"
+	"github.com/dusk-network/pituitary/internal/source"
 )
 
 type cliIssue struct {
@@ -116,6 +117,13 @@ func writeCLIJSON(w io.Writer, payload cliEnvelope) int {
 
 func cliWarningsForResult(result any) []cliIssue {
 	switch typed := result.(type) {
+	case *source.DiscoverResult:
+		return discoverWarningsToCLIIssues(typed.Warnings)
+	case *initResult:
+		if typed.Discover == nil {
+			return nil
+		}
+		return discoverWarningsToCLIIssues(typed.Discover.Warnings)
 	case *analysis.AnalyzeImpactResult:
 		return warningsToCLIIssues(typed.Warnings)
 	case *analysis.TerminologyAuditResult:
@@ -127,6 +135,21 @@ func cliWarningsForResult(result any) []cliIssue {
 	default:
 		return nil
 	}
+}
+
+func discoverWarningsToCLIIssues(warnings []source.DiscoverWarning) []cliIssue {
+	if len(warnings) == 0 {
+		return nil
+	}
+	issues := make([]cliIssue, 0, len(warnings))
+	for _, warning := range warnings {
+		issues = append(issues, cliIssue{
+			Code:    warning.Code,
+			Message: warning.Message,
+			Path:    warning.SkippedPath,
+		})
+	}
+	return issues
 }
 
 func warningsToCLIIssues(warnings []analysis.Warning) []cliIssue {

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/dusk-network/pituitary/internal/config"
 )
@@ -31,6 +32,18 @@ type DiscoverResult struct {
 	Config        string             `json:"config"`
 	Sources       []DiscoveredSource `json:"sources"`
 	Preview       *PreviewResult     `json:"preview,omitempty"`
+	Warnings      []DiscoverWarning  `json:"warnings,omitempty"`
+}
+
+// DiscoverWarning reports non-fatal discovery decisions that changed the
+// generated source selection.
+type DiscoverWarning struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Ref         string `json:"ref,omitempty"`
+	KeptPath    string `json:"kept_path,omitempty"`
+	SkippedPath string `json:"skipped_path,omitempty"`
+	Reason      string `json:"reason,omitempty"`
 }
 
 // DiscoveredSource describes one proposed source block and the items behind it.
@@ -54,10 +67,14 @@ type DiscoveredItem struct {
 }
 
 type discoveredCandidate struct {
-	path       string
-	confidence string
-	score      int
-	rationale  []string
+	path        string
+	kind        string
+	ref         string
+	contentHash string
+	confidence  string
+	score       int
+	modifiedAt  time.Time
+	rationale   []string
 }
 
 // DiscoverWorkspace scans one repo-like directory and proposes a starting
@@ -88,6 +105,7 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	specCandidates, contractCandidates, warnings := dedupeDiscoveredSpecCandidates(specCandidates, contractCandidates)
 
 	sources := buildDiscoveredSources(workspaceRoot, specCandidates, contractCandidates, docCandidates)
 	if len(sources) == 0 {
@@ -113,6 +131,7 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 		Config:        configText,
 		Sources:       sources,
 		Preview:       preview,
+		Warnings:      warnings,
 	}
 
 	if options.Write {
@@ -163,11 +182,23 @@ func discoverSpecBundleCandidates(workspaceRoot string) ([]discoveredCandidate, 
 			return nil
 		}
 		bundleDirs[bundleDir] = struct{}{}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("inspect discovered spec bundle %q: %w", workspaceRelative(workspaceRoot, bundleDir), err)
+		}
+		ref, contentHash, err := discoverSpecBundleIdentity(bundleDir)
+		if err != nil {
+			return err
+		}
 		candidates = append(candidates, discoveredCandidate{
-			path:       workspaceRelative(workspaceRoot, path),
-			confidence: "high",
-			score:      100,
-			rationale:  rationale,
+			path:        workspaceRelative(workspaceRoot, path),
+			kind:        config.SourceKindSpecBundle,
+			ref:         ref,
+			contentHash: contentHash,
+			confidence:  "high",
+			score:       100,
+			modifiedAt:  info.ModTime(),
+			rationale:   rationale,
 		})
 		return nil
 	})
@@ -177,6 +208,24 @@ func discoverSpecBundleCandidates(workspaceRoot string) ([]discoveredCandidate, 
 
 	sortDiscoveredCandidates(candidates)
 	return candidates, bundleDirs, nil
+}
+
+func discoverSpecBundleIdentity(bundleDir string) (string, string, error) {
+	specPath := filepath.Join(bundleDir, "spec.toml")
+	specBytes, err := os.ReadFile(specPath)
+	if err != nil {
+		return "", "", fmt.Errorf("read discovered spec bundle %q: %w", filepath.ToSlash(bundleDir), err)
+	}
+	raw, err := parseSpecBundle(specBytes)
+	if err != nil {
+		return "", "", fmt.Errorf("parse discovered spec bundle %q: %w", filepath.ToSlash(specPath), err)
+	}
+	bodyPath := filepath.Clean(filepath.Join(bundleDir, raw.Body))
+	bodyBytes, err := os.ReadFile(bodyPath)
+	if err != nil {
+		return "", "", fmt.Errorf("read discovered spec body %q: %w", filepath.ToSlash(bodyPath), err)
+	}
+	return raw.ID, joinedContentHash(specBytes, bodyBytes), nil
 }
 
 func isValidDiscoveredSpecBundle(workspaceRoot, bundleDir string) (bool, []string) {
@@ -229,7 +278,10 @@ func discoverMarkdownCandidates(workspaceRoot string, specBundleDirs map[string]
 			return nil
 		}
 
-		kind, candidate, ok := classifyMarkdownCandidate(workspaceRoot, path)
+		kind, candidate, ok, err := classifyMarkdownCandidate(workspaceRoot, path)
+		if err != nil {
+			return err
+		}
 		if !ok {
 			return nil
 		}
@@ -249,10 +301,14 @@ func discoverMarkdownCandidates(workspaceRoot string, specBundleDirs map[string]
 	return contractCandidates, docCandidates, nil
 }
 
-func classifyMarkdownCandidate(workspaceRoot, path string) (string, discoveredCandidate, bool) {
+func classifyMarkdownCandidate(workspaceRoot, path string) (string, discoveredCandidate, bool, error) {
 	body, err := os.ReadFile(path)
 	if err != nil {
-		return "", discoveredCandidate{}, false
+		return "", discoveredCandidate{}, false, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", discoveredCandidate{}, false, nil
 	}
 
 	relPath := workspaceRelative(workspaceRoot, path)
@@ -274,21 +330,132 @@ func classifyMarkdownCandidate(workspaceRoot, path string) (string, discoveredCa
 
 	switch {
 	case contractScore >= 3 && contractScore >= docScore+1:
+		ref, contentHash, err := discoverMarkdownContractIdentity(workspaceRoot, path, body)
+		if err != nil {
+			return "", discoveredCandidate{}, false, err
+		}
 		return config.SourceKindMarkdownContract, discoveredCandidate{
-			path:       relPath,
-			confidence: discoveryConfidence(contractScore),
-			score:      contractScore,
-			rationale:  contractReasons,
-		}, true
+			path:        relPath,
+			kind:        config.SourceKindMarkdownContract,
+			ref:         ref,
+			contentHash: contentHash,
+			confidence:  discoveryConfidence(contractScore),
+			score:       contractScore,
+			modifiedAt:  info.ModTime(),
+			rationale:   contractReasons,
+		}, true, nil
 	case docScore >= 2:
 		return config.SourceKindMarkdownDocs, discoveredCandidate{
 			path:       relPath,
+			kind:       config.SourceKindMarkdownDocs,
 			confidence: discoveryConfidence(docScore),
 			score:      docScore,
+			modifiedAt: info.ModTime(),
 			rationale:  docReasons,
-		}, true
+		}, true, nil
 	default:
-		return "", discoveredCandidate{}, false
+		return "", discoveredCandidate{}, false, nil
+	}
+}
+
+func discoverMarkdownContractIdentity(workspaceRoot, path string, body []byte) (string, string, error) {
+	fields := inferMarkdownContractFields(body)
+	ref := strings.TrimSpace(fields.Ref)
+	if ref == "" {
+		var err error
+		ref, err = markdownContractRefForPath(workspaceRoot, path)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	return ref, contentHash(body), nil
+}
+
+func dedupeDiscoveredSpecCandidates(specs, contracts []discoveredCandidate) ([]discoveredCandidate, []discoveredCandidate, []DiscoverWarning) {
+	all := append(append([]discoveredCandidate(nil), specs...), contracts...)
+	if len(all) == 0 {
+		return nil, nil, nil
+	}
+
+	groups := make(map[string][]discoveredCandidate)
+	var passthrough []discoveredCandidate
+	for _, candidate := range all {
+		ref := strings.TrimSpace(candidate.ref)
+		if ref == "" {
+			passthrough = append(passthrough, candidate)
+			continue
+		}
+		groups[ref] = append(groups[ref], candidate)
+	}
+
+	refs := make([]string, 0, len(groups))
+	for ref := range groups {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+
+	deduped := append([]discoveredCandidate(nil), passthrough...)
+	var warnings []DiscoverWarning
+	for _, ref := range refs {
+		group := groups[ref]
+		preferred := group[0]
+		for _, candidate := range group[1:] {
+			if prefersDiscoveredCandidate(candidate, preferred) {
+				preferred = candidate
+			}
+		}
+		deduped = append(deduped, preferred)
+		for _, candidate := range group {
+			if candidate.path == preferred.path {
+				continue
+			}
+			if candidate.contentHash != "" && preferred.contentHash != "" && candidate.contentHash == preferred.contentHash {
+				continue
+			}
+			reason := discoverConflictPreferenceReason(preferred, candidate)
+			warnings = append(warnings, DiscoverWarning{
+				Code:        "duplicate_spec_ref_skipped",
+				Message:     fmt.Sprintf("skipped %s during discovery: ref %q conflicts with %s; kept %s (%s)", candidate.path, ref, preferred.path, preferred.path, reason),
+				Ref:         ref,
+				KeptPath:    preferred.path,
+				SkippedPath: candidate.path,
+				Reason:      reason,
+			})
+		}
+	}
+
+	sortDiscoveredCandidates(deduped)
+	var dedupedSpecs []discoveredCandidate
+	var dedupedContracts []discoveredCandidate
+	for _, candidate := range deduped {
+		switch candidate.kind {
+		case config.SourceKindSpecBundle:
+			dedupedSpecs = append(dedupedSpecs, candidate)
+		case config.SourceKindMarkdownContract:
+			dedupedContracts = append(dedupedContracts, candidate)
+		}
+	}
+	return dedupedSpecs, dedupedContracts, warnings
+}
+
+func prefersDiscoveredCandidate(left, right discoveredCandidate) bool {
+	if left.score != right.score {
+		return left.score > right.score
+	}
+	if !left.modifiedAt.Equal(right.modifiedAt) {
+		return left.modifiedAt.After(right.modifiedAt)
+	}
+	return left.path < right.path
+}
+
+func discoverConflictPreferenceReason(preferred, skipped discoveredCandidate) string {
+	switch {
+	case preferred.score != skipped.score:
+		return "higher discovery score"
+	case !preferred.modifiedAt.Equal(skipped.modifiedAt):
+		return "newer file"
+	default:
+		return "stable path tie-breaker"
 	}
 }
 

--- a/internal/source/discover_test.go
+++ b/internal/source/discover_test.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dusk-network/pituitary/internal/config"
@@ -185,5 +186,94 @@ func TestDiscoverDetectsIntentArtifacts(t *testing.T) {
 		if !projectItems[name] {
 			t.Errorf("expected %s to be in project-docs source, got items: %v", name, projectItems)
 		}
+	}
+}
+
+func TestDiscoverWorkspaceSkipsConflictingMarkdownContractRefs(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "rfcs", "primary.md"), `
+# Primary Contract
+
+Ref: DUPE-001
+Status: draft
+Domain: api
+`)
+	mustWriteFile(t, filepath.Join(repo, "notes.md"), `
+# Root Proposal
+
+Ref: DUPE-001
+Status: draft
+Domain: api
+`)
+
+	result, err := DiscoverWorkspace(DiscoverOptions{RootPath: repo})
+	if err != nil {
+		t.Fatalf("DiscoverWorkspace() error = %v", err)
+	}
+
+	if got, want := len(result.Warnings), 1; got != want {
+		t.Fatalf("warning count = %d, want %d", got, want)
+	}
+	warning := result.Warnings[0]
+	if got, want := warning.Code, "duplicate_spec_ref_skipped"; got != want {
+		t.Fatalf("warning code = %q, want %q", got, want)
+	}
+	if got, want := warning.Ref, "DUPE-001"; got != want {
+		t.Fatalf("warning ref = %q, want %q", got, want)
+	}
+	if got, want := warning.KeptPath, "rfcs/primary.md"; got != want {
+		t.Fatalf("warning kept_path = %q, want %q", got, want)
+	}
+	if got, want := warning.SkippedPath, "notes.md"; got != want {
+		t.Fatalf("warning skipped_path = %q, want %q", got, want)
+	}
+	if got, want := warning.Reason, "higher discovery score"; got != want {
+		t.Fatalf("warning reason = %q, want %q", got, want)
+	}
+	if got, want := len(result.Sources), 1; got != want {
+		t.Fatalf("source count = %d, want %d", got, want)
+	}
+	if got, want := result.Sources[0].ItemCount, 1; got != want {
+		t.Fatalf("contracts item count = %d, want %d", got, want)
+	}
+	if !strings.Contains(result.Config, "primary.md") {
+		t.Fatalf("generated config %q does not include kept contract path", result.Config)
+	}
+	if strings.Contains(result.Config, "notes.md") {
+		t.Fatalf("generated config %q unexpectedly includes skipped contract path", result.Config)
+	}
+}
+
+func TestDiscoverWorkspaceSilentlySkipsTrueDuplicateMarkdownContractRefs(t *testing.T) {
+	repo := t.TempDir()
+	body := `
+# Shared Contract
+
+Ref: DUPE-001
+Status: draft
+Domain: api
+`
+	mustWriteFile(t, filepath.Join(repo, "rfcs", "primary.md"), body)
+	mustWriteFile(t, filepath.Join(repo, "notes.md"), body)
+
+	result, err := DiscoverWorkspace(DiscoverOptions{RootPath: repo})
+	if err != nil {
+		t.Fatalf("DiscoverWorkspace() error = %v", err)
+	}
+
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %+v, want none for same-content duplicates", result.Warnings)
+	}
+	if got, want := len(result.Sources), 1; got != want {
+		t.Fatalf("source count = %d, want %d", got, want)
+	}
+	if got, want := result.Sources[0].ItemCount, 1; got != want {
+		t.Fatalf("contracts item count = %d, want %d", got, want)
+	}
+	if !strings.Contains(result.Config, "primary.md") {
+		t.Fatalf("generated config %q does not include kept contract path", result.Config)
+	}
+	if strings.Contains(result.Config, "notes.md") {
+		t.Fatalf("generated config %q unexpectedly includes skipped duplicate path", result.Config)
 	}
 }


### PR DESCRIPTION
## Summary
- dedupe discovered spec refs before rendering the generated config
- silently skip same-content duplicates and warn when discovery drops a lower-priority conflicting file
- surface discovery warnings in discover/init CLI success output and cover the behavior with regression tests

## Testing
- go test ./internal/source ./cmd
- make ci

Fixes #181