### PR TITLE
Add role-aware doc drift analysis

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -1633,10 +1633,14 @@ func driftAssessmentBadge(p renderPresentation, status string) string {
 }
 
 func driftFindingSummary(finding analysis.DriftFinding) string {
+	summary := strings.TrimSpace(finding.Message)
 	if strings.TrimSpace(finding.Code) != "" {
-		return humanizeSymbol(finding.Code)
+		summary = humanizeSymbol(finding.Code)
 	}
-	return strings.TrimSpace(finding.Message)
+	if finding.Classification == "role_mismatch" {
+		return "role mismatch · " + summary
+	}
+	return summary
 }
 
 func overlapBlock(p renderPresentation, item analysis.OverlapItem) string {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,7 @@ path = "specs"
 name = "docs"
 adapter = "filesystem"
 kind = "markdown_docs"
+role = "current_state"
 path = "docs"
 include = ["guides/*.md", "runbooks/*.md"]
 
@@ -89,6 +90,20 @@ per_page = 100
 ```
 
 The built-in GitHub adapter indexes RFC/spec-style issues as `SpecRecord`s and other issues as `DocRecord`s. Keep GitHub-specific settings inside `sources.options`; the kernel still treats `name`, `adapter`, `kind`, `path`, `files`, `include`, and `exclude` as the explicit shared config surface.
+
+### Source Roles
+
+Set `role` on a source when its artifacts should be interpreted with an authority level during semantic workflows such as `check-doc-drift`.
+
+- `canonical`: stable source of truth for accepted design intent
+- `current_state`: current operational guidance or runtime-facing documentation
+- `runtime_authoritative`: runtime truth that should override softer documentation surfaces
+- `planning`: forward-looking design or rollout notes
+- `historical`: migration notes or superseded context that should not be treated as current drift by default
+- `generated`: generated output that should be checked against its stronger source
+- `mirror`: mirrored compatibility surface derived from another canonical document
+
+Roles are applied per source. If one directory mixes current-state and historical docs, split it into separate `[[sources]]` blocks with different `include` patterns.
 
 ### Example: Indexing AI agent instructions
 

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -18,6 +19,12 @@ import (
 
 var requestsPerMinutePattern = regexp.MustCompile(`(?i)(\d+)\s+requests per minute`)
 var artifactReferencePattern = regexp.MustCompile(`(?i)[a-z0-9][a-z0-9._-]*\.(?:db|json|md|toml|yaml|yml)`)
+
+const (
+	driftClassificationSemantic = "semantic_contradiction"
+	driftClassificationRole     = "role_mismatch"
+	sourceRoleMetadataKey       = "source_role"
+)
 
 type docDocument struct {
 	Record   model.DocRecord
@@ -56,15 +63,18 @@ type DriftConfidence struct {
 
 // DriftFinding reports one contradiction between a doc and a spec.
 type DriftFinding struct {
-	SpecRef    string           `json:"spec_ref"`
-	Artifact   string           `json:"artifact,omitempty"`
-	Code       string           `json:"code"`
-	Message    string           `json:"message"`
-	Rationale  string           `json:"rationale,omitempty"`
-	Expected   string           `json:"expected,omitempty"`
-	Observed   string           `json:"observed,omitempty"`
-	Evidence   *DriftEvidence   `json:"evidence,omitempty"`
-	Confidence *DriftConfidence `json:"confidence,omitempty"`
+	SpecRef        string           `json:"spec_ref"`
+	Artifact       string           `json:"artifact,omitempty"`
+	Code           string           `json:"code"`
+	Classification string           `json:"classification,omitempty"`
+	DocRole        string           `json:"doc_role,omitempty"`
+	SpecRole       string           `json:"spec_role,omitempty"`
+	Message        string           `json:"message"`
+	Rationale      string           `json:"rationale,omitempty"`
+	Expected       string           `json:"expected,omitempty"`
+	Observed       string           `json:"observed,omitempty"`
+	Evidence       *DriftEvidence   `json:"evidence,omitempty"`
+	Confidence     *DriftConfidence `json:"confidence,omitempty"`
 }
 
 // DriftItem reports one doc that drifts from accepted specs.
@@ -241,6 +251,18 @@ func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, scop
 	for _, ref := range sortedDocRefs(selectedDocs) {
 		doc := selectedDocs[ref]
 		relevant := relevantAcceptedSpecs(doc, specs)
+		if roleToleratesHistoricalDrift(doc) {
+			if assessment := historicalDocAssessment(doc, relevant); assessment != nil {
+				assessments = append(assessments, *assessment)
+				relevantSpecRefs = append(relevantSpecRefs, assessment.SpecRefs...)
+				for _, specRef := range assessment.SpecRefs {
+					if spec, ok := specs[specRef]; ok {
+						warningSpecs = append(warningSpecs, spec)
+					}
+				}
+			}
+			continue
+		}
 		item, remediation := driftAgainstAcceptedSpecs(doc, relevant)
 		if item != nil && analyzer != nil {
 			relevantByRef := make(map[string]specDocument, len(relevant))
@@ -358,6 +380,7 @@ func loadIndexedDocsContext(ctx context.Context, db *sql.DB, refs []string) (map
 				Title:      row.Title,
 				SourceRef:  row.SourceRef,
 				BodyFormat: model.BodyFormatMarkdown,
+				Metadata:   row.Metadata,
 			},
 		}
 	}
@@ -372,6 +395,7 @@ func loadIndexedDocRowsContext(ctx context.Context, db *sql.DB, refs []string) (
 	args := make([]any, 0, len(refs)+1)
 	builder.WriteString(`
 SELECT ref, title, '', '', source_ref
+     , metadata_json
 FROM artifacts
 WHERE kind = ?`)
 	args = append(args, model.ArtifactKindDoc)
@@ -396,8 +420,14 @@ WHERE kind = ?`)
 	var result []indexedArtifactRow
 	for rows.Next() {
 		var row indexedArtifactRow
-		if err := rows.Scan(&row.Ref, &row.Title, &row.Status, &row.Domain, &row.SourceRef); err != nil {
+		var rawMetadata string
+		if err := rows.Scan(&row.Ref, &row.Title, &row.Status, &row.Domain, &row.SourceRef, &rawMetadata); err != nil {
 			return nil, fmt.Errorf("scan indexed doc: %w", err)
+		}
+		if strings.TrimSpace(rawMetadata) != "" {
+			if err := json.Unmarshal([]byte(rawMetadata), &row.Metadata); err != nil {
+				return nil, fmt.Errorf("parse indexed metadata for %s: %w", row.Ref, err)
+			}
 		}
 		result = append(result, row)
 	}
@@ -517,6 +547,9 @@ func driftAgainstAcceptedSpecs(doc docDocument, relevant []specDocument) (*Drift
 }
 
 func enrichDriftFinding(doc docDocument, spec specDocument, finding DriftFinding) DriftFinding {
+	finding.DocRole = sourceRoleFromMetadata(doc.Record.Metadata)
+	finding.SpecRole = sourceRoleFromMetadata(spec.Record.Metadata)
+	finding.Classification = classifyDriftFinding(finding.DocRole, finding.SpecRole)
 	evidence, score := driftEvidence(doc, spec, finding)
 	finding.Evidence = evidence
 	finding.Rationale = rationaleForFinding(finding)
@@ -592,13 +625,23 @@ func assessmentFallbackSpecs(doc docDocument, specs map[string]specDocument) []s
 		score float64
 	}
 
-	var scored []scoredSpec
+	var (
+		scored              []scoredSpec
+		authoritativeScored []scoredSpec
+	)
 	for _, spec := range specs {
 		if spec.Record.Status != model.StatusAccepted {
 			continue
 		}
 		score := assessmentSimilarity(doc.Sections, spec.Sections)
-		scored = append(scored, scoredSpec{spec: spec, score: score})
+		entry := scoredSpec{spec: spec, score: score}
+		scored = append(scored, entry)
+		if sourceRoleIsAuthoritative(spec.Record.Metadata) {
+			authoritativeScored = append(authoritativeScored, entry)
+		}
+	}
+	if len(authoritativeScored) > 0 {
+		scored = authoritativeScored
 	}
 	sort.Slice(scored, func(i, j int) bool {
 		switch {
@@ -652,7 +695,10 @@ func relevantAcceptedSpecs(doc docDocument, specs map[string]specDocument) []spe
 		score float64
 	}
 	docArtifacts := artifactMentionSet(doc.Sections)
-	var scored []scoredSpec
+	var (
+		scored              []scoredSpec
+		authoritativeScored []scoredSpec
+	)
 	for _, spec := range specs {
 		if spec.Record.Status != model.StatusAccepted {
 			continue
@@ -664,7 +710,14 @@ func relevantAcceptedSpecs(doc docDocument, specs map[string]specDocument) []spe
 		if score < 0.35 {
 			continue
 		}
-		scored = append(scored, scoredSpec{spec: spec, score: score})
+		entry := scoredSpec{spec: spec, score: score}
+		scored = append(scored, entry)
+		if sourceRoleIsAuthoritative(spec.Record.Metadata) {
+			authoritativeScored = append(authoritativeScored, entry)
+		}
+	}
+	if len(authoritativeScored) > 0 {
+		scored = authoritativeScored
 	}
 	sort.Slice(scored, func(i, j int) bool {
 		switch {
@@ -680,6 +733,86 @@ func relevantAcceptedSpecs(doc docDocument, specs map[string]specDocument) []spe
 		result = append(result, item.spec)
 	}
 	return result
+}
+
+func roleToleratesHistoricalDrift(doc docDocument) bool {
+	return sourceRoleFromMetadata(doc.Record.Metadata) == config.SourceRoleHistorical
+}
+
+func historicalDocAssessment(doc docDocument, relevant []specDocument) *DocDriftAssessment {
+	assessment := &DocDriftAssessment{
+		DocRef:    doc.Record.Ref,
+		Title:     doc.Record.Title,
+		SourceRef: doc.Record.SourceRef,
+		Status:    "aligned",
+		Rationale: "doc source is marked historical, so historical terminology and superseded behavior are tolerated during drift checks",
+		Confidence: &DriftConfidence{
+			Level: "medium",
+			Basis: "source role marks this document as historical context rather than current operational truth",
+		},
+	}
+	if candidate := bestAlignedAssessmentCandidateForDocs(doc, relevant); shouldEmitAlignedAssessment(candidate) {
+		assessment.SpecRefs = []string{candidate.spec.Record.Ref}
+		assessment.Evidence = candidate.evidence
+		assessment.Confidence.Score = roundScore(candidate.score)
+	}
+	return assessment
+}
+
+func sourceRoleFromMetadata(metadata map[string]string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	return config.NormalizeSourceRole(metadata[sourceRoleMetadataKey])
+}
+
+func sourceRoleIsAuthoritative(metadata map[string]string) bool {
+	switch sourceRoleFromMetadata(metadata) {
+	case "":
+		return true
+	case config.SourceRoleCanonical, config.SourceRoleCurrentState, config.SourceRoleRuntimeAuth:
+		return true
+	default:
+		return false
+	}
+}
+
+func classifyDriftFinding(docRole, specRole string) string {
+	docRole = config.NormalizeSourceRole(docRole)
+	specRole = config.NormalizeSourceRole(specRole)
+	if docRole == "" && specRole == "" {
+		return driftClassificationSemantic
+	}
+	if docRole != "" && specRole != "" && docRole != specRole {
+		return driftClassificationRole
+	}
+	switch docRole {
+	case config.SourceRolePlanning, config.SourceRoleGenerated, config.SourceRoleMirror:
+		return driftClassificationRole
+	default:
+		return driftClassificationSemantic
+	}
+}
+
+func humanizeSourceRole(role string) string {
+	switch config.NormalizeSourceRole(role) {
+	case config.SourceRoleCanonical:
+		return "canonical"
+	case config.SourceRoleCurrentState:
+		return "current-state"
+	case config.SourceRoleRuntimeAuth:
+		return "runtime-authoritative"
+	case config.SourceRolePlanning:
+		return "planning"
+	case config.SourceRoleHistorical:
+		return "historical"
+	case config.SourceRoleGenerated:
+		return "generated"
+	case config.SourceRoleMirror:
+		return "mirror"
+	default:
+		return ""
+	}
 }
 
 func joinDocumentText(sections []embeddedSection) string {
@@ -1219,25 +1352,43 @@ func stringsHasPrefix(value, prefix string) bool {
 }
 
 func rationaleForFinding(finding DriftFinding) string {
+	base := ""
 	switch finding.Code {
 	case "window_mismatch":
-		return fmt.Sprintf("accepted spec expects %s, but the doc still describes %s", humanizedDriftValue(finding.Code, finding.Expected), humanizedDriftValue(finding.Code, finding.Observed))
+		base = fmt.Sprintf("accepted spec expects %s, but the doc still describes %s", humanizedDriftValue(finding.Code, finding.Expected), humanizedDriftValue(finding.Code, finding.Observed))
 	case "subject_mismatch":
-		return fmt.Sprintf("accepted spec expects %s, but the doc still targets %s", humanizedDriftValue(finding.Code, finding.Expected), humanizedDriftValue(finding.Code, finding.Observed))
+		base = fmt.Sprintf("accepted spec expects %s, but the doc still targets %s", humanizedDriftValue(finding.Code, finding.Expected), humanizedDriftValue(finding.Code, finding.Observed))
 	case "default_limit_mismatch":
-		return fmt.Sprintf("accepted spec sets %s, but the doc still states %s", humanizedDriftValue(finding.Code, finding.Expected), humanizedDriftValue(finding.Code, finding.Observed))
+		base = fmt.Sprintf("accepted spec sets %s, but the doc still states %s", humanizedDriftValue(finding.Code, finding.Expected), humanizedDriftValue(finding.Code, finding.Observed))
 	case "override_support_mismatch":
-		return fmt.Sprintf("accepted spec says %s, but the doc still says %s", humanizedDriftValue(finding.Code, finding.Expected), humanizedDriftValue(finding.Code, finding.Observed))
+		base = fmt.Sprintf("accepted spec says %s, but the doc still says %s", humanizedDriftValue(finding.Code, finding.Expected), humanizedDriftValue(finding.Code, finding.Observed))
 	case "artifact_runtime_input_mismatch":
 		if finding.Artifact != "" {
-			return fmt.Sprintf("accepted spec says `%s` is not a canonical runtime input, but the doc still presents it as active startup input", finding.Artifact)
+			base = fmt.Sprintf("accepted spec says `%s` is not a canonical runtime input, but the doc still presents it as active startup input", finding.Artifact)
 		}
 	case "artifact_contract_mismatch":
 		if finding.Artifact != "" {
-			return fmt.Sprintf("accepted spec says `%s` is not part of the active runtime contract, but the doc still presents it as active runtime state", finding.Artifact)
+			base = fmt.Sprintf("accepted spec says `%s` is not part of the active runtime contract, but the doc still presents it as active runtime state", finding.Artifact)
 		}
 	}
-	return finding.Message
+	if base == "" {
+		base = finding.Message
+	}
+	if finding.Classification != driftClassificationRole {
+		return base
+	}
+	docRole := humanizeSourceRole(finding.DocRole)
+	specRole := humanizeSourceRole(finding.SpecRole)
+	switch {
+	case docRole != "" && specRole != "":
+		return fmt.Sprintf("%s (%s source contradicts %s source)", base, docRole, specRole)
+	case docRole != "":
+		return fmt.Sprintf("%s (%s source is not the active operational authority)", base, docRole)
+	case specRole != "":
+		return fmt.Sprintf("%s (%s source takes precedence here)", base, specRole)
+	default:
+		return base
+	}
 }
 
 func confidenceForDriftFinding(finding DriftFinding, score float64) *DriftConfidence {

--- a/internal/analysis/doc_drift_test.go
+++ b/internal/analysis/doc_drift_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dusk-network/pituitary/internal/config"
@@ -361,6 +362,127 @@ func TestCheckDocDriftKeepsPossibleDriftInMixedBatches(t *testing.T) {
 	}
 }
 
+func TestCheckDocDriftToleratesHistoricalDocs(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeRoleAwareDocDriftWorkspace(t, config.SourceRoleCanonical, `
+# Rate Limit Contract
+
+Use a sliding-window limiter with a default limit of 200 requests per minute.
+Apply limits per tenant.
+`, config.SourceRoleHistorical, `
+# 2024 Rollout Notes
+
+Use a fixed-window limiter with a default limit of 100 requests per minute.
+Apply limits per API key.
+`)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := CheckDocDrift(cfg, DocDriftRequest{Scope: "all"})
+	if err != nil {
+		t.Fatalf("CheckDocDrift() error = %v", err)
+	}
+	if len(result.DriftItems) != 0 {
+		t.Fatalf("drift_items = %+v, want historical doc to be tolerated", result.DriftItems)
+	}
+	if len(result.Assessments) != 1 {
+		t.Fatalf("assessments = %+v, want one historical assessment", result.Assessments)
+	}
+	assessment := result.Assessments[0]
+	if got, want := assessment.Status, "aligned"; got != want {
+		t.Fatalf("assessment.status = %q, want %q", got, want)
+	}
+	if assessment.Rationale == "" || assessment.Confidence == nil {
+		t.Fatalf("assessment = %+v, want rationale and confidence", assessment)
+	}
+	if want := "historical"; !containsSubstringFold(assessment.Rationale, want) {
+		t.Fatalf("assessment.rationale = %q, want substring %q", assessment.Rationale, want)
+	}
+}
+
+func TestCheckDocDriftClassifiesRoleMismatchAgainstRuntimeAuthority(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeRoleAwareDocDriftWorkspace(t, config.SourceRoleRuntimeAuth, `
+# Runtime Rate Limit Contract
+
+Use a sliding-window limiter with a default limit of 200 requests per minute.
+Apply limits per tenant.
+`, config.SourceRoleCurrentState, `
+# Public API Runtime Guide
+
+Use a fixed-window limiter with a default limit of 100 requests per minute.
+Apply limits per API key.
+`)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := CheckDocDrift(cfg, DocDriftRequest{Scope: "all"})
+	if err != nil {
+		t.Fatalf("CheckDocDrift() error = %v", err)
+	}
+	if len(result.DriftItems) != 1 {
+		t.Fatalf("drift_items = %+v, want one role mismatch doc", result.DriftItems)
+	}
+	finding := result.DriftItems[0].Findings[0]
+	if got, want := finding.Classification, driftClassificationRole; got != want {
+		t.Fatalf("finding.classification = %q, want %q", got, want)
+	}
+	if got, want := finding.DocRole, config.SourceRoleCurrentState; got != want {
+		t.Fatalf("finding.doc_role = %q, want %q", got, want)
+	}
+	if got, want := finding.SpecRole, config.SourceRoleRuntimeAuth; got != want {
+		t.Fatalf("finding.spec_role = %q, want %q", got, want)
+	}
+}
+
+func TestCheckDocDriftIgnoresPlanningSpecsWhenAuthoritativeSpecExists(t *testing.T) {
+	t.Parallel()
+
+	cfg := writePlanningConflictDocDriftWorkspace(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := CheckDocDrift(cfg, DocDriftRequest{Scope: "all"})
+	if err != nil {
+		t.Fatalf("CheckDocDrift() error = %v", err)
+	}
+	if len(result.DriftItems) != 0 {
+		t.Fatalf("drift_items = %+v, want planning spec excluded from authoritative drift checks", result.DriftItems)
+	}
+	if len(result.Assessments) != 1 {
+		t.Fatalf("assessments = %+v, want one aligned assessment", result.Assessments)
+	}
+	assessment := result.Assessments[0]
+	if assessment.Status != "aligned" && assessment.Status != "possible_drift" {
+		t.Fatalf("assessment.status = %q, want aligned or possible_drift", assessment.Status)
+	}
+	for _, specRef := range assessment.SpecRefs {
+		if specRef == "SPEC-PLAN" {
+			t.Fatalf("assessment.spec_refs = %+v, did not expect planning spec", assessment.SpecRefs)
+		}
+	}
+	if len(assessment.SpecRefs) > 0 && assessment.SpecRefs[0] != "SPEC-CANON" {
+		t.Fatalf("assessment.spec_refs = %+v, want canonical spec when a spec ref is surfaced", assessment.SpecRefs)
+	}
+}
+
 func TestClassifyArtifactConstraintScopesRuntimeInputToLocalArtifact(t *testing.T) {
 	t.Parallel()
 
@@ -427,6 +549,138 @@ kind = "markdown_docs"
 path = "docs"
 include = ["guides/*.md"]
 `)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
+}
+
+func writeRoleAwareDocDriftWorkspace(tb testing.TB, specRole, specBody, docRole, docBody string) *config.Config {
+	tb.Helper()
+
+	root := tb.TempDir()
+	indexPath := filepath.Join(root, ".pituitary", "pituitary.db")
+	configPath := filepath.Join(root, "pituitary.toml")
+
+	mustWriteFile(tb, filepath.Join(root, "specs", "rate-limit", "spec.toml"), `
+id = "SPEC-ROLE"
+title = "Role Aware Rate Limit Contract"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "rate-limit", "body.md"), specBody)
+	mustWriteFile(tb, filepath.Join(root, "docs", "guides", "rate-limit.md"), docBody)
+
+	mustWriteFile(tb, configPath, fmt.Sprintf(`
+[workspace]
+root = %q
+index_path = %q
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+role = %q
+path = %q
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+role = %q
+path = %q
+`, root, indexPath, specRole, filepath.Join(root, "specs"), docRole, filepath.Join(root, "docs")))
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
+}
+
+func writePlanningConflictDocDriftWorkspace(tb testing.TB) *config.Config {
+	tb.Helper()
+
+	root := tb.TempDir()
+	indexPath := filepath.Join(root, ".pituitary", "pituitary.db")
+	configPath := filepath.Join(root, "pituitary.toml")
+
+	mustWriteFile(tb, filepath.Join(root, "specs", "canonical", "spec.toml"), `
+id = "SPEC-CANON"
+title = "Canonical Rate Limit Contract"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "canonical", "body.md"), `
+# Canonical Rate Limit Contract
+
+Use a sliding-window limiter with a default limit of 200 requests per minute.
+Apply limits per tenant.
+`)
+
+	mustWriteFile(tb, filepath.Join(root, "plans", "future-rollout", "spec.toml"), `
+id = "SPEC-PLAN"
+title = "Future Rate Limit Rollout"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(tb, filepath.Join(root, "plans", "future-rollout", "body.md"), `
+# Future Rate Limit Rollout
+
+Use a fixed-window limiter with a default limit of 100 requests per minute.
+Apply limits per API key.
+`)
+
+	mustWriteFile(tb, filepath.Join(root, "docs", "guides", "rate-limit.md"), `
+# Public API Runtime Guide
+
+Use a sliding-window limiter with a default limit of 200 requests per minute.
+Apply limits per tenant.
+`)
+
+	mustWriteFile(tb, configPath, fmt.Sprintf(`
+[workspace]
+root = %q
+index_path = %q
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+role = "canonical"
+path = %q
+
+[[sources]]
+name = "plans"
+adapter = "filesystem"
+kind = "spec_bundle"
+role = "planning"
+path = %q
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+role = "current_state"
+path = %q
+`, root, indexPath, filepath.Join(root, "specs"), filepath.Join(root, "plans"), filepath.Join(root, "docs")))
 
 	cfg, err := config.Load(configPath)
 	if err != nil {
@@ -592,4 +846,8 @@ path = %q
 		tb.Fatalf("config.Load() error = %v", err)
 	}
 	return cfg
+}
+
+func containsSubstringFold(value, needle string) bool {
+	return strings.Contains(strings.ToLower(value), strings.ToLower(needle))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,13 @@ const (
 	SourceKindSpecBundle       = "spec_bundle"
 	SourceKindMarkdownDocs     = "markdown_docs"
 	SourceKindMarkdownContract = "markdown_contract"
+	SourceRoleCanonical        = "canonical"
+	SourceRoleCurrentState     = "current_state"
+	SourceRoleRuntimeAuth      = "runtime_authoritative"
+	SourceRolePlanning         = "planning"
+	SourceRoleHistorical       = "historical"
+	SourceRoleGenerated        = "generated"
+	SourceRoleMirror           = "mirror"
 	RuntimeProviderFixture     = "fixture"
 	RuntimeProviderOpenAI      = "openai_compatible"
 	RuntimeProviderDisabled    = "disabled"
@@ -49,6 +56,7 @@ type Source struct {
 	Name         string
 	Adapter      string
 	Kind         string
+	Role         string
 	Path         string
 	Files        []string
 	Include      []string
@@ -94,6 +102,7 @@ type rawSource struct {
 	Name    string         `toml:"name"`
 	Adapter string         `toml:"adapter"`
 	Kind    string         `toml:"kind"`
+	Role    string         `toml:"role"`
 	Path    string         `toml:"path"`
 	Files   []string       `toml:"files"`
 	Include []string       `toml:"include"`
@@ -206,6 +215,7 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 			Name:    source.Name,
 			Adapter: source.Adapter,
 			Kind:    source.Kind,
+			Role:    NormalizeSourceRole(source.Role),
 			Path:    source.Path,
 			Files:   append([]string(nil), source.Files...),
 			Include: append([]string(nil), source.Include...),
@@ -369,6 +379,9 @@ func validate(cfg *Config) error {
 		if source.Kind == "" {
 			errs.add("%s.kind: value is required", label)
 		}
+		if source.Role != "" && !IsValidSourceRole(source.Role) {
+			errs.add("%s.role: unsupported role %q", label, source.Role)
+		}
 
 		filesystemSource := source.Adapter == AdapterFilesystem
 		if strings.TrimSpace(source.Path) == "" && filesystemSource {
@@ -469,6 +482,25 @@ func normalizeSourceFileSelector(value string) (string, error) {
 		return "", fmt.Errorf("%q escapes the source root", value)
 	}
 	return normalized, nil
+}
+
+func NormalizeSourceRole(role string) string {
+	return strings.ToLower(strings.TrimSpace(role))
+}
+
+func IsValidSourceRole(role string) bool {
+	switch NormalizeSourceRole(role) {
+	case SourceRoleCanonical,
+		SourceRoleCurrentState,
+		SourceRoleRuntimeAuth,
+		SourceRolePlanning,
+		SourceRoleHistorical,
+		SourceRoleGenerated,
+		SourceRoleMirror:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateRuntime(runtime Runtime) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -853,6 +853,101 @@ func TestRenderRoundTripsSourceOptions(t *testing.T) {
 	}
 }
 
+func TestLoadAcceptsSourceRole(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "docs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+role = "historical"
+path = "docs"
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got, want := cfg.Sources[0].Role, SourceRoleHistorical; got != want {
+		t.Fatalf("source role = %q, want %q", got, want)
+	}
+}
+
+func TestLoadRejectsInvalidSourceRole(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "docs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+role = "activeish"
+path = "docs"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), `source "docs".role: unsupported role "activeish"`) {
+		t.Fatalf("Load() error = %q, want unsupported role detail", err)
+	}
+}
+
+func TestRenderRoundTripsSourceRole(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "docs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	cfg := &Config{
+		SchemaVersion: CurrentSchemaVersion,
+		ConfigPath:    configPath,
+		ConfigDir:     repo,
+		Workspace: Workspace{
+			Root:      ".",
+			IndexPath: ".pituitary/pituitary.db",
+		},
+		Sources: []Source{
+			{
+				Name:    "docs",
+				Adapter: AdapterFilesystem,
+				Kind:    SourceKindMarkdownDocs,
+				Role:    SourceRoleMirror,
+				Path:    "docs",
+			},
+		},
+	}
+
+	rendered, err := Render(cfg)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	loaded, err := LoadFromText(rendered, configPath)
+	if err != nil {
+		t.Fatalf("LoadFromText() error = %v", err)
+	}
+	if got, want := loaded.Sources[0].Role, SourceRoleMirror; got != want {
+		t.Fatalf("loaded role = %q, want %q", got, want)
+	}
+}
+
 func TestLoadRejectsMissingSourcePath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -53,6 +53,9 @@ func Render(cfg *Config) (string, error) {
 		fmt.Fprintf(&builder, "name = %s\n", strconv.Quote(source.Name))
 		fmt.Fprintf(&builder, "adapter = %s\n", strconv.Quote(source.Adapter))
 		fmt.Fprintf(&builder, "kind = %s\n", strconv.Quote(source.Kind))
+		if source.Role != "" {
+			fmt.Fprintf(&builder, "role = %s\n", strconv.Quote(source.Role))
+		}
 		if source.Path != "" {
 			fmt.Fprintf(&builder, "path = %s\n", strconv.Quote(source.Path))
 		}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -78,6 +78,7 @@ func LoadFromConfigWithOptions(cfg *config.Config, options LoadOptions) (*LoadRe
 		if err != nil {
 			return nil, fmt.Errorf("source %q: %w", source.Name, err)
 		}
+		annotateSourceRoleMetadata(source.Role, adapterResult)
 
 		if err := appendUniqueSpecRecords(result, seenSpecs, source, adapterResult.Specs); err != nil {
 			return nil, err
@@ -127,4 +128,25 @@ func unknownAdapterError(sourceName, adapter string) error {
 		adapter,
 		strings.Join(registered, ", "),
 	)
+}
+
+func annotateSourceRoleMetadata(role string, result *sdk.AdapterResult) {
+	role = config.NormalizeSourceRole(role)
+	if role == "" || result == nil {
+		return
+	}
+	for i := range result.Specs {
+		result.Specs[i].Metadata = withSourceRole(result.Specs[i].Metadata, role)
+	}
+	for i := range result.Docs {
+		result.Docs[i].Metadata = withSourceRole(result.Docs[i].Metadata, role)
+	}
+}
+
+func withSourceRole(metadata map[string]string, role string) map[string]string {
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+	metadata["source_role"] = role
+	return metadata
 }


### PR DESCRIPTION
## Summary
- add explicit per-source role metadata to config and carry it into normalized artifact metadata
- make doc-drift load doc roles, tolerate historical docs, and classify role mismatches against authoritative sources
- document source roles and add focused config/doc-drift coverage for authoritative vs planning/historical behavior

Closes #207

## Testing
- go test ./internal/config ./internal/source ./internal/analysis ./cmd
- make ci
