### PR TITLE
Add pituitary new scaffold command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ git diff origin/main...HEAD | pituitary check-compliance --diff-file -
 
 ```sh
 pituitary init --path .              # discover, index, report
+pituitary new --title "Rate limiting policy" --domain api  # scaffold a draft spec
 pituitary check-doc-drift --scope all  # find stale docs
 pituitary review-spec --path specs/X   # full review of one spec
 pituitary status                       # index health at a glance
@@ -58,6 +59,7 @@ pituitary status                       # index health at a glance
 | What you want to do | Command |
 |---|---|
 | First run on a repo | `pituitary init --path .` |
+| Scaffold a new draft spec | `pituitary new --title "Rate limiting policy" --domain api` |
 | Find stale docs | `pituitary check-doc-drift --scope all` |
 | Check a PR diff against specs | `git diff origin/main...HEAD \| pituitary check-compliance --diff-file -` |
 | Full spec review | `pituitary review-spec --path specs/X` |

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -12,6 +12,7 @@ func TestRunCommandHelpAcrossSurface(t *testing.T) {
 	testCases := map[string][]string{
 		"init":              {"usage: pituitary init [--path PATH] [--config-path PATH] [--dry-run] [--format FORMAT]", "--path VALUE", "--config-path VALUE", "--dry-run"},
 		"index":             {"usage: pituitary [--config PATH] index (--rebuild | --dry-run) [--full] [--format FORMAT]", "shared config resolution:", "PITUITARY_CONFIG", "--rebuild", "--dry-run", "--full", "--verbose"},
+		"new":               {"usage: pituitary [--config PATH] new --title TITLE [--domain DOMAIN] [--id ID] [--bundle-dir PATH] [--format FORMAT]", "shared config resolution:", "--title VALUE", "--domain VALUE", "--id VALUE", "--bundle-dir VALUE"},
 		"migrate-config":    {"usage: pituitary migrate-config [--path PATH] [--write] [--format FORMAT]", "--path VALUE", "--write"},
 		"status":            {"usage: pituitary [--config PATH] status [--format FORMAT] [--check-runtime SCOPE]", "shared config resolution:", "--format VALUE", "--check-runtime VALUE"},
 		"preview-sources":   {"usage: pituitary [--config PATH] preview-sources", "shared config resolution:", "--format VALUE"},

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,0 +1,227 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+type newRequest struct {
+	Title     string `json:"title"`
+	Domain    string `json:"domain,omitempty"`
+	ID        string `json:"id,omitempty"`
+	BundleDir string `json:"bundle_dir,omitempty"`
+}
+
+type newCommandDefaults struct {
+	WorkspaceRoot string
+	SpecRoot      string
+	ConfigPath    string
+	SourceName    string
+	SourceHasFile bool
+	Warnings      []source.NewSpecBundleWarning
+}
+
+func runNew(args []string, stdout, stderr io.Writer) int {
+	return runNewContext(context.Background(), args, stdout, stderr)
+}
+
+func runNewContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("new", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	help := newCommandHelp("new", "pituitary [--config PATH] new --title TITLE [--domain DOMAIN] [--id ID] [--bundle-dir PATH] [--format FORMAT]")
+
+	var (
+		title     string
+		domain    string
+		id        string
+		bundleDir string
+		format    string
+	)
+	fs.StringVar(&title, "title", "", "spec title")
+	fs.StringVar(&domain, "domain", "", "spec domain (defaults to unknown)")
+	fs.StringVar(&id, "id", "", "explicit spec id")
+	fs.StringVar(&bundleDir, "bundle-dir", "", "bundle directory to write")
+	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
+
+	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
+		return writeCLIError(stdout, stderr, format, "new", nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	} else if handled {
+		return 0
+	}
+	if fs.NArg() != 0 {
+		return writeCLIError(stdout, stderr, format, "new", nil, cliIssue{
+			Code:    "validation_error",
+			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
+		}, 2)
+	}
+	if err := validateCLIFormat("new", format); err != nil {
+		return writeCLIError(stdout, stderr, format, "new", nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	request := newRequest{
+		Title:     strings.TrimSpace(title),
+		Domain:    strings.TrimSpace(domain),
+		ID:        strings.TrimSpace(id),
+		BundleDir: strings.TrimSpace(bundleDir),
+	}
+	if request.Title == "" {
+		return writeCLIError(stdout, stderr, format, "new", request, cliIssue{
+			Code:    "validation_error",
+			Message: "--title is required",
+		}, 2)
+	}
+
+	defaults, err := resolveNewCommandDefaults(ctx)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "new", request, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	result, err := source.NewSpecBundle(source.NewSpecBundleOptions{
+		WorkspaceRoot: defaults.WorkspaceRoot,
+		SpecRoot:      defaults.SpecRoot,
+		BundleDir:     request.BundleDir,
+		ID:            request.ID,
+		Title:         request.Title,
+		Domain:        request.Domain,
+	})
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "new", request, cliIssue{
+			Code:    "new_error",
+			Message: err.Error(),
+		}, 2)
+	}
+	if defaults.ConfigPath != "" {
+		result.ConfigPath = filepath.ToSlash(defaults.ConfigPath)
+	}
+	result.Warnings = append(result.Warnings, defaults.Warnings...)
+	appendNewConfigWarnings(result, defaults)
+
+	return writeCLISuccess(stdout, stderr, format, "new", request, result, nil)
+}
+
+func resolveNewCommandDefaults(ctx context.Context) (newCommandDefaults, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return newCommandDefaults{}, fmt.Errorf("resolve working directory: %w", err)
+	}
+	cwd, err = filepath.Abs(cwd)
+	if err != nil {
+		return newCommandDefaults{}, fmt.Errorf("resolve workspace root: %w", err)
+	}
+
+	defaults := newCommandDefaults{
+		WorkspaceRoot: cwd,
+		SpecRoot:      filepath.Join(cwd, "specs"),
+	}
+
+	resolvedConfigPath, resolution, err := resolveCommandConfigPathWithResolution(ctx, "")
+	if err != nil {
+		return defaults, nil
+	}
+
+	cfg, err := config.Load(resolvedConfigPath)
+	if err != nil {
+		if resolution != nil && resolution.SelectedBy != configSourceDiscovery {
+			return newCommandDefaults{}, err
+		}
+		defaults.WorkspaceRoot = workspaceRootForConfigPath(resolvedConfigPath)
+		defaults.SpecRoot = filepath.Join(defaults.WorkspaceRoot, "specs")
+		defaults.Warnings = append(defaults.Warnings, source.NewSpecBundleWarning{
+			Code:    "config_fallback",
+			Message: fmt.Sprintf("ignoring discovered config %s: %v; using default spec root %s", filepath.ToSlash(resolvedConfigPath), err, filepath.ToSlash(defaults.SpecRoot)),
+		})
+		return defaults, nil
+	}
+
+	defaults.WorkspaceRoot = cfg.Workspace.RootPath
+	defaults.ConfigPath = resolvedConfigPath
+	selectedSource := firstFilesystemSpecSource(cfg)
+	if selectedSource == nil {
+		defaults.SpecRoot = filepath.Join(cfg.Workspace.RootPath, "specs")
+		defaults.Warnings = append(defaults.Warnings, source.NewSpecBundleWarning{
+			Code:    "spec_source_fallback",
+			Message: fmt.Sprintf("config %s has no filesystem spec_bundle source; using default spec root %s", filepath.ToSlash(resolvedConfigPath), filepath.ToSlash(defaults.SpecRoot)),
+		})
+		return defaults, nil
+	}
+
+	defaults.SpecRoot = selectedSource.ResolvedPath
+	defaults.SourceName = selectedSource.Name
+	defaults.SourceHasFile = len(selectedSource.Files) > 0
+	return defaults, nil
+}
+
+func firstFilesystemSpecSource(cfg *config.Config) *config.Source {
+	if cfg == nil {
+		return nil
+	}
+	for i := range cfg.Sources {
+		source := &cfg.Sources[i]
+		if source.Adapter == config.AdapterFilesystem && source.Kind == config.SourceKindSpecBundle {
+			return source
+		}
+	}
+	return nil
+}
+
+func workspaceRootForConfigPath(configPath string) string {
+	configPath = filepath.Clean(configPath)
+	configDir := filepath.Dir(configPath)
+	if filepath.Base(configPath) == defaultConfigName && filepath.Base(configDir) == localConfigDirName {
+		return filepath.Dir(configDir)
+	}
+	return configDir
+}
+
+func appendNewConfigWarnings(result *source.NewSpecBundleResult, defaults newCommandDefaults) {
+	if result == nil || defaults.ConfigPath == "" || defaults.SourceName == "" {
+		return
+	}
+
+	bundlePath := filepath.Join(defaults.WorkspaceRoot, filepath.FromSlash(result.BundleDir))
+	specPath := filepath.Join(bundlePath, "spec.toml")
+	if !pathWithinRootNew(defaults.SpecRoot, bundlePath) {
+		result.Warnings = append(result.Warnings, source.NewSpecBundleWarning{
+			Code:    "outside_config_scope",
+			Message: fmt.Sprintf("bundle %s is outside configured spec source %q (%s); it will not be indexed until config changes", filepath.ToSlash(result.BundleDir), defaults.SourceName, filepath.ToSlash(defaults.SpecRoot)),
+		})
+		return
+	}
+	if !defaults.SourceHasFile {
+		return
+	}
+
+	relSpecPath, err := filepath.Rel(defaults.SpecRoot, specPath)
+	if err != nil {
+		return
+	}
+	result.Warnings = append(result.Warnings, source.NewSpecBundleWarning{
+		Code:    "config_files_selector",
+		Message: fmt.Sprintf("config source %q uses explicit files selectors; add %q if you want this bundle indexed", defaults.SourceName, filepath.ToSlash(relSpecPath)),
+	})
+}
+
+func pathWithinRootNew(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunNewJSONCreatesBundleThatIndexes(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runNew([]string{"--title", "Queue shaping", "--domain", "api", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runNew() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runNew() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request newRequest `json:"request"`
+		Result  struct {
+			BundleDir string `json:"bundle_dir"`
+			Spec      struct {
+				Ref    string `json:"ref"`
+				Status string `json:"status"`
+				Domain string `json:"domain"`
+			} `json:"spec"`
+			Files []struct {
+				Path string `json:"path"`
+			} `json:"files"`
+		} `json:"result"`
+		Warnings []cliIssue `json:"warnings"`
+		Errors   []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal new payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if got, want := payload.Request.Title, "Queue shaping"; got != want {
+		t.Fatalf("request.title = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.BundleDir, "specs/queue-shaping"; got != want {
+		t.Fatalf("bundle_dir = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.Spec.Status, "draft"; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.Spec.Domain, "api"; got != want {
+		t.Fatalf("domain = %q, want %q", got, want)
+	}
+	if payload.Result.Spec.Ref == "" {
+		t.Fatal("spec.ref is empty, want generated id")
+	}
+	for _, path := range []string{
+		filepath.Join(repo, "specs", "queue-shaping", "spec.toml"),
+		filepath.Join(repo, "specs", "queue-shaping", "body.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected scaffold file %s: %v", path, err)
+		}
+	}
+
+	var indexStdout bytes.Buffer
+	var indexStderr bytes.Buffer
+	exitCode = withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &indexStdout, &indexStderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex(--rebuild) exit code = %d, want 0 (stderr: %q)", exitCode, indexStderr.String())
+	}
+}
+
+func TestRunNewDefaultsDomainToUnknown(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runNew([]string{"--title", "Queue shaping", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runNew() exit code = %d, want 0", exitCode)
+	}
+
+	var payload struct {
+		Result struct {
+			Spec struct {
+				Domain string `json:"domain"`
+			} `json:"spec"`
+		} `json:"result"`
+		Warnings []cliIssue `json:"warnings"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal new payload: %v", err)
+	}
+	if got, want := payload.Result.Spec.Domain, "unknown"; got != want {
+		t.Fatalf("domain = %q, want %q", got, want)
+	}
+	if len(payload.Warnings) == 0 || !strings.Contains(payload.Warnings[0].Message, `domain defaulted to "unknown"`) {
+		t.Fatalf("warnings = %+v, want placeholder domain warning", payload.Warnings)
+	}
+}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -119,6 +119,8 @@ func cliWarningsForResult(result any) []cliIssue {
 	switch typed := result.(type) {
 	case *source.DiscoverResult:
 		return discoverWarningsToCLIIssues(typed.Warnings)
+	case *source.NewSpecBundleResult:
+		return newSpecWarningsToCLIIssues(typed.Warnings)
 	case *initResult:
 		if typed.Discover == nil {
 			return nil
@@ -135,6 +137,20 @@ func cliWarningsForResult(result any) []cliIssue {
 	default:
 		return nil
 	}
+}
+
+func newSpecWarningsToCLIIssues(warnings []source.NewSpecBundleWarning) []cliIssue {
+	if len(warnings) == 0 {
+		return nil
+	}
+	issues := make([]cliIssue, 0, len(warnings))
+	for _, warning := range warnings {
+		issues = append(issues, cliIssue{
+			Code:    warning.Code,
+			Message: warning.Message,
+		})
+	}
+	return issues
 }
 
 func discoverWarningsToCLIIssues(warnings []source.DiscoverWarning) []cliIssue {

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -26,6 +26,8 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 	switch typed := result.(type) {
 	case *source.CanonicalizeResult:
 		renderCanonicalizeResult(w, typed)
+	case *source.NewSpecBundleResult:
+		renderNewSpecBundleResult(w, typed)
 	case *source.DiscoverResult:
 		renderDiscoverResult(w, typed)
 	case *initResult:
@@ -197,6 +199,25 @@ func renderCanonicalizeResult(w io.Writer, result *source.CanonicalizeResult) {
 		if !strings.HasSuffix(file.Content, "\n") {
 			fmt.Fprintln(w)
 		}
+	}
+}
+
+func renderNewSpecBundleResult(w io.Writer, result *source.NewSpecBundleResult) {
+	fmt.Fprintf(w, "workspace: %s\n", result.WorkspaceRoot)
+	if result.ConfigPath != "" {
+		fmt.Fprintf(w, "config path: %s\n", result.ConfigPath)
+	}
+	fmt.Fprintf(w, "spec root: %s\n", result.SpecRoot)
+	fmt.Fprintf(w, "bundle dir: %s\n", result.BundleDir)
+	if result.WroteBundle {
+		fmt.Fprintln(w, "bundle write: wrote draft bundle")
+	}
+	fmt.Fprintf(w, "spec ref: %s\n", result.Spec.Ref)
+	fmt.Fprintf(w, "title: %s\n", result.Spec.Title)
+	fmt.Fprintf(w, "status: %s\n", result.Spec.Status)
+	fmt.Fprintf(w, "domain: %s\n", result.Spec.Domain)
+	for _, file := range result.Files {
+		fmt.Fprintf(w, "generated file: %s\n", file.Path)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ func commandRegistry() map[string]commandSpec {
 		"canonicalize":      {Description: "promote an inferred contract into a spec bundle", Formats: commandFormats(), Run: runCanonicalizeContext},
 		"discover":          {Description: "scan a repo and propose a local config", Formats: commandFormats(), Run: runDiscoverContext},
 		"init":              {Description: "discover, write, index, and summarize a workspace", Formats: commandFormats(), Run: runInitContext},
+		"new":               {Description: "scaffold a draft spec bundle from a template", Formats: commandFormats(), Run: runNewContext},
 		"migrate-config":    {Description: "rewrite a legacy config into the current schema", Formats: commandFormats(), Run: runMigrateConfigContext},
 		"index":             {Description: "rebuild or validate the local Pituitary index", Formats: commandFormats(), Run: runIndexContext},
 		"status":            {Description: "show current index status", Formats: commandFormats(), Run: runStatusContext},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -32,7 +32,7 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 				return
 			}
 
-			if name == "canonicalize" || name == "discover" || name == "init" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "fix" || name == "review-spec" || name == "schema" {
+			if name == "canonicalize" || name == "discover" || name == "init" || name == "new" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "fix" || name == "review-spec" || name == "schema" {
 				repoRoot := writeSearchWorkspace(t)
 				if name == "discover" || name == "init" || name == "canonicalize" {
 					repoRoot = writeDiscoveryWorkspace(t)
@@ -53,6 +53,13 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 				}
 				if name == "init" {
 					args = []string{name, "--path", "."}
+					expectBootstrapStatus = false
+					exitCode := withWorkingDir(t, repoRoot, run)
+					assertKnownCommandResult(t, name, commandDescription(name), exitCode, stdout.String(), stderr.String(), expectBootstrapStatus)
+					return
+				}
+				if name == "new" {
+					args = []string{name, "--title", "Kernel locality", "--domain", "core"}
 					expectBootstrapStatus = false
 					exitCode := withWorkingDir(t, repoRoot, run)
 					assertKnownCommandResult(t, name, commandDescription(name), exitCode, stdout.String(), stderr.String(), expectBootstrapStatus)

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -257,6 +257,17 @@ func commandSchemaRegistry() map[string]schemaCommandSpec {
 			InputType:  discoverRequest{},
 			OutputType: source.DiscoverResult{},
 		},
+		"new": {
+			Summary: schemaCommandSummary{
+				Name:             "new",
+				Description:      commandDescription("new"),
+				MutatesState:     true,
+				ConfigScoped:     true,
+				SupportedFormats: sortedCommandFormats("new"),
+			},
+			InputType:  newRequest{},
+			OutputType: source.NewSpecBundleResult{},
+		},
 		"explain-file": {
 			Summary: schemaCommandSummary{
 				Name:             "explain-file",

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -7,6 +7,7 @@ Quick command map for the common workflows. For the full install, config, runtim
 ```sh
 pituitary init --path .                         # discover + config + index + status
 pituitary init --path . --dry-run               # preview without writing
+pituitary new --title "Rate limiting policy" --domain api  # scaffold a draft spec
 pituitary discover --path .                     # propose sources (lower-level)
 pituitary preview-sources                       # show what will be indexed
 pituitary explain-file README.md                # why is this file in/out of scope?

--- a/internal/source/new.go
+++ b/internal/source/new.go
@@ -1,0 +1,332 @@
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/model"
+)
+
+// NewSpecBundleOptions controls creation of one draft spec bundle.
+type NewSpecBundleOptions struct {
+	WorkspaceRoot string
+	SpecRoot      string
+	BundleDir     string
+	ID            string
+	Title         string
+	Domain        string
+}
+
+// NewSpecBundleWarning reports non-fatal decisions made while scaffolding.
+type NewSpecBundleWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// NewSpecBundleResult reports the generated bundle and rendered files.
+type NewSpecBundleResult struct {
+	WorkspaceRoot string                    `json:"workspace_root"`
+	ConfigPath    string                    `json:"config_path,omitempty"`
+	SpecRoot      string                    `json:"spec_root"`
+	BundleDir     string                    `json:"bundle_dir"`
+	WroteBundle   bool                      `json:"wrote_bundle,omitempty"`
+	Spec          model.SpecRecord          `json:"spec"`
+	Files         []CanonicalizedBundleFile `json:"files"`
+	Warnings      []NewSpecBundleWarning    `json:"warnings,omitempty"`
+}
+
+// NewSpecBundle writes one draft spec.toml + body.md bundle.
+func NewSpecBundle(options NewSpecBundleOptions) (*NewSpecBundleResult, error) {
+	title := strings.TrimSpace(options.Title)
+	if title == "" {
+		return nil, fmt.Errorf("--title is required")
+	}
+
+	workspaceRoot, err := resolveNewWorkspaceRoot(options.WorkspaceRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	specRoot, err := resolveNewSpecRoot(workspaceRoot, options.SpecRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	bundleDir, err := resolveNewBundleDir(workspaceRoot, specRoot, options.BundleDir, title)
+	if err != nil {
+		return nil, err
+	}
+
+	existingBundles, existingIDs, nextID, err := inspectExistingSpecBundles(workspaceRoot, specRoot)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateNewBundleDir(workspaceRoot, bundleDir, existingBundles); err != nil {
+		return nil, err
+	}
+
+	specID := strings.TrimSpace(options.ID)
+	if specID == "" {
+		specID = nextID
+	} else if _, exists := existingIDs[specID]; exists {
+		return nil, fmt.Errorf("spec id %q already exists under %s", specID, workspaceRelative(workspaceRoot, specRoot))
+	}
+
+	domain := strings.TrimSpace(options.Domain)
+	var warnings []NewSpecBundleWarning
+	if domain == "" {
+		domain = "unknown"
+		warnings = append(warnings, NewSpecBundleWarning{
+			Code:    "placeholder_domain",
+			Message: `domain defaulted to "unknown"; replace it before review or acceptance`,
+		})
+	}
+
+	specToml := renderNewSpecToml(specID, title, domain)
+	bodyMarkdown := renderNewBodyMarkdown(title)
+	if err := writeCanonicalizedBundle(bundleDir, specToml, bodyMarkdown); err != nil {
+		return nil, err
+	}
+
+	specPath := filepath.Join(bundleDir, "spec.toml")
+	bodyPath := filepath.Join(bundleDir, "body.md")
+	result := &NewSpecBundleResult{
+		WorkspaceRoot: workspaceRoot,
+		SpecRoot:      workspaceRelative(workspaceRoot, specRoot),
+		BundleDir:     workspaceRelative(workspaceRoot, bundleDir),
+		WroteBundle:   true,
+		Spec: model.SpecRecord{
+			Ref:        specID,
+			Kind:       model.ArtifactKindSpec,
+			Title:      title,
+			Status:     model.StatusDraft,
+			Domain:     domain,
+			SourceRef:  fileSourceRef(workspaceRoot, specPath),
+			BodyFormat: model.BodyFormatMarkdown,
+			BodyText:   bodyMarkdown,
+			Metadata: map[string]string{
+				"bundle_path": workspaceRelative(workspaceRoot, bundleDir),
+				"body_path":   workspaceRelative(workspaceRoot, bodyPath),
+			},
+		},
+		Files: []CanonicalizedBundleFile{
+			{
+				Path:    filepath.ToSlash(filepath.Join(workspaceRelative(workspaceRoot, bundleDir), "spec.toml")),
+				Content: specToml,
+			},
+			{
+				Path:    filepath.ToSlash(filepath.Join(workspaceRelative(workspaceRoot, bundleDir), "body.md")),
+				Content: bodyMarkdown,
+			},
+		},
+		Warnings: warnings,
+	}
+	return result, nil
+}
+
+func resolveNewWorkspaceRoot(raw string) (string, error) {
+	workspaceRoot := strings.TrimSpace(raw)
+	if workspaceRoot == "" {
+		var err error
+		workspaceRoot, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve working directory: %w", err)
+		}
+	}
+	workspaceRoot, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace root: %w", err)
+	}
+	info, err := os.Stat(workspaceRoot)
+	switch {
+	case err == nil && !info.IsDir():
+		return "", fmt.Errorf("workspace root %q is not a directory", filepath.ToSlash(workspaceRoot))
+	case err != nil:
+		return "", fmt.Errorf("workspace root %q: %w", filepath.ToSlash(workspaceRoot), err)
+	}
+	return workspaceRoot, nil
+}
+
+func resolveNewSpecRoot(workspaceRoot, raw string) (string, error) {
+	specRoot := strings.TrimSpace(raw)
+	if specRoot == "" {
+		specRoot = filepath.Join(workspaceRoot, "specs")
+	}
+	if !filepath.IsAbs(specRoot) {
+		specRoot = filepath.Join(workspaceRoot, specRoot)
+	}
+	specRoot, err := filepath.Abs(specRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve spec root %q: %w", raw, err)
+	}
+	if !pathWithinRoot(workspaceRoot, specRoot) {
+		return "", fmt.Errorf("spec root %q resolves outside workspace root %q", raw, filepath.ToSlash(workspaceRoot))
+	}
+	return specRoot, nil
+}
+
+func resolveNewBundleDir(workspaceRoot, specRoot, requested, title string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		slug := newSpecBundleSlug(title)
+		if slug == "" {
+			return "", fmt.Errorf("cannot derive bundle directory from title %q; pass --bundle-dir explicitly", title)
+		}
+		requested = filepath.Join(specRoot, slug)
+	}
+	if !filepath.IsAbs(requested) {
+		requested = filepath.Join(workspaceRoot, requested)
+	}
+	bundleDir, err := filepath.Abs(requested)
+	if err != nil {
+		return "", fmt.Errorf("resolve bundle directory %q: %w", requested, err)
+	}
+	if !pathWithinRoot(workspaceRoot, bundleDir) {
+		return "", fmt.Errorf("--bundle-dir %q resolves outside workspace root %q", requested, filepath.ToSlash(workspaceRoot))
+	}
+	return bundleDir, nil
+}
+
+func inspectExistingSpecBundles(workspaceRoot, specRoot string) ([]string, map[string]struct{}, string, error) {
+	info, err := os.Stat(specRoot)
+	switch {
+	case os.IsNotExist(err):
+		return nil, map[string]struct{}{}, formatSpecID(1, 3), nil
+	case err != nil:
+		return nil, nil, "", fmt.Errorf("inspect spec root %q: %w", workspaceRelative(workspaceRoot, specRoot), err)
+	case !info.IsDir():
+		return nil, nil, "", fmt.Errorf("spec root %q is not a directory", workspaceRelative(workspaceRoot, specRoot))
+	}
+
+	bundleDirs, err := discoverSpecBundleDirs(specRoot)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("scan spec root %q: %w", workspaceRelative(workspaceRoot, specRoot), err)
+	}
+
+	existingIDs := make(map[string]struct{}, len(bundleDirs))
+	maxNumericID := 0
+	width := 3
+	for _, bundleDir := range bundleDirs {
+		specPath := filepath.Join(bundleDir, "spec.toml")
+		// #nosec G304 -- specPath comes from a discovered bundle within the workspace.
+		data, err := os.ReadFile(specPath)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("read existing spec bundle %q: %w", workspaceRelative(workspaceRoot, specPath), err)
+		}
+		raw, err := parseSpecBundle(data)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("parse existing spec bundle %q: %w", workspaceRelative(workspaceRoot, specPath), err)
+		}
+		if raw.ID != "" {
+			existingIDs[raw.ID] = struct{}{}
+		}
+		if value, valueWidth, ok := numericSpecID(raw.ID); ok {
+			if value > maxNumericID {
+				maxNumericID = value
+			}
+			if valueWidth > width {
+				width = valueWidth
+			}
+		}
+	}
+
+	return bundleDirs, existingIDs, formatSpecID(maxNumericID+1, width), nil
+}
+
+func validateNewBundleDir(workspaceRoot, bundleDir string, existingBundles []string) error {
+	for _, existing := range existingBundles {
+		switch {
+		case isNestedBundle(existing, bundleDir):
+			return fmt.Errorf("bundle %q would be nested inside existing bundle %q", workspaceRelative(workspaceRoot, bundleDir), workspaceRelative(workspaceRoot, existing))
+		case isNestedBundle(bundleDir, existing):
+			return fmt.Errorf("bundle %q would contain existing bundle %q", workspaceRelative(workspaceRoot, bundleDir), workspaceRelative(workspaceRoot, existing))
+		}
+	}
+	return nil
+}
+
+func numericSpecID(id string) (int, int, bool) {
+	if !strings.HasPrefix(id, "SPEC-") {
+		return 0, 0, false
+	}
+	suffix := strings.TrimPrefix(id, "SPEC-")
+	if suffix == "" {
+		return 0, 0, false
+	}
+	for _, r := range suffix {
+		if r < '0' || r > '9' {
+			return 0, 0, false
+		}
+	}
+	value, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, 0, false
+	}
+	return value, len(suffix), true
+}
+
+func formatSpecID(value, width int) string {
+	if width < 3 {
+		width = 3
+	}
+	return fmt.Sprintf("SPEC-%0*d", width, value)
+}
+
+func newSpecBundleSlug(title string) string {
+	title = strings.TrimSpace(strings.ToLower(title))
+	var builder strings.Builder
+	lastHyphen := true
+	for _, r := range title {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+			lastHyphen = false
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+			lastHyphen = false
+		default:
+			if !lastHyphen {
+				builder.WriteRune('-')
+				lastHyphen = true
+			}
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func renderNewSpecToml(id, title, domain string) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# Generated by pituitary new\n")
+	if domain == "unknown" {
+		fmt.Fprintf(&builder, "# TODO: replace placeholder domain %q before review or acceptance\n", domain)
+	}
+	fmt.Fprintf(&builder, "id = %s\n", strconv.Quote(id))
+	fmt.Fprintf(&builder, "title = %s\n", strconv.Quote(title))
+	fmt.Fprintf(&builder, "status = %s\n", strconv.Quote(model.StatusDraft))
+	fmt.Fprintf(&builder, "domain = %s\n", strconv.Quote(domain))
+	fmt.Fprintf(&builder, "body = %s\n", strconv.Quote("body.md"))
+	fmt.Fprintf(&builder, "\n# Optional fields:\n")
+	fmt.Fprintf(&builder, "# authors = [\"your-name\"]\n")
+	fmt.Fprintf(&builder, "# tags = [\"area\", \"topic\"]\n")
+	fmt.Fprintf(&builder, "# depends_on = [\"SPEC-012\"]\n")
+	fmt.Fprintf(&builder, "# supersedes = [\"SPEC-008\"]\n")
+	fmt.Fprintf(&builder, "# applies_to = [\"code://path/to/file\"]\n")
+	return builder.String()
+}
+
+func renderNewBodyMarkdown(title string) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# %s\n\n", title)
+	fmt.Fprintf(&builder, "## Overview\n\n")
+	fmt.Fprintf(&builder, "TODO: describe the problem, scope, and intended outcome.\n\n")
+	fmt.Fprintf(&builder, "## Requirements\n\n")
+	fmt.Fprintf(&builder, "- TODO: capture the key requirements.\n\n")
+	fmt.Fprintf(&builder, "## Design Decisions\n\n")
+	fmt.Fprintf(&builder, "- TODO: document the chosen approach.\n\n")
+	fmt.Fprintf(&builder, "## Open Questions\n\n")
+	fmt.Fprintf(&builder, "- TODO: track unresolved decisions.\n")
+	return builder.String()
+}

--- a/internal/source/new_test.go
+++ b/internal/source/new_test.go
@@ -1,0 +1,83 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewSpecBundleGeneratesNextIDAndWritesTemplate(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "specs", "rate-limit-v2", "spec.toml"), `
+id = "SPEC-042"
+title = "Per-Tenant Rate Limiting"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(t, filepath.Join(repo, "specs", "rate-limit-v2", "body.md"), "# Rate Limiting\n")
+	mustWriteFile(t, filepath.Join(repo, "specs", "burst-handling", "spec.toml"), `
+id = "SPEC-055"
+title = "Burst Handling"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(t, filepath.Join(repo, "specs", "burst-handling", "body.md"), "# Burst Handling\n")
+
+	result, err := NewSpecBundle(NewSpecBundleOptions{
+		WorkspaceRoot: repo,
+		SpecRoot:      "specs",
+		Title:         "Queue shaping",
+		Domain:        "api",
+	})
+	if err != nil {
+		t.Fatalf("NewSpecBundle() error = %v", err)
+	}
+	if got, want := result.BundleDir, "specs/queue-shaping"; got != want {
+		t.Fatalf("bundle dir = %q, want %q", got, want)
+	}
+	if got, want := result.Spec.Ref, "SPEC-056"; got != want {
+		t.Fatalf("spec ref = %q, want %q", got, want)
+	}
+	if got, want := result.Spec.Status, "draft"; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if len(result.Files) != 2 {
+		t.Fatalf("files = %d, want 2", len(result.Files))
+	}
+	if !strings.Contains(result.Files[0].Content, `status = "draft"`) {
+		t.Fatalf("spec.toml = %q, want draft status scaffold", result.Files[0].Content)
+	}
+	if !strings.Contains(result.Files[1].Content, "## Requirements") {
+		t.Fatalf("body.md = %q, want requirements heading", result.Files[1].Content)
+	}
+	for _, path := range []string{
+		filepath.Join(repo, "specs", "queue-shaping", "spec.toml"),
+		filepath.Join(repo, "specs", "queue-shaping", "body.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected scaffold file %s: %v", path, err)
+		}
+	}
+}
+
+func TestNewSpecBundleWarnsWhenDomainIsMissing(t *testing.T) {
+	repo := t.TempDir()
+
+	result, err := NewSpecBundle(NewSpecBundleOptions{
+		WorkspaceRoot: repo,
+		SpecRoot:      "specs",
+		Title:         "Draft spec",
+	})
+	if err != nil {
+		t.Fatalf("NewSpecBundle() error = %v", err)
+	}
+	if got, want := result.Spec.Domain, "unknown"; got != want {
+		t.Fatalf("domain = %q, want %q", got, want)
+	}
+	if len(result.Warnings) != 1 || result.Warnings[0].Code != "placeholder_domain" {
+		t.Fatalf("warnings = %+v, want placeholder_domain warning", result.Warnings)
+	}
+}


### PR DESCRIPTION
## Summary
- add a flag-driven pituitary new command that scaffolds a draft spec bundle
- generate sensible default bundle paths and next numeric SPEC-### ids when possible
- add CLI/source tests and document the new command in the README and cheatsheet

Closes #154
