### PR TITLE
docs: add semantic runtime operator note

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ See [docs/development/ci-recipes.md](docs/development/ci-recipes.md) for a compl
 
 Pituitary works out of the box with no API keys and no external dependencies. For higher-quality semantic retrieval on a real corpus, configure an embedding runtime and rebuild the index. For bounded provider-backed adjudication in `compare-specs` and `check-doc-drift`, also configure a separate analysis runtime.
 
+> "Pituitary got me from a large architecture spec plus drifted docs to a scoped, inspectable set of affected files quickly."
+>
+> From a real Hermes/Raoh doc-convergence pass across `harper`, `openclaw`, `autoskiller`, and `souther`: semantic support was most useful for narrowing scope, tracing terminology drift, and reducing omission risk before manual code/runtime verification.
+
 **Cloud: OpenAI-compatible embeddings** (if you already have a key)
 
 ```toml


### PR DESCRIPTION
## Summary

- Add a short operator quote to the README Semantic Runtime section from a real doc-convergence pass.
- Explain where semantic support was most helpful in practice: narrowing scope, tracing terminology drift, and reducing omission risk before manual verification.
- Link the note to the broader dogfooding backlog opened from that same experience.

## Backlog / Issue

- Follow-up backlog opened in:
  - #207
  - #208
  - #209
  - #210
  - #211
  - #212
  - #213

## Core Trust Surface

- No core write path changes.
- Surface: README / product positioning for semantic support.
- Blocking proof: rendered diff only.

## Validation

- [ ] I ran `make ci`
- [ ] I added or updated tests where needed
- [x] Docs-only diff reviewed

## Notes

- This PR is intentionally separate from the runtime embedder fix in #206.
