### PR TITLE
Fix Windows path handling

### DIFF
--- a/internal/app/fix.go
+++ b/internal/app/fix.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -69,6 +70,8 @@ type plannedFixEdit struct {
 type fixNotFoundError struct {
 	message string
 }
+
+var fixPathCaseInsensitive = runtime.GOOS == "windows"
 
 func (e *fixNotFoundError) Error() string {
 	if e == nil {
@@ -249,7 +252,11 @@ func normalizeFixPath(workspaceRoot, path string) string {
 			trimmed = rel
 		}
 	}
-	return filepath.ToSlash(filepath.Clean(trimmed))
+	normalized := filepath.ToSlash(filepath.Clean(trimmed))
+	if fixPathCaseInsensitive {
+		return strings.ToLower(normalized)
+	}
+	return normalized
 }
 
 func docRecordsByRef(records []model.DocRecord) map[string]model.DocRecord {

--- a/internal/app/fix_test.go
+++ b/internal/app/fix_test.go
@@ -91,3 +91,27 @@ func TestFixDocDriftAppliesEditsAndMarksIndexStale(t *testing.T) {
 		}
 	}
 }
+
+func TestFixDocDriftMatchesPathCaseInsensitivelyOnWindows(t *testing.T) {
+	t.Parallel()
+
+	previous := fixPathCaseInsensitive
+	fixPathCaseInsensitive = true
+	t.Cleanup(func() {
+		fixPathCaseInsensitive = previous
+	})
+
+	configPath := writeOperationWorkspace(t, false)
+	operation := FixDocDrift(context.Background(), configPath, FixRequest{
+		Path: "DOCS/GUIDES/API-RATE-LIMITS.MD",
+	})
+	if operation.Issue != nil {
+		t.Fatalf("FixDocDrift() issue = %+v, want nil", operation.Issue)
+	}
+	if operation.Result == nil {
+		t.Fatal("FixDocDrift() result = nil, want structured result")
+	}
+	if got, want := operation.Result.PlannedFileCount, 1; got != want {
+		t.Fatalf("planned_file_count = %d, want %d", got, want)
+	}
+}

--- a/internal/index/spec_paths.go
+++ b/internal/index/spec_paths.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -24,6 +25,8 @@ type indexedSpecPathResolver struct {
 	workspaceRoot string
 	refsByPath    map[string][]string
 }
+
+var indexedSpecPathCaseInsensitive = runtime.GOOS == "windows"
 
 type specPathNotFoundError struct {
 	Input      string
@@ -158,8 +161,8 @@ ORDER BY ref ASC`, model.ArtifactKindSpec)
 
 func indexedSpecCandidatePaths(row indexedSpecPathRow) ([]string, error) {
 	candidates := []string{
-		normalizeIndexedSpecPath(row.SourceRef),
-		normalizeIndexedSpecPath(strings.TrimPrefix(strings.TrimSpace(row.SourceRef), "file://")),
+		normalizeIndexedSpecLookupPath(row.SourceRef),
+		normalizeIndexedSpecLookupPath(strings.TrimPrefix(strings.TrimSpace(row.SourceRef), "file://")),
 	}
 
 	var metadata map[string]string
@@ -169,7 +172,7 @@ func indexedSpecCandidatePaths(row indexedSpecPathRow) ([]string, error) {
 		}
 	}
 	for _, key := range []string{"path", "body_path", "bundle_path"} {
-		if value := normalizeIndexedSpecPath(metadata[key]); value != "" {
+		if value := normalizeIndexedSpecLookupPath(metadata[key]); value != "" {
 			candidates = append(candidates, value)
 		}
 	}
@@ -224,7 +227,7 @@ func normalizeSpecSelectorPath(workspaceRoot, rawPath string) (string, error) {
 			WorkspaceRoot: workspaceRoot,
 		}
 	}
-	return normalizeIndexedSpecPath(relPath), nil
+	return normalizeIndexedSpecLookupPath(relPath), nil
 }
 
 func normalizeIndexedSpecPath(path string) string {
@@ -233,6 +236,17 @@ func normalizeIndexedSpecPath(path string) string {
 		return ""
 	}
 	return filepath.ToSlash(filepath.Clean(path))
+}
+
+func normalizeIndexedSpecLookupPath(path string) string {
+	path = normalizeIndexedSpecPath(path)
+	if path == "" {
+		return ""
+	}
+	if indexedSpecPathCaseInsensitive {
+		return strings.ToLower(path)
+	}
+	return path
 }
 
 func pathEscapesRoot(relPath string) bool {

--- a/internal/index/spec_paths_test.go
+++ b/internal/index/spec_paths_test.go
@@ -58,3 +58,30 @@ func TestResolveIndexedSpecRefWithConfigContextClassifiesMissingPath(t *testing.
 		t.Fatalf("ResolveIndexedSpecRefWithConfigContext() error = %v, want classified not-found error", err)
 	}
 }
+
+func TestResolveIndexedSpecRefsWithConfigContextMatchesCaseInsensitivelyOnWindows(t *testing.T) {
+	t.Parallel()
+
+	previous := indexedSpecPathCaseInsensitive
+	indexedSpecPathCaseInsensitive = true
+	t.Cleanup(func() {
+		indexedSpecPathCaseInsensitive = previous
+	})
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	ref, err := ResolveIndexedSpecRefWithConfigContext(context.Background(), cfg, "SPECS/RATE-LIMIT-V2/BODY.MD")
+	if err != nil {
+		t.Fatalf("ResolveIndexedSpecRefWithConfigContext() error = %v", err)
+	}
+	if got, want := ref, "SPEC-042"; got != want {
+		t.Fatalf("resolved ref = %q, want %q", got, want)
+	}
+}

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	sqlitevec "github.com/asg017/sqlite-vec-go-bindings/cgo"
@@ -77,9 +78,13 @@ func OpenReadOnlyContext(ctx context.Context, path string) (*sql.DB, error) {
 }
 
 func sqliteURI(path, mode string) string {
+	normalizedPath := filepath.ToSlash(path)
+	if hasWindowsDrivePrefix(normalizedPath) && !strings.HasPrefix(normalizedPath, "/") {
+		normalizedPath = "/" + normalizedPath
+	}
 	u := url.URL{
 		Scheme: "file",
-		Path:   filepath.ToSlash(path),
+		Path:   normalizedPath,
 	}
 	query := url.Values{}
 	if mode != "" {
@@ -87,6 +92,14 @@ func sqliteURI(path, mode string) string {
 	}
 	u.RawQuery = query.Encode()
 	return u.String()
+}
+
+func hasWindowsDrivePrefix(path string) bool {
+	if len(path) < 2 || path[1] != ':' {
+		return false
+	}
+	drive := path[0]
+	return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
 }
 
 func ensureSQLiteDriver() {

--- a/internal/index/store_test.go
+++ b/internal/index/store_test.go
@@ -6,6 +6,26 @@ import (
 	"testing"
 )
 
+func TestSQLiteURIUsesWindowsSafeDriveLetterForm(t *testing.T) {
+	t.Parallel()
+
+	got := sqliteURI("C:/Users/alice/pituitary.db", "")
+	want := "file:///C:/Users/alice/pituitary.db"
+	if got != want {
+		t.Fatalf("sqliteURI() = %q, want %q", got, want)
+	}
+}
+
+func TestSQLiteURIPreservesModeForWindowsDriveLetterPaths(t *testing.T) {
+	t.Parallel()
+
+	got := sqliteURI("C:/Users/alice/pituitary.db.new", "ro")
+	want := "file:///C:/Users/alice/pituitary.db.new?mode=ro"
+	if got != want {
+		t.Fatalf("sqliteURI() = %q, want %q", got, want)
+	}
+}
+
 func TestCheckSQLiteReadyPasses(t *testing.T) {
 	resetSQLiteReadyForTest(t)
 


### PR DESCRIPTION
## Summary
- emit Windows SQLite file URIs in a safe drive-letter form so init can open the staging DB
- match indexed spec selectors and fix paths case-insensitively on Windows
- add regression coverage for both Windows path behaviors

Closes #183