### PR TITLE
Clean Go analyzer findings

### DIFF
--- a/cmd/check_compliance.go
+++ b/cmd/check_compliance.go
@@ -130,6 +130,7 @@ func loadComplianceDiffFile(path string) (string, error) {
 			return "", fmt.Errorf("read diff from stdin: %w", err)
 		}
 	} else {
+		// #nosec G304 -- path is an explicit CLI diff file supplied by the operator.
 		data, err = os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("read diff file %q: %w", path, err)

--- a/cmd/check_overlap.go
+++ b/cmd/check_overlap.go
@@ -138,6 +138,7 @@ func loadSpecRecordFile(path string) (model.SpecRecord, error) {
 			return model.SpecRecord{}, fmt.Errorf("read spec record from stdin: %w", err)
 		}
 	} else {
+		// #nosec G304 -- path is an explicit CLI spec-record file supplied by the operator.
 		data, err = os.ReadFile(path)
 		if err != nil {
 			return model.SpecRecord{}, fmt.Errorf("read spec record file %q: %w", path, err)

--- a/cmd/config_path.go
+++ b/cmd/config_path.go
@@ -105,18 +105,6 @@ func resolveCommandConfigPathWithResolution(ctx context.Context, localConfigPath
 	)
 }
 
-func resolveCLIConfigPath(explicitPaths ...string) (string, error) {
-	options := make([]configPathOption, 0, len(explicitPaths))
-	for i, explicitPath := range explicitPaths {
-		options = append(options, configPathOption{
-			Source: fmt.Sprintf("explicit_%d", i+1),
-			Path:   explicitPath,
-		})
-	}
-	resolvedPath, _, err := resolveCLIConfigPathWithResolution(options...)
-	return resolvedPath, err
-}
-
 func resolveCLIConfigPathWithResolution(explicitOptions ...configPathOption) (string, *configResolution, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -179,27 +167,6 @@ func resolveCLIConfigPathFromWorkingDir(cwd string, explicitOptions ...configPat
 	}
 
 	return selected.Path, resolution, nil
-}
-
-func discoverCLIConfigPath(startDir string) (string, bool) {
-	dir := filepath.Clean(startDir)
-	for {
-		for _, candidate := range []string{
-			filepath.Join(dir, localConfigDirName, defaultConfigName),
-			filepath.Join(dir, defaultConfigName),
-		} {
-			info, err := os.Stat(candidate)
-			if err == nil && !info.IsDir() {
-				return candidate, true
-			}
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", false
-		}
-		dir = parent
-	}
 }
 
 func buildConfigResolutionCandidate(precedence int, source, rawPath string) configResolutionCandidate {

--- a/cmd/migrate_config.go
+++ b/cmd/migrate_config.go
@@ -88,6 +88,7 @@ func runMigrateConfigContext(_ context.Context, args []string, stdout, stderr io
 	}
 
 	if write {
+		// #nosec G306 -- migrated config files are normal repo files intended to remain readable by standard tooling.
 		if err := os.WriteFile(migration.Config.ConfigPath, []byte(rendered), 0o644); err != nil {
 			return writeCLIError(stdout, stderr, format, "migrate-config", request, cliIssue{
 				Code:    "config_error",

--- a/cmd/presentation.go
+++ b/cmd/presentation.go
@@ -154,12 +154,6 @@ func (p renderPresentation) blockMedium() string {
 	}
 	return p.yellow("[~]")
 }
-func (p renderPresentation) blockOK() string {
-	if p.utf8 {
-		return p.green("██")
-	}
-	return p.green("[+]")
-}
 func (p renderPresentation) okBadge() string {
 	if p.utf8 {
 		return p.green("██ OK")

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -726,28 +726,6 @@ func renderDocDriftResult(w io.Writer, result *analysis.DocDriftResult) {
 	}
 }
 
-func renderDriftEvidence(w io.Writer, evidence *analysis.DriftEvidence, prefix string) {
-	if evidence == nil {
-		return
-	}
-	if evidence.SpecRef != "" || evidence.SpecSection != "" || evidence.SpecExcerpt != "" {
-		fmt.Fprintf(w, "%sspec evidence: %s", prefix, evidence.SpecRef)
-		if evidence.SpecSection != "" {
-			fmt.Fprintf(w, " | %s", evidence.SpecSection)
-		}
-		fmt.Fprintln(w)
-		if evidence.SpecExcerpt != "" {
-			fmt.Fprintf(w, "%s  excerpt: %s\n", prefix, evidence.SpecExcerpt)
-		}
-	}
-	if evidence.DocSection != "" || evidence.DocExcerpt != "" {
-		fmt.Fprintf(w, "%sdoc evidence: %s\n", prefix, evidence.DocSection)
-		if evidence.DocExcerpt != "" {
-			fmt.Fprintf(w, "%s  excerpt: %s\n", prefix, evidence.DocExcerpt)
-		}
-	}
-}
-
 func renderFixResult(w io.Writer, result *app.FixResult) {
 	p := presentationForWriter(w)
 	suffix := ""
@@ -1796,45 +1774,6 @@ func driftAssessmentsFromItems(items []analysis.DriftItem) []analysis.DocDriftAs
 		})
 	}
 	return result
-}
-
-func renderReviewImpactSummary(w io.Writer, impact *analysis.AnalyzeImpactResult) {
-	if impact == nil {
-		return
-	}
-	specs := topImpactedSpecs(impact.AffectedSpecs, 3)
-	if len(specs) == 0 {
-		fmt.Fprintln(w, "top impacted specs: none")
-	} else {
-		fmt.Fprintln(w, "top impacted specs:")
-		for _, item := range specs {
-			fmt.Fprintf(w, "- %s | %s | %s", item.Ref, item.Title, item.Relationship)
-			if item.Historical {
-				fmt.Fprint(w, " | historical")
-			}
-			fmt.Fprintln(w)
-		}
-		if extra := len(impact.AffectedSpecs) - len(specs); extra > 0 {
-			fmt.Fprintf(w, "- %d more impacted spec(s)\n", extra)
-		}
-	}
-
-	docs := topImpactedDocs(impact.AffectedDocs, 3)
-	if len(docs) == 0 {
-		fmt.Fprintln(w, "top impacted docs: none")
-		return
-	}
-	fmt.Fprintln(w, "top impacted docs:")
-	for _, item := range docs {
-		fmt.Fprintf(w, "- %s | %s | %.3f", item.Ref, item.Title, item.Score)
-		if item.SourceRef != "" {
-			fmt.Fprintf(w, " | %s", item.SourceRef)
-		}
-		fmt.Fprintln(w)
-	}
-	if extra := len(impact.AffectedDocs) - len(docs); extra > 0 {
-		fmt.Fprintf(w, "- %d more impacted doc(s)\n", extra)
-	}
 }
 
 func topImpactedSpecs(items []analysis.ImpactedSpec, limit int) []analysis.ImpactedSpec {

--- a/docs/development/prerequisites.md
+++ b/docs/development/prerequisites.md
@@ -2,7 +2,7 @@
 
 Pituitary currently requires:
 
-- Go 1.25+
+- Go 1.25.8+
 - `make`
 - a CGO-capable C toolchain for the `sqlite-vec` path
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,7 +48,7 @@ If your repo already has a config, skip `init` and go straight to `status`, `ind
 
 ## Build from Source
 
-**Prerequisites:** Go 1.25+, a C toolchain (required for the sqlite-vec extension). For platform-specific setup, see [prerequisites.md](development/prerequisites.md).
+**Prerequisites:** Go 1.25.8+, a C toolchain (required for the sqlite-vec extension). For platform-specific setup, see [prerequisites.md](development/prerequisites.md).
 
 ```sh
 git clone https://github.com/dusk-network/pituitary.git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dusk-network/pituitary
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -286,6 +286,7 @@ func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, p
 			return nil, fmt.Errorf("path %q is a directory; --path expects a file", rawPath)
 		}
 
+		// #nosec G304 -- absPath is resolved under the workspace root by resolveWorkspaceFilePath.
 		data, err := os.ReadFile(absPath)
 		if err != nil {
 			return nil, fmt.Errorf("read path %q: %w", rawPath, err)
@@ -495,7 +496,7 @@ func parseDiffPathToken(token string) string {
 	token = stringsTrimSpace(token)
 	token = strings.TrimPrefix(token, "a/")
 	token = strings.TrimPrefix(token, "b/")
-	if token == "" || token == "/dev/null" {
+	if token == "" || token == os.DevNull {
 		return ""
 	}
 	return normalizeCompliancePath(token)

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -340,10 +340,6 @@ func normalizeDocDriftScope(request DocDriftRequest) (DocDriftScope, error) {
 	}
 }
 
-func loadIndexedDocs(db *sql.DB, refs []string) (map[string]docDocument, error) {
-	return loadIndexedDocsContext(context.Background(), db, refs)
-}
-
 func loadIndexedDocsContext(ctx context.Context, db *sql.DB, refs []string) (map[string]docDocument, error) {
 	rows, err := loadIndexedDocRowsContext(ctx, db, refs)
 	if err != nil {
@@ -366,10 +362,6 @@ func loadIndexedDocsContext(ctx context.Context, db *sql.DB, refs []string) (map
 		return nil, err
 	}
 	return docs, nil
-}
-
-func loadIndexedDocRows(db *sql.DB, refs []string) ([]indexedArtifactRow, error) {
-	return loadIndexedDocRowsContext(context.Background(), db, refs)
 }
 
 func loadIndexedDocRowsContext(ctx context.Context, db *sql.DB, refs []string) ([]indexedArtifactRow, error) {
@@ -410,10 +402,6 @@ WHERE kind = ?`)
 		return nil, fmt.Errorf("iterate indexed docs: %w", err)
 	}
 	return result, nil
-}
-
-func loadDocSections(db *sql.DB, docs map[string]docDocument) error {
-	return loadDocSectionsContext(context.Background(), db, docs)
 }
 
 func loadDocSectionsContext(ctx context.Context, db *sql.DB, docs map[string]docDocument) error {
@@ -1134,26 +1122,6 @@ func humanizedDriftValue(code, value string) string {
 	return value
 }
 
-func docEvidenceForFinding(doc docDocument, finding DriftFinding) (string, string) {
-	keywords := evidenceKeywordsForFinding(finding)
-	for _, section := range doc.Sections {
-		if excerpt, ok := sectionExcerptForKeywords(section, keywords); ok {
-			return section.Heading, excerpt
-		}
-	}
-	return "", ""
-}
-
-func specEvidenceForFinding(spec specDocument, finding DriftFinding) (string, string) {
-	keywords := evidenceKeywordsForFinding(finding)
-	for _, section := range spec.Sections {
-		if excerpt, ok := sectionExcerptForKeywords(section, keywords); ok {
-			return section.Heading, excerpt
-		}
-	}
-	return "", ""
-}
-
 func evidenceKeywordsForFinding(finding DriftFinding) []string {
 	switch finding.Code {
 	case "window_mismatch":
@@ -1407,37 +1375,6 @@ func bestAlignedAssessmentCandidateForDocs(doc docDocument, relevant []specDocum
 		}
 	}
 	return best
-}
-
-func bestAlignedEvidence(doc docDocument, spec specDocument) (*DriftEvidence, float64) {
-	var (
-		bestDoc   *embeddedSection
-		bestSpec  *embeddedSection
-		bestScore float64
-	)
-	for i := range doc.Sections {
-		docSection := &doc.Sections[i]
-		for j := range spec.Sections {
-			specSection := &spec.Sections[j]
-			score := sectionAssessmentScore(*docSection, *specSection)
-			if bestDoc == nil || score > bestScore {
-				bestScore = score
-				bestDoc = docSection
-				bestSpec = specSection
-			}
-		}
-	}
-	if bestDoc == nil || bestSpec == nil {
-		return nil, 0
-	}
-	return &DriftEvidence{
-		SpecRef:     spec.Record.Ref,
-		SpecTitle:   spec.Record.Title,
-		SpecSection: defaultString(stringsTrimSpace(bestSpec.Heading), "(body)"),
-		SpecExcerpt: defaultString(sectionExcerpt(*bestSpec), stringsTrimSpace(spec.Record.Title)),
-		DocSection:  defaultString(stringsTrimSpace(bestDoc.Heading), "(body)"),
-		DocExcerpt:  sectionExcerpt(*bestDoc),
-	}, bestScore
 }
 
 func shouldEmitAlignedAssessment(candidate *alignedAssessmentCandidate) bool {

--- a/internal/analysis/openai_provider.go
+++ b/internal/analysis/openai_provider.go
@@ -22,7 +22,6 @@ type openAICompatibleAnalysisProvider struct {
 }
 
 type openAICompatibleChatRequest = openaicompat.ChatRequest
-type openAICompatibleChatMessage = openaicompat.ChatMessage
 
 type compareAnalysisPrompt struct {
 	Command     string               `json:"command"`

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -288,10 +288,6 @@ func validateDraftSpec(record model.SpecRecord) error {
 	return nil
 }
 
-func loadIndexedSpecs(db *sql.DB, refs []string) (map[string]specDocument, error) {
-	return loadIndexedSpecsContext(context.Background(), db, refs)
-}
-
 func loadIndexedSpecsContext(ctx context.Context, db *sql.DB, refs []string) (map[string]specDocument, error) {
 	artifacts, err := loadIndexedArtifactRowsContext(ctx, db, refs)
 	if err != nil {
@@ -328,10 +324,6 @@ func loadIndexedSpecsContext(ctx context.Context, db *sql.DB, refs []string) (ma
 	}
 
 	return specs, nil
-}
-
-func loadIndexedArtifactRows(db *sql.DB, refs []string) ([]indexedArtifactRow, error) {
-	return loadIndexedArtifactRowsContext(context.Background(), db, refs)
 }
 
 func loadIndexedArtifactRowsContext(ctx context.Context, db *sql.DB, refs []string) ([]indexedArtifactRow, error) {
@@ -379,10 +371,6 @@ WHERE kind = ?`)
 		return nil, fmt.Errorf("iterate indexed specs: %w", err)
 	}
 	return result, nil
-}
-
-func loadSpecEdges(db *sql.DB, specs map[string]specDocument) error {
-	return loadSpecEdgesContext(context.Background(), db, specs)
 }
 
 func loadSpecEdgesContext(ctx context.Context, db *sql.DB, specs map[string]specDocument) error {
@@ -437,10 +425,6 @@ ORDER BY from_ref ASC, edge_type ASC, to_ref ASC`)
 		return fmt.Errorf("iterate spec edges: %w", err)
 	}
 	return nil
-}
-
-func loadSpecSections(db *sql.DB, specs map[string]specDocument) error {
-	return loadSpecSectionsContext(context.Background(), db, specs)
 }
 
 func loadSpecSectionsContext(ctx context.Context, db *sql.DB, specs map[string]specDocument) error {

--- a/internal/analysis/review.go
+++ b/internal/analysis/review.go
@@ -36,10 +36,8 @@ func ReviewSpecContext(ctx context.Context, cfg *config.Config, request ReviewRe
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
-	if err := validateOverlapRequest(OverlapRequest{
-		SpecRef:    request.SpecRef,
-		SpecRecord: request.SpecRecord,
-	}); err != nil {
+	overlapRequest := OverlapRequest(request)
+	if err := validateOverlapRequest(overlapRequest); err != nil {
 		return nil, err
 	}
 
@@ -54,10 +52,7 @@ func ReviewSpecContext(ctx context.Context, cfg *config.Config, request ReviewRe
 		return nil, err
 	}
 
-	candidate, err := loadCandidate(repo, OverlapRequest{
-		SpecRef:    request.SpecRef,
-		SpecRecord: request.SpecRecord,
-	}, nil)
+	candidate, err := loadCandidate(repo, overlapRequest, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/analysis/terminology.go
+++ b/internal/analysis/terminology.go
@@ -151,9 +151,7 @@ func CheckTerminologyContext(ctx context.Context, cfg *config.Config, request Te
 	findings := auditTerminologyArtifacts(artifacts, matchers, evidenceSections)
 
 	warningSpecs := make([]specDocument, 0, len(anchors))
-	for _, spec := range anchors {
-		warningSpecs = append(warningSpecs, spec)
-	}
+	warningSpecs = append(warningSpecs, anchors...)
 	warnings = append(warnings, buildSpecInferenceWarnings("terminology audit", warningSpecs...)...)
 
 	return &TerminologyAuditResult{

--- a/internal/app/fix.go
+++ b/internal/app/fix.go
@@ -272,6 +272,7 @@ func buildFixFileResult(cfg *config.Config, record model.DocRecord, remediation 
 	if err != nil {
 		return FixFileResult{}, err
 	}
+	// #nosec G304 -- path is resolved from a workspace source reference before reading.
 	bodyBytes, err := os.ReadFile(path)
 	if err != nil {
 		return FixFileResult{}, fmt.Errorf("read %s: %w", path, err)
@@ -508,6 +509,7 @@ func allMatchIndicesFold(text, needle string) []int {
 }
 
 func applyFixEdits(path, expectedContent, expectedChecksum string, edits []plannedFixEdit) error {
+	// #nosec G304 -- path is the previously planned workspace file being updated in place.
 	currentBytes, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read %s before apply: %w", path, err)

--- a/internal/app/fix_test.go
+++ b/internal/app/fix_test.go
@@ -93,8 +93,6 @@ func TestFixDocDriftAppliesEditsAndMarksIndexStale(t *testing.T) {
 }
 
 func TestFixDocDriftMatchesPathCaseInsensitivelyOnWindows(t *testing.T) {
-	t.Parallel()
-
 	previous := fixPathCaseInsensitive
 	fixPathCaseInsensitive = true
 	t.Cleanup(func() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,6 +125,7 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("resolve config path: %w", err)
 	}
 
+	// #nosec G304 -- configPath is the explicit config file selected by the caller.
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", configPath, err)

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -31,6 +31,7 @@ func MigrateFile(path string) (*MigrationResult, error) {
 		return nil, fmt.Errorf("resolve config path: %w", err)
 	}
 
+	// #nosec G304 -- configPath is the explicit config file selected for migration.
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", configPath, err)

--- a/internal/index/embedder.go
+++ b/internal/index/embedder.go
@@ -159,7 +159,7 @@ func tokenize(text string) []string {
 func tokenBucket(token string, dimension int) int {
 	hasher := fnv.New32a()
 	_, _ = hasher.Write([]byte(token))
-	return int(hasher.Sum32() % uint32(dimension))
+	return int(int64(hasher.Sum32()) % int64(dimension))
 }
 
 func normalize(vector []float64) []float64 {

--- a/internal/index/freshness.go
+++ b/internal/index/freshness.go
@@ -298,7 +298,8 @@ func readMetadataContext(ctx context.Context, db *sql.DB, keys ...string) (map[s
 		return result, nil
 	}
 
-	query := fmt.Sprintf(`SELECT key, value FROM metadata WHERE key IN (%s)`, placeholders(len(keys)))
+	// #nosec G202 -- placeholders() only emits '?' markers; key values are still passed as bound parameters.
+	query := `SELECT key, value FROM metadata WHERE key IN (` + placeholders(len(keys)) + `)`
 	args := make([]any, 0, len(keys))
 	for _, key := range keys {
 		args = append(args, key)

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -255,6 +255,7 @@ func ensureDirectoryPath(dirPath string) ([]string, error) {
 			}
 			created := make([]string, 0, len(missing))
 			for i := len(missing) - 1; i >= 0; i-- {
+				// #nosec G301 -- staging directories are local workspace state, not secret material.
 				if err := os.Mkdir(missing[i], 0o755); err != nil {
 					cleanupCreatedDirectories(created)
 					if os.IsExist(err) {
@@ -361,10 +362,6 @@ func probeStagingDatabaseContext(ctx context.Context, stagePath string, dimensio
 		return fmt.Errorf("remove staging database probe: %w", err)
 	}
 	return nil
-}
-
-func buildStaging(db *sql.DB, cfg *config.Config, dimension int, embedder Embedder, records *source.LoadResult) (*RebuildResult, error) {
-	return buildStagingContext(context.Background(), db, cfg, dimension, embedder, records, &reuseState{artifacts: map[string]storedArtifact{}}, RebuildOptions{}, nil)
 }
 
 func buildStagingContext(ctx context.Context, db *sql.DB, cfg *config.Config, dimension int, embedder Embedder, records *source.LoadResult, state *reuseState, options RebuildOptions, reporter RebuildProgressReporter) (*RebuildResult, error) {
@@ -508,10 +505,6 @@ func buildStagingContext(ctx context.Context, db *sql.DB, cfg *config.Config, di
 	return result, nil
 }
 
-func createSchema(db *sql.DB, dimension int) error {
-	return createSchemaContext(context.Background(), db, dimension)
-}
-
 func createSchemaContext(ctx context.Context, db *sql.DB, dimension int) error {
 	statements := []string{
 		`CREATE TABLE artifacts (
@@ -565,10 +558,6 @@ func createSchemaContext(ctx context.Context, db *sql.DB, dimension int) error {
 	return nil
 }
 
-func insertSpecArtifact(tx *sql.Tx, spec model.SpecRecord) error {
-	return insertSpecArtifactContext(context.Background(), tx, spec)
-}
-
 func insertSpecArtifactContext(ctx context.Context, tx *sql.Tx, spec model.SpecRecord) error {
 	metadataJSON, err := json.Marshal(spec.Metadata)
 	if err != nil {
@@ -595,10 +584,6 @@ func insertSpecArtifactContext(ctx context.Context, tx *sql.Tx, spec model.SpecR
 	return nil
 }
 
-func insertDocArtifact(tx *sql.Tx, doc model.DocRecord) error {
-	return insertDocArtifactContext(context.Background(), tx, doc)
-}
-
 func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocRecord) error {
 	metadataJSON, err := json.Marshal(doc.Metadata)
 	if err != nil {
@@ -623,12 +608,6 @@ func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocReco
 		return fmt.Errorf("insert doc artifact %s: %w", doc.Ref, err)
 	}
 	return nil
-}
-
-func insertArtifactChunks(chunkStmt, vectorStmt *sql.Stmt, embedder Embedder, artifactRef, title, body string) error {
-	plan := planArtifactReuse(title, "", body, storedArtifact{})
-	_, _, _, err := insertArtifactChunksContext(context.Background(), chunkStmt, vectorStmt, embedder, artifactRef, title, plan, RebuildProgressEvent{}, nil)
-	return err
 }
 
 func insertArtifactChunksContext(ctx context.Context, chunkStmt, vectorStmt *sql.Stmt, embedder Embedder, artifactRef, title string, plan artifactChunkPlan, event RebuildProgressEvent, reporter RebuildProgressReporter) (int, int, int, error) {
@@ -706,10 +685,6 @@ func reportRebuildProgress(reporter RebuildProgressReporter, event RebuildProgre
 	reporter(event)
 }
 
-func insertChunk(stmt *sql.Stmt, artifactRef, section, content string) (int64, error) {
-	return insertChunkContext(context.Background(), stmt, artifactRef, section, content)
-}
-
 func insertChunkContext(ctx context.Context, stmt *sql.Stmt, artifactRef, section, content string) (int64, error) {
 	result, err := stmt.ExecContext(ctx, artifactRef, section, content)
 	if err != nil {
@@ -720,10 +695,6 @@ func insertChunkContext(ctx context.Context, stmt *sql.Stmt, artifactRef, sectio
 		return 0, fmt.Errorf("read chunk id for %s: %w", artifactRef, err)
 	}
 	return chunkID, nil
-}
-
-func insertChunkVector(stmt *sql.Stmt, chunkID int64, _ int, vector []float64) error {
-	return insertChunkVectorContext(context.Background(), stmt, chunkID, 0, vector)
 }
 
 func insertChunkVectorContext(ctx context.Context, stmt *sql.Stmt, chunkID int64, _ int, vector []float64) error {
@@ -755,19 +726,11 @@ func textForEmbedding(title string, section chunk.Section) string {
 	return strings.Join(parts, "\n\n")
 }
 
-func insertEdge(stmt *sql.Stmt, fromRef, toRef, edgeType string) error {
-	return insertEdgeContext(context.Background(), stmt, fromRef, toRef, edgeType)
-}
-
 func insertEdgeContext(ctx context.Context, stmt *sql.Stmt, fromRef, toRef, edgeType string) error {
 	if _, err := stmt.ExecContext(ctx, fromRef, toRef, edgeType); err != nil {
 		return fmt.Errorf("insert edge %s -> %s (%s): %w", fromRef, toRef, edgeType, err)
 	}
 	return nil
-}
-
-func insertMetadata(tx *sql.Tx, key, value string) error {
-	return insertMetadataContext(context.Background(), tx, key, value)
 }
 
 func insertMetadataContext(ctx context.Context, tx *sql.Tx, key, value string) error {
@@ -777,19 +740,11 @@ func insertMetadataContext(ctx context.Context, tx *sql.Tx, key, value string) e
 	return nil
 }
 
-func insertContentFingerprint(db *sql.DB, value string) error {
-	return insertContentFingerprintContext(context.Background(), db, value)
-}
-
 func insertContentFingerprintContext(ctx context.Context, db *sql.DB, value string) error {
 	if _, err := db.ExecContext(ctx, `INSERT INTO metadata (key, value) VALUES (?, ?)`, "content_fingerprint", value); err != nil {
 		return fmt.Errorf("insert content fingerprint: %w", err)
 	}
 	return nil
-}
-
-func runIntegrityChecks(db *sql.DB) error {
-	return runIntegrityChecksContext(context.Background(), db)
 }
 
 func runIntegrityChecksContext(ctx context.Context, db *sql.DB) error {

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -232,10 +232,6 @@ func isSupportedSearchStatus(status string) bool {
 	}
 }
 
-func validateStoredDimension(db *sql.DB, configured int) error {
-	return validateStoredEmbedderContext(context.Background(), db, "", configured)
-}
-
 func validateStoredEmbedderContext(ctx context.Context, db *sql.DB, fingerprint string, configured int) error {
 	var raw string
 	err := db.QueryRowContext(ctx, `SELECT value FROM metadata WHERE key = 'embedder_dimension'`).Scan(&raw)
@@ -270,10 +266,6 @@ func validateStoredEmbedderContext(ctx context.Context, db *sql.DB, fingerprint 
 		return fmt.Errorf("index embedder fingerprint %q does not match configured embedder fingerprint %q; run `pituitary index --rebuild`", storedFingerprint, fingerprint)
 	}
 	return nil
-}
-
-func loadRankedCandidates(db *sql.DB, query SearchSpecQuery, queryEmbedding []float64) ([]chunkCandidate, error) {
-	return loadRankedCandidatesContext(context.Background(), db, query, queryEmbedding)
 }
 
 func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, query SearchSpecQuery, queryEmbedding []float64) ([]chunkCandidate, error) {

--- a/internal/index/spec_paths_test.go
+++ b/internal/index/spec_paths_test.go
@@ -60,8 +60,6 @@ func TestResolveIndexedSpecRefWithConfigContextClassifiesMissingPath(t *testing.
 }
 
 func TestResolveIndexedSpecRefsWithConfigContextMatchesCaseInsensitivelyOnWindows(t *testing.T) {
-	t.Parallel()
-
 	previous := indexedSpecPathCaseInsensitive
 	indexedSpecPathCaseInsensitive = true
 	t.Cleanup(func() {

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -21,10 +21,6 @@ var sqliteReadinessProbe = probeSQLiteReadyContext
 
 const sqliteReadinessDSN = "file:pituitary-sqlite-ready?mode=memory&cache=shared"
 
-func openReadWrite(path string) (*sql.DB, error) {
-	return openReadWriteContext(context.Background(), path)
-}
-
 func openReadWriteContext(ctx context.Context, path string) (*sql.DB, error) {
 	if err := CheckSQLiteReadyContext(ctx); err != nil {
 		return nil, err

--- a/internal/openaicompat/client.go
+++ b/internal/openaicompat/client.go
@@ -200,7 +200,7 @@ func doWithRetries[T any](ctx context.Context, client *Client, path string, body
 
 		retryAfter := retryAfterDuration(resp.Header.Get("Retry-After"))
 		responseBody, readErr := io.ReadAll(io.LimitReader(resp.Body, responseSizeLimit))
-		resp.Body.Close()
+		closeErr := resp.Body.Close()
 		if readErr != nil {
 			err = NewDependencyUnavailable(client.Runtime, "read %s response: %v", client.Runtime, readErr)
 		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -215,9 +215,15 @@ func doWithRetries[T any](ctx context.Context, client *Client, path string, body
 		} else {
 			value, decodeErr := decode(resp, responseBody)
 			if decodeErr == nil {
+				if closeErr != nil {
+					return zero, NewDependencyUnavailable(client.Runtime, "close %s response: %v", client.Runtime, closeErr)
+				}
 				return value, nil
 			}
 			err = decodeErr
+		}
+		if closeErr != nil && err == nil {
+			err = NewDependencyUnavailable(client.Runtime, "close %s response: %v", client.Runtime, closeErr)
 		}
 
 		lastErr = err
@@ -243,7 +249,7 @@ func shouldRetry(err error, statusCode int) bool {
 
 	var netErr net.Error
 	if errors.As(err, &netErr) {
-		return netErr.Timeout() || netErr.Temporary()
+		return netErr.Timeout()
 	}
 	if err == nil {
 		return false

--- a/internal/openaicompat/client_test.go
+++ b/internal/openaicompat/client_test.go
@@ -1,0 +1,83 @@
+package openaicompat
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type readCloserWithCloseErr struct {
+	io.Reader
+	closeErr error
+}
+
+func (r readCloserWithCloseErr) Close() error {
+	return r.closeErr
+}
+
+type stubNetError struct {
+	timeout bool
+}
+
+func (e stubNetError) Error() string   { return "stub network error" }
+func (e stubNetError) Timeout() bool   { return e.timeout }
+func (e stubNetError) Temporary() bool { return false }
+
+func TestShouldRetryRetriesTimeoutNetErrors(t *testing.T) {
+	t.Parallel()
+
+	if !shouldRetry(stubNetError{timeout: true}, 0) {
+		t.Fatal("shouldRetry(timeout net.Error) = false, want true")
+	}
+}
+
+func TestShouldRetryRetriesKnownConnectionFailures(t *testing.T) {
+	t.Parallel()
+
+	if !shouldRetry(errors.New("write tcp: broken pipe"), 0) {
+		t.Fatal("shouldRetry(broken pipe) = false, want true")
+	}
+}
+
+func TestDoWithRetriesReturnsCloseErrorOnSuccessfulResponse(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{
+		Runtime:    "test-runtime",
+		Endpoint:   "https://example.invalid",
+		MaxRetries: 0,
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Header:     make(http.Header),
+					Body: readCloserWithCloseErr{
+						Reader:   strings.NewReader(`{"ok":true}`),
+						closeErr: errors.New("close failed"),
+					},
+					Request: req,
+				}, nil
+			}),
+		},
+	}
+
+	_, err := doWithRetries(context.Background(), client, "/v1/test", []byte(`{}`), func(resp *http.Response, body []byte) (string, error) {
+		return "ok", nil
+	})
+	if err == nil {
+		t.Fatal("doWithRetries() error = nil, want close error")
+	}
+	if got := err.Error(); !strings.Contains(got, "close test-runtime response: close failed") {
+		t.Fatalf("doWithRetries() error = %q, want close failure", got)
+	}
+}

--- a/internal/source/canonicalize.go
+++ b/internal/source/canonicalize.go
@@ -62,6 +62,7 @@ func CanonicalizeMarkdownContract(options CanonicalizeOptions) (*CanonicalizeRes
 		return nil, fmt.Errorf("canonicalize source %q is not markdown", workspaceRelative(workspaceRoot, sourcePath))
 	}
 
+	// #nosec G304 -- sourcePath is resolved from the workspace and validated before reading.
 	body, err := os.ReadFile(sourcePath)
 	if err != nil {
 		return nil, fmt.Errorf("read markdown contract %q: %w", workspaceRelative(workspaceRoot, sourcePath), err)
@@ -264,12 +265,15 @@ func writeCanonicalizedBundle(bundleDir, specToml, bodyMarkdown string) error {
 			return fmt.Errorf("stat output path %s: %w", filepath.ToSlash(path), err)
 		}
 	}
+	// #nosec G301 -- generated bundle directories use normal checkout permissions for repo files.
 	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
 		return fmt.Errorf("create bundle directory: %w", err)
 	}
+	// #nosec G306 -- generated spec bundles are non-secret repo files intended to be readable by standard tooling.
 	if err := os.WriteFile(filepath.Join(bundleDir, "spec.toml"), []byte(specToml), 0o644); err != nil {
 		return fmt.Errorf("write generated spec.toml: %w", err)
 	}
+	// #nosec G306 -- generated spec bundles are non-secret repo files intended to be readable by standard tooling.
 	if err := os.WriteFile(filepath.Join(bundleDir, "body.md"), []byte(bodyMarkdown), 0o644); err != nil {
 		return fmt.Errorf("write generated body.md: %w", err)
 	}

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -3,7 +3,6 @@ package source
 import (
 	"fmt"
 	"os"
-	pathpkg "path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -212,6 +211,7 @@ func discoverSpecBundleCandidates(workspaceRoot string) ([]discoveredCandidate, 
 
 func discoverSpecBundleIdentity(bundleDir string) (string, string, error) {
 	specPath := filepath.Join(bundleDir, "spec.toml")
+	// #nosec G304 -- specPath is the fixed bundle manifest inside a discovered workspace directory.
 	specBytes, err := os.ReadFile(specPath)
 	if err != nil {
 		return "", "", fmt.Errorf("read discovered spec bundle %q: %w", filepath.ToSlash(bundleDir), err)
@@ -221,6 +221,10 @@ func discoverSpecBundleIdentity(bundleDir string) (string, string, error) {
 		return "", "", fmt.Errorf("parse discovered spec bundle %q: %w", filepath.ToSlash(specPath), err)
 	}
 	bodyPath := filepath.Clean(filepath.Join(bundleDir, raw.Body))
+	if !pathWithinRoot(bundleDir, bodyPath) {
+		return "", "", fmt.Errorf("read discovered spec body %q: path escapes bundle", filepath.ToSlash(bodyPath))
+	}
+	// #nosec G304 -- bodyPath is validated to remain inside the discovered bundle directory.
 	bodyBytes, err := os.ReadFile(bodyPath)
 	if err != nil {
 		return "", "", fmt.Errorf("read discovered spec body %q: %w", filepath.ToSlash(bodyPath), err)
@@ -230,6 +234,7 @@ func discoverSpecBundleIdentity(bundleDir string) (string, string, error) {
 
 func isValidDiscoveredSpecBundle(workspaceRoot, bundleDir string) (bool, []string) {
 	specPath := filepath.Join(bundleDir, "spec.toml")
+	// #nosec G304 -- specPath is the fixed bundle manifest inside a discovered workspace directory.
 	specBytes, err := os.ReadFile(specPath)
 	if err != nil {
 		return false, nil
@@ -302,6 +307,7 @@ func discoverMarkdownCandidates(workspaceRoot string, specBundleDirs map[string]
 }
 
 func classifyMarkdownCandidate(workspaceRoot, path string) (string, discoveredCandidate, bool, error) {
+	// #nosec G304 -- path comes from filepath.WalkDir rooted at the workspace.
 	body, err := os.ReadFile(path)
 	if err != nil {
 		return "", discoveredCandidate{}, false, nil
@@ -728,9 +734,11 @@ func writeDiscoveredConfig(path, content string) error {
 		return fmt.Errorf("stat config path: %w", err)
 	}
 
+	// #nosec G301 -- generated config directories use normal checkout permissions for repo files.
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create config directory: %w", err)
 	}
+	// #nosec G306 -- discovered config files are non-secret repo files intended to be readable by standard tooling.
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("write discovered config: %w", err)
 	}
@@ -881,8 +889,4 @@ func minInt(left, right int) int {
 		return left
 	}
 	return right
-}
-
-func discoveryPathJoin(parts ...string) string {
-	return pathpkg.Join(parts...)
 }

--- a/internal/source/explain.go
+++ b/internal/source/explain.go
@@ -214,6 +214,7 @@ func explainMarkdownContractSource(workspaceRoot string, explanation SourceFileE
 		return explanation, nil
 	}
 
+	// #nosec G304 -- absolutePath is derived from the selected workspace source and explanation target.
 	body, err := os.ReadFile(absolutePath)
 	if err != nil {
 		return SourceFileExplanation{}, fmt.Errorf(

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -253,6 +253,7 @@ type rawSpecBundle struct {
 
 func loadSpecBundle(workspaceRoot string, source config.Source, bundleDir string) (model.SpecRecord, error) {
 	specPath := filepath.Join(bundleDir, "spec.toml")
+	// #nosec G304 -- specPath is the fixed spec.toml file within a discovered bundle directory under the workspace.
 	specBytes, err := os.ReadFile(specPath)
 	if err != nil {
 		return model.SpecRecord{}, fmt.Errorf("source %q bundle %q: read spec.toml: %w", source.Name, workspaceRelative(workspaceRoot, bundleDir), err)
@@ -278,6 +279,7 @@ func loadSpecBundle(workspaceRoot string, source config.Source, bundleDir string
 		return model.SpecRecord{}, fmt.Errorf("source %q bundle %q body %q does not exist", source.Name, workspaceRelative(workspaceRoot, bundleDir), workspaceRelative(workspaceRoot, bodyPath))
 	}
 
+	// #nosec G304 -- bodyPath is validated to remain within the selected bundle directory.
 	bodyBytes, err := os.ReadFile(bodyPath)
 	if err != nil {
 		return model.SpecRecord{}, fmt.Errorf("source %q bundle %q: read body %q: %w", source.Name, workspaceRelative(workspaceRoot, bundleDir), workspaceRelative(workspaceRoot, bodyPath), err)
@@ -357,6 +359,7 @@ func loadMarkdownDocs(workspaceRoot string, source config.Source) ([]model.DocRe
 		return nil, err
 	}
 	for _, match := range matches {
+		// #nosec G304 -- match.AbsolutePath is selected from the configured workspace source.
 		bodyBytes, err := os.ReadFile(match.AbsolutePath)
 		if err != nil {
 			return nil, fmt.Errorf("source %q doc %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
@@ -389,6 +392,7 @@ func loadMarkdownContracts(workspaceRoot string, source config.Source) ([]model.
 		return nil, err
 	}
 	for _, match := range matches {
+		// #nosec G304 -- match.AbsolutePath is selected from the configured workspace source.
 		bodyBytes, err := os.ReadFile(match.AbsolutePath)
 		if err != nil {
 			return nil, fmt.Errorf("source %q contract %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)


### PR DESCRIPTION
## Summary
- bump the repo toolchain requirement to Go 1.25.8
- fix the remaining real analyzer findings and add retry/client regression tests
- remove dead wrapper code and annotate intentional local-file and permission behavior for gosec

## Validation
- /Users/emanuele/go/bin/staticcheck ./...
- /Users/emanuele/go/bin/gosec ./...
- /Users/emanuele/go/bin/go1.25.8 run golang.org/x/vuln/cmd/govulncheck@latest ./...
- /Users/emanuele/go/bin/go1.25.8 test -race ./...
- GOTOOLCHAIN=go1.25.8 make ci