### PR TITLE
Clarify semantic runtime model guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,15 @@ endpoint = "http://127.0.0.1:1234/v1"
 provider = "openai_compatible"
 model = "your-analysis-model"
 endpoint = "http://127.0.0.1:1234/v1"
+timeout_ms = 30000
+max_retries = 1
 ```
 
 For `runtime.analysis`, prefer a text model that is good at bounded adjudication rather than a generic embedding or agent stack:
 
 - strong instruction following and schema adherence
-- direct-answer or non-thinking mode for clean outputs
-- enough context for shortlisted evidence, typically `128k+`
+- concise answers without verbose reasoning text or intermediate chain-of-thought
+- enough context for Pituitary's shortlisted evidence bundle; typical general-purpose `8k`-`32k` context is sufficient, with larger windows optional
 - active-parameter cost that fits your latency and hardware budget
 
 Examples today include recent instruct models from the Qwen and Mistral families, but the important choice is the capability profile, not one fixed model name.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -41,8 +41,8 @@ When choosing `runtime.analysis`, optimize for bounded semantic adjudication rat
 
 - strong instruction following under tight evidence constraints
 - reliable structured-output hygiene
-- direct-answer or non-thinking mode when available
-- enough context for prompt plus shortlisted excerpts, usually `128k+`
+- concise answers without verbose reasoning text or intermediate chain-of-thought
+- enough context for the prompt plus Pituitary's small shortlisted evidence bundle; typical general-purpose `8k`-`32k` context is sufficient, with larger windows optional
 - a parameter and active-parameter footprint that fits your local hardware and latency budget
 
 Examples today include recent instruct-capable Qwen and Mistral models, but Pituitary does not require one specific analysis model.


### PR DESCRIPTION
## Summary
- clarify that Pituitary uses separate embedding and analysis runtimes
- replace the README and runtime docs' named analysis-model recommendation with capability-based guidance
- keep current model families as examples rather than hard-coded recommendations

## Validation
- git diff --check -- README.md docs/runtime.md
- make ci