### PR TITLE
Improve runtime failure diagnostics for provider errors

### DIFF
--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -117,10 +117,7 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 
 	operation := app.AnalyzeImpact(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", operation.Request, cliIssue{
-			Code:    operation.Issue.Code,
-			Message: operation.Issue.Message,
-		}, operation.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "analyze-impact", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "analyze-impact", operation.Request, operation.Result, nil)

--- a/cmd/check_compliance.go
+++ b/cmd/check_compliance.go
@@ -126,10 +126,7 @@ func runCheckComplianceContext(ctx context.Context, args []string, stdout, stder
 
 	operation := app.CheckCompliance(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-compliance", operation.Request, cliIssue{
-			Code:    operation.Issue.Code,
-			Message: operation.Issue.Message,
-		}, operation.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "check-compliance", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "check-compliance", operation.Request, operation.Result, nil)

--- a/cmd/check_doc_drift.go
+++ b/cmd/check_doc_drift.go
@@ -103,10 +103,7 @@ func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr 
 
 	operation := app.CheckDocDrift(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", operation.Request, cliIssue{
-			Code:    operation.Issue.Code,
-			Message: operation.Issue.Message,
-		}, operation.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "check-doc-drift", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "check-doc-drift", operation.Request, operation.Result, nil)

--- a/cmd/check_overlap.go
+++ b/cmd/check_overlap.go
@@ -99,10 +99,7 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 		}
 		operation := app.CheckOverlap(ctx, resolvedConfigPath, request)
 		if operation.Issue != nil {
-			return writeCLIError(stdout, stderr, format, "check-overlap", operation.Request, cliIssue{
-				Code:    operation.Issue.Code,
-				Message: operation.Issue.Message,
-			}, operation.Issue.ExitCode)
+			return writeCLIError(stdout, stderr, format, "check-overlap", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 		}
 		return writeCLISuccess(stdout, stderr, format, "check-overlap", operation.Request, operation.Result, nil)
 	}
@@ -126,10 +123,7 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 
 	operation := app.CheckOverlap(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", operation.Request, cliIssue{
-			Code:    operation.Issue.Code,
-			Message: operation.Issue.Message,
-		}, operation.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "check-overlap", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "check-overlap", operation.Request, operation.Result, nil)

--- a/cmd/check_terminology.go
+++ b/cmd/check_terminology.go
@@ -139,10 +139,7 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 
 	operation := app.CheckTerminology(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", operation.Request, cliIssue{
-			Code:    operation.Issue.Code,
-			Message: operation.Issue.Message,
-		}, operation.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "check-terminology", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "check-terminology", operation.Request, operation.Result, nil)

--- a/cmd/compare_specs.go
+++ b/cmd/compare_specs.go
@@ -133,10 +133,7 @@ func runCompareSpecsContext(ctx context.Context, args []string, stdout, stderr i
 
 	operation := app.CompareSpecs(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", operation.Request, cliIssue{
-			Code:    operation.Issue.Code,
-			Message: operation.Issue.Message,
-		}, operation.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "compare-specs", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "compare-specs", operation.Request, operation.Result, nil)

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -6,13 +6,15 @@ import (
 	"io"
 
 	"github.com/dusk-network/pituitary/internal/analysis"
+	"github.com/dusk-network/pituitary/internal/app"
 	"github.com/dusk-network/pituitary/internal/source"
 )
 
 type cliIssue struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Path    string `json:"path,omitempty"`
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
+	Path    string         `json:"path,omitempty"`
 }
 
 type cliEnvelope struct {
@@ -113,6 +115,17 @@ func writeCLIJSON(w io.Writer, payload cliEnvelope) int {
 		return 2
 	}
 	return 0
+}
+
+func cliIssueFromAppIssue(issue *app.Issue) cliIssue {
+	if issue == nil {
+		return cliIssue{}
+	}
+	return cliIssue{
+		Code:    issue.Code,
+		Message: issue.Message,
+		Details: issue.Details,
+	}
 }
 
 func cliWarningsForResult(result any) []cliIssue {

--- a/cmd/review_spec.go
+++ b/cmd/review_spec.go
@@ -94,10 +94,7 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 		}
 		operation := app.ReviewSpec(ctx, resolvedConfigPath, request)
 		if operation.Issue != nil {
-			return writeCLIError(stdout, stderr, format, "review-spec", operation.Request, cliIssue{
-				Code:    operation.Issue.Code,
-				Message: operation.Issue.Message,
-			}, operation.Issue.ExitCode)
+			return writeCLIError(stdout, stderr, format, "review-spec", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 		}
 		return writeCLISuccess(stdout, stderr, format, "review-spec", operation.Request, operation.Result, nil)
 	}
@@ -121,10 +118,7 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 
 	operation := app.ReviewSpec(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", operation.Request, cliIssue{
-			Code:    operation.Issue.Code,
-			Message: operation.Issue.Message,
-		}, operation.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "review-spec", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "review-spec", operation.Request, operation.Result, nil)

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -132,10 +132,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 
 	operation := app.SearchSpecs(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssue{
-			Code:    operation.Issue.Code,
-			Message: operation.Issue.Message,
-		}, operation.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "search-specs", operation.Request, operation.Result, nil)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -106,10 +106,7 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 
 	response := app.Status(ctx, resolvedConfigPath, app.StatusRequest{CheckRuntime: scope})
 	if response.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
-			Code:    response.Issue.Code,
-			Message: response.Issue.Message,
-		}, response.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "status", request, cliIssueFromAppIssue(response.Issue), response.Issue.ExitCode)
 	}
 	result := response.Result
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -341,6 +341,15 @@ path = "specs"
 	if !strings.Contains(payload.Errors[0].Message, "load or pin model") {
 		t.Fatalf("errors[0].message = %q, want model loading guidance", payload.Errors[0].Message)
 	}
+	if got, want := payload.Errors[0].Details["runtime"], "runtime.embedder"; got != want {
+		t.Fatalf("errors[0].details.runtime = %#v, want %q", got, want)
+	}
+	if got, want := payload.Errors[0].Details["request_type"], "embeddings"; got != want {
+		t.Fatalf("errors[0].details.request_type = %#v, want %q", got, want)
+	}
+	if got, want := payload.Errors[0].Details["failure_class"], "dependency_unavailable"; got != want {
+		t.Fatalf("errors[0].details.failure_class = %#v, want %q", got, want)
+	}
 }
 
 func TestRunStatusReportsConfigError(t *testing.T) {

--- a/internal/analysis/openai_provider.go
+++ b/internal/analysis/openai_provider.go
@@ -127,7 +127,7 @@ func (p *openAICompatibleAnalysisProvider) Probe(ctx context.Context) error {
 		return err
 	}
 	if !response.OK {
-		return analysisDependencyUnavailable("%s probe returned ok=false", openAICompatibleAnalysisRuntime)
+		return p.dependencyError(openaicompat.FailureClassDependency, "%s probe returned ok=false", openAICompatibleAnalysisRuntime)
 	}
 	return nil
 }
@@ -193,7 +193,7 @@ func (p *openAICompatibleAnalysisProvider) completeJSON(ctx context.Context, sys
 	}
 
 	if err := json.Unmarshal([]byte(responseBody), target); err != nil {
-		return openaicompat.NewDependencyUnavailable(openAICompatibleAnalysisRuntime, "decode %s response as JSON object: %v", openAICompatibleAnalysisRuntime, err)
+		return p.dependencyError(openaicompat.FailureClassSchemaMismatch, "decode %s response as JSON object: %v", openAICompatibleAnalysisRuntime, err)
 	}
 	return nil
 }
@@ -204,11 +204,11 @@ func (p *openAICompatibleAnalysisProvider) requestChatCompletion(ctx context.Con
 		return "", err
 	}
 	if text == "" {
-		return "", analysisDependencyUnavailable("%s returned an empty message", openAICompatibleAnalysisRuntime)
+		return "", p.dependencyError(openaicompat.FailureClassSchemaMismatch, "%s returned an empty message", openAICompatibleAnalysisRuntime)
 	}
 	text = normalizeJSONResponseText(text)
 	if text == "" {
-		return "", analysisDependencyUnavailable("%s returned no JSON object", openAICompatibleAnalysisRuntime)
+		return "", p.dependencyError(openaicompat.FailureClassSchemaMismatch, "%s returned no JSON object", openAICompatibleAnalysisRuntime)
 	}
 	return text, nil
 }
@@ -236,8 +236,10 @@ func normalizeJSONResponseText(text string) string {
 	return ""
 }
 
-func analysisDependencyUnavailable(format string, args ...any) *openaicompat.DependencyUnavailableError {
-	return openaicompat.NewDependencyUnavailable(openAICompatibleAnalysisRuntime, format, args...)
+func (p *openAICompatibleAnalysisProvider) dependencyError(failureClass, format string, args ...any) *openaicompat.DependencyUnavailableError {
+	details := p.client.RequestFailureDetails("analysis")
+	details.FailureClass = strings.TrimSpace(failureClass)
+	return openaicompat.NewDependencyUnavailableWithDetails(details, format, args...)
 }
 
 func analysisSpecsFromMap(specs map[string]specDocument, orderedRefs []string) []analysisSpecPrompt {

--- a/internal/analysis/openai_provider_test.go
+++ b/internal/analysis/openai_provider_test.go
@@ -199,4 +199,58 @@ func TestOpenAICompatibleAnalysisProviderParsesStringErrorBodies(t *testing.T) {
 	if strings.Contains(err.Error(), `{"error":"Model unloaded.."}`) {
 		t.Fatalf("completeJSON() error = %q, want parsed message instead of raw JSON", err)
 	}
+	details := index.DependencyUnavailableDetails(err)
+	if got, want := details["request_type"], "analysis"; got != want {
+		t.Fatalf("details.request_type = %#v, want %q", got, want)
+	}
+	if got, want := details["http_status"], http.StatusBadRequest; got != want {
+		t.Fatalf("details.http_status = %#v, want %d", got, want)
+	}
+	if got, want := details["failure_class"], "dependency_unavailable"; got != want {
+		t.Fatalf("details.failure_class = %#v, want %q", got, want)
+	}
+}
+
+func TestOpenAICompatibleAnalysisProviderClassifiesSchemaMismatchDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"content": "not-json"}},
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	rawProvider, err := newOpenAICompatibleAnalysisProvider(config.RuntimeProvider{
+		Provider:   config.RuntimeProviderOpenAI,
+		Model:      "pituitary-analysis",
+		Endpoint:   server.URL,
+		TimeoutMS:  1000,
+		MaxRetries: 0,
+	})
+	if err != nil {
+		t.Fatalf("newOpenAICompatibleAnalysisProvider() error = %v", err)
+	}
+	provider := rawProvider.(*openAICompatibleAnalysisProvider)
+
+	var response map[string]any
+	err = provider.completeJSON(context.Background(), "system", map[string]string{"ping": "pong"}, &response)
+	if err == nil {
+		t.Fatal("completeJSON() error = nil, want dependency-unavailable failure")
+	}
+	if !index.IsDependencyUnavailable(err) {
+		t.Fatalf("completeJSON() error = %v, want dependency-unavailable classification", err)
+	}
+	details := index.DependencyUnavailableDetails(err)
+	if got, want := details["failure_class"], "schema_mismatch"; got != want {
+		t.Fatalf("details.failure_class = %#v, want %q", got, want)
+	}
+	if got, want := details["request_type"], "analysis"; got != want {
+		t.Fatalf("details.request_type = %#v, want %q", got, want)
+	}
 }

--- a/internal/app/operations.go
+++ b/internal/app/operations.go
@@ -23,6 +23,7 @@ const (
 type Issue struct {
 	Code     string
 	Message  string
+	Details  map[string]any
 	ExitCode int
 }
 
@@ -58,7 +59,10 @@ func executeWithConfig[Req any, Res any](ctx context.Context, configPath string,
 	result, err := run(cfg)
 	if err != nil {
 		issue := classify(cfg, err)
-		return failure[Req, Res](request, issue.Code, issue.Message, issue.ExitCode)
+		return Response[Req, Res]{
+			Request: request,
+			Issue:   issue,
+		}
 	}
 
 	return success(request, result)
@@ -94,11 +98,7 @@ func classifyExecutionError(cfg *config.Config, err error, policy operationExecu
 			ExitCode: 2,
 		}
 	case index.IsDependencyUnavailable(err):
-		return &Issue{
-			Code:     CodeDependencyUnavailable,
-			Message:  FormatDependencyUnavailableMessage(cfg, err),
-			ExitCode: 3,
-		}
+		return dependencyUnavailableIssue(cfg, err)
 	default:
 		code := strings.TrimSpace(policy.DefaultCode)
 		if code == "" {
@@ -209,11 +209,7 @@ func ensureFreshIndex(ctx context.Context, cfg *config.Config) *Issue {
 	case err == nil:
 		return nil
 	case index.IsDependencyUnavailable(err):
-		return &Issue{
-			Code:     CodeDependencyUnavailable,
-			Message:  FormatDependencyUnavailableMessage(cfg, err),
-			ExitCode: 3,
-		}
+		return dependencyUnavailableIssue(cfg, err)
 	case index.IsStaleIndex(err):
 		return &Issue{
 			Code:     CodeConfigError,
@@ -244,6 +240,15 @@ func failure[Req any, Res any](request Req, code, message string, exitCode int) 
 			Message:  message,
 			ExitCode: exitCode,
 		},
+	}
+}
+
+func dependencyUnavailableIssue(cfg *config.Config, err error) *Issue {
+	return &Issue{
+		Code:     CodeDependencyUnavailable,
+		Message:  FormatDependencyUnavailableMessage(cfg, err),
+		Details:  index.DependencyUnavailableDetails(err),
+		ExitCode: 3,
 	}
 }
 

--- a/internal/app/operations_test.go
+++ b/internal/app/operations_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/analysis"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/openaicompat"
 	"github.com/dusk-network/pituitary/internal/source"
 )
 
@@ -234,6 +235,41 @@ func TestFormatDependencyUnavailableMessageUsesRuntimeSpecificAPIKeyEnv(t *testi
 	}
 	if strings.Contains(message, "OPENAI_API_KEY") {
 		t.Fatalf("FormatDependencyUnavailableMessage() = %q, did not want embedder env var", message)
+	}
+}
+
+func TestClassifyExecutionErrorCarriesDependencyDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	err := openaicompat.NewDependencyUnavailableStatusWithDetails(openaicompat.FailureDetails{
+		Runtime:      "runtime.embedder",
+		Provider:     config.RuntimeProviderOpenAI,
+		Model:        "pituitary-embed",
+		Endpoint:     "http://127.0.0.1:1234/v1",
+		RequestType:  "embeddings",
+		FailureClass: openaicompat.FailureClassServer,
+		HTTPStatus:   http.StatusInternalServerError,
+		TimeoutMS:    1000,
+		MaxRetries:   2,
+		BatchSize:    8,
+		InputCount:   8,
+	}, http.StatusInternalServerError, "runtime.embedder failed")
+
+	issue := classifyExecutionError(nil, err, operationExecutionPolicy{})
+	if issue.Code != CodeDependencyUnavailable {
+		t.Fatalf("classifyExecutionError() code = %q, want %q", issue.Code, CodeDependencyUnavailable)
+	}
+	if got, want := issue.Details["runtime"], "runtime.embedder"; got != want {
+		t.Fatalf("issue.details.runtime = %#v, want %q", got, want)
+	}
+	if got, want := issue.Details["provider"], config.RuntimeProviderOpenAI; got != want {
+		t.Fatalf("issue.details.provider = %#v, want %q", got, want)
+	}
+	if got, want := issue.Details["failure_class"], openaicompat.FailureClassServer; got != want {
+		t.Fatalf("issue.details.failure_class = %#v, want %q", got, want)
+	}
+	if got, want := issue.Details["http_status"], http.StatusInternalServerError; got != want {
+		t.Fatalf("issue.details.http_status = %#v, want %d", got, want)
 	}
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -91,11 +91,7 @@ func fixtureEmbedderGuidance(cfg *config.Config, status *index.Status) []string 
 func classifyStatusError(cfg *config.Config, err error) *Issue {
 	switch {
 	case index.IsDependencyUnavailable(err):
-		return &Issue{
-			Code:     CodeDependencyUnavailable,
-			Message:  FormatDependencyUnavailableMessage(cfg, err),
-			ExitCode: 3,
-		}
+		return dependencyUnavailableIssue(cfg, err)
 	default:
 		return &Issue{
 			Code:     CodeInternalError,

--- a/internal/index/embedder.go
+++ b/internal/index/embedder.go
@@ -27,6 +27,16 @@ func (e *DependencyUnavailableError) RuntimeName() string {
 	return strings.TrimSpace(e.Runtime)
 }
 
+func (e *DependencyUnavailableError) DiagnosticFields() map[string]any {
+	values := map[string]any{
+		"failure_class": "dependency_unavailable",
+	}
+	if runtime := strings.TrimSpace(e.Runtime); runtime != "" {
+		values["runtime"] = runtime
+	}
+	return values
+}
+
 // IsDependencyUnavailable reports whether err wraps a dependency-unavailable failure.
 func IsDependencyUnavailable(err error) bool {
 	var target interface {
@@ -47,6 +57,27 @@ func DependencyUnavailableRuntime(err error) string {
 		return ""
 	}
 	return strings.TrimSpace(target.RuntimeName())
+}
+
+// DependencyUnavailableDetails reports structured diagnostic fields associated
+// with a dependency-unavailable failure, if the wrapped error exposes any.
+func DependencyUnavailableDetails(err error) map[string]any {
+	var target interface {
+		error
+		DiagnosticFields() map[string]any
+	}
+	if !errors.As(err, &target) {
+		return nil
+	}
+	values := target.DiagnosticFields()
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 // Embedder generates embeddings for rebuild and query-time retrieval.

--- a/internal/index/openai_embedder.go
+++ b/internal/index/openai_embedder.go
@@ -3,7 +3,6 @@ package index
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -58,7 +57,7 @@ func (e *openAICompatibleEmbedder) Dimension(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	if len(vectors) != 1 || len(vectors[0]) == 0 {
-		return 0, embedderDependencyUnavailable("%s returned no embedding dimensions", openAICompatibleEmbedderRuntime)
+		return 0, e.schemaMismatchError(1, "%s returned no embedding dimensions", openAICompatibleEmbedderRuntime)
 	}
 	return len(vectors[0]), nil
 }
@@ -142,10 +141,7 @@ func (e *openAICompatibleEmbedder) embedBatch(ctx context.Context, input []strin
 		return nil, err
 	}
 	if len(payload.Data) != len(input) {
-		return nil, &openaicompat.DependencyUnavailableError{
-			Runtime: openAICompatibleEmbedderRuntime,
-			Message: fmt.Sprintf("%s returned %d embedding(s) for %d input(s)", openAICompatibleEmbedderRuntime, len(payload.Data), len(input)),
-		}
+		return nil, e.schemaMismatchError(len(input), "%s returned %d embedding(s) for %d input(s)", openAICompatibleEmbedderRuntime, len(payload.Data), len(input))
 	}
 
 	vectors := make([][]float64, len(input))
@@ -155,10 +151,7 @@ func (e *openAICompatibleEmbedder) embedBatch(ctx context.Context, input []strin
 			index = i
 		}
 		if len(item.Embedding) == 0 {
-			return nil, &openaicompat.DependencyUnavailableError{
-				Runtime: openAICompatibleEmbedderRuntime,
-				Message: fmt.Sprintf("%s returned an empty embedding for input %d", openAICompatibleEmbedderRuntime, index),
-			}
+			return nil, e.schemaMismatchError(len(input), "%s returned an empty embedding for input %d", openAICompatibleEmbedderRuntime, index)
 		}
 		if err := e.cacheDimension(len(item.Embedding)); err != nil {
 			return nil, err
@@ -167,10 +160,7 @@ func (e *openAICompatibleEmbedder) embedBatch(ctx context.Context, input []strin
 	}
 	for i, vector := range vectors {
 		if len(vector) == 0 {
-			return nil, &openaicompat.DependencyUnavailableError{
-				Runtime: openAICompatibleEmbedderRuntime,
-				Message: fmt.Sprintf("%s omitted embedding for input %d", openAICompatibleEmbedderRuntime, i),
-			}
+			return nil, e.schemaMismatchError(len(input), "%s omitted embedding for input %d", openAICompatibleEmbedderRuntime, i)
 		}
 	}
 	return vectors, nil
@@ -205,7 +195,7 @@ func (e *openAICompatibleEmbedder) cachedDimension() int {
 
 func (e *openAICompatibleEmbedder) cacheDimension(dimension int) error {
 	if dimension <= 0 {
-		return embedderDependencyUnavailable("%s returned a non-positive embedding dimension", openAICompatibleEmbedderRuntime)
+		return e.schemaMismatchError(1, "%s returned a non-positive embedding dimension", openAICompatibleEmbedderRuntime)
 	}
 
 	e.mu.Lock()
@@ -215,14 +205,20 @@ func (e *openAICompatibleEmbedder) cacheDimension(dimension int) error {
 		return nil
 	}
 	if e.dimension != dimension {
-		return &openaicompat.DependencyUnavailableError{
-			Runtime: openAICompatibleEmbedderRuntime,
-			Message: fmt.Sprintf("%s changed embedding dimension from %d to %d", openAICompatibleEmbedderRuntime, e.dimension, dimension),
-		}
+		return e.schemaMismatchError(1, "%s changed embedding dimension from %d to %d", openAICompatibleEmbedderRuntime, e.dimension, dimension)
 	}
 	return nil
 }
 
-func embedderDependencyUnavailable(format string, args ...any) *openaicompat.DependencyUnavailableError {
-	return openaicompat.NewDependencyUnavailable(openAICompatibleEmbedderRuntime, format, args...)
+func (e *openAICompatibleEmbedder) embeddingFailureDetails(inputCount int) openaicompat.FailureDetails {
+	details := e.client.RequestFailureDetails("embeddings")
+	details.BatchSize = inputCount
+	details.InputCount = inputCount
+	return details
+}
+
+func (e *openAICompatibleEmbedder) schemaMismatchError(inputCount int, format string, args ...any) *openaicompat.DependencyUnavailableError {
+	details := e.embeddingFailureDetails(inputCount)
+	details.FailureClass = openaicompat.FailureClassSchemaMismatch
+	return openaicompat.NewDependencyUnavailableWithDetails(details, format, args...)
 }

--- a/internal/index/openai_embedder_test.go
+++ b/internal/index/openai_embedder_test.go
@@ -113,6 +113,16 @@ func TestOpenAICompatibleEmbedderRequiresConfiguredAPIKey(t *testing.T) {
 	if !strings.Contains(err.Error(), "missing API key for runtime.embedder") {
 		t.Fatalf("NewEmbedder() error = %q, want missing-API-key detail", err)
 	}
+	details := DependencyUnavailableDetails(err)
+	if got, want := details["runtime"], "runtime.embedder"; got != want {
+		t.Fatalf("details.runtime = %#v, want %q", got, want)
+	}
+	if got, want := details["provider"], config.RuntimeProviderOpenAI; got != want {
+		t.Fatalf("details.provider = %#v, want %q", got, want)
+	}
+	if got, want := details["failure_class"], "auth"; got != want {
+		t.Fatalf("details.failure_class = %#v, want %q", got, want)
+	}
 }
 
 func TestOpenAICompatibleEmbedderParsesStringErrorBodies(t *testing.T) {
@@ -151,6 +161,22 @@ func TestOpenAICompatibleEmbedderParsesStringErrorBodies(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), `{"error":"Model unloaded.."}`) {
 		t.Fatalf("EmbedQueries() error = %q, want parsed message instead of raw JSON", err)
+	}
+	details := DependencyUnavailableDetails(err)
+	if got, want := details["request_type"], "embeddings"; got != want {
+		t.Fatalf("details.request_type = %#v, want %q", got, want)
+	}
+	if got, want := details["batch_size"], 1; got != want {
+		t.Fatalf("details.batch_size = %#v, want %d", got, want)
+	}
+	if got, want := details["input_count"], 1; got != want {
+		t.Fatalf("details.input_count = %#v, want %d", got, want)
+	}
+	if got, want := details["http_status"], http.StatusBadRequest; got != want {
+		t.Fatalf("details.http_status = %#v, want %d", got, want)
+	}
+	if got, want := details["failure_class"], "dependency_unavailable"; got != want {
+		t.Fatalf("details.failure_class = %#v, want %q", got, want)
 	}
 }
 

--- a/internal/openaicompat/client.go
+++ b/internal/openaicompat/client.go
@@ -21,9 +21,11 @@ const responseSizeLimit = 4 << 20
 
 type Client struct {
 	Runtime    string
+	Provider   string
 	Model      string
 	Endpoint   string
 	Token      string
+	TimeoutMS  int
 	MaxRetries int
 	HTTPClient *http.Client
 }
@@ -68,11 +70,20 @@ type chatChoiceMessage struct {
 }
 
 func NewClient(provider config.RuntimeProvider, runtime string) (*Client, error) {
+	endpoint := strings.TrimRight(strings.TrimSpace(provider.Endpoint), "/")
 	token := ""
 	if envVar := strings.TrimSpace(provider.APIKeyEnv); envVar != "" {
 		token = strings.TrimSpace(os.Getenv(envVar))
 		if token == "" {
-			return nil, NewDependencyUnavailable(runtime, "missing API key for %s", runtime)
+			return nil, NewDependencyUnavailableWithDetails(FailureDetails{
+				Runtime:      strings.TrimSpace(runtime),
+				Provider:     config.RuntimeProviderOpenAI,
+				Model:        strings.TrimSpace(provider.Model),
+				Endpoint:     endpoint,
+				FailureClass: FailureClassAuth,
+				TimeoutMS:    provider.TimeoutMS,
+				MaxRetries:   provider.MaxRetries,
+			}, "missing API key for %s", runtime)
 		}
 	}
 
@@ -83,9 +94,11 @@ func NewClient(provider config.RuntimeProvider, runtime string) (*Client, error)
 
 	return &Client{
 		Runtime:    strings.TrimSpace(runtime),
+		Provider:   config.RuntimeProviderOpenAI,
 		Model:      strings.TrimSpace(provider.Model),
-		Endpoint:   strings.TrimRight(strings.TrimSpace(provider.Endpoint), "/"),
+		Endpoint:   endpoint,
 		Token:      token,
+		TimeoutMS:  provider.TimeoutMS,
 		MaxRetries: provider.MaxRetries,
 		HTTPClient: httpClient,
 	}, nil
@@ -100,13 +113,20 @@ func (c *Client) Embeddings(ctx context.Context, input []string) (*EmbeddingsRes
 		return nil, fmt.Errorf("encode %s request: %w", c.Runtime, err)
 	}
 
-	return doWithRetries(ctx, c, "/embeddings", body, func(resp *http.Response, responseBody []byte) (*EmbeddingsResponse, error) {
+	details := c.RequestFailureDetails("embeddings")
+	details.BatchSize = len(input)
+	details.InputCount = len(input)
+
+	return doWithRetries(ctx, c, "/embeddings", body, details, func(resp *http.Response, responseBody []byte) (*EmbeddingsResponse, error) {
 		var payload EmbeddingsResponse
 		if err := json.Unmarshal(responseBody, &payload); err != nil {
-			return nil, NewDependencyUnavailable(c.Runtime, "decode %s response: %v", c.Runtime, err)
+			failure := details
+			failure.FailureClass = FailureClassSchemaMismatch
+			return nil, NewDependencyUnavailableWithDetails(failure, "decode %s response: %v", c.Runtime, err)
 		}
 		if message := ExtractErrorValue(payload.Err); message != "" {
-			return nil, NewDependencyUnavailable(c.Runtime, "%s endpoint %s returned an error: %s", c.Runtime, resp.Request.URL, message)
+			failure := classifiedFailureDetails(details, 0, nil, message)
+			return nil, NewDependencyUnavailableWithDetails(failure, "%s endpoint %s returned an error: %s", c.Runtime, resp.Request.URL, message)
 		}
 		return &payload, nil
 	})
@@ -122,24 +142,46 @@ func (c *Client) ChatCompletionText(ctx context.Context, messages []ChatMessage,
 		return "", fmt.Errorf("encode %s request: %w", c.Runtime, err)
 	}
 
-	return doWithRetries(ctx, c, "/chat/completions", body, func(resp *http.Response, responseBody []byte) (string, error) {
+	details := c.RequestFailureDetails("analysis")
+	details.InputCount = len(messages)
+
+	return doWithRetries(ctx, c, "/chat/completions", body, details, func(resp *http.Response, responseBody []byte) (string, error) {
 		var payload chatResponse
 		if err := json.Unmarshal(responseBody, &payload); err != nil {
-			return "", NewDependencyUnavailable(c.Runtime, "decode %s response: %v", c.Runtime, err)
+			failure := details
+			failure.FailureClass = FailureClassSchemaMismatch
+			return "", NewDependencyUnavailableWithDetails(failure, "decode %s response: %v", c.Runtime, err)
 		}
 		if message := ExtractErrorValue(payload.Err); message != "" {
-			return "", NewDependencyUnavailable(c.Runtime, "%s endpoint %s returned an error: %s", c.Runtime, resp.Request.URL, message)
+			failure := classifiedFailureDetails(details, 0, nil, message)
+			return "", NewDependencyUnavailableWithDetails(failure, "%s endpoint %s returned an error: %s", c.Runtime, resp.Request.URL, message)
 		}
 		if len(payload.Choices) == 0 {
-			return "", NewDependencyUnavailable(c.Runtime, "%s returned no choices", c.Runtime)
+			failure := details
+			failure.FailureClass = FailureClassSchemaMismatch
+			return "", NewDependencyUnavailableWithDetails(failure, "%s returned no choices", c.Runtime)
 		}
 
 		text := ExtractMessageText(payload.Choices[0].Message.Content)
 		if text == "" {
-			return "", NewDependencyUnavailable(c.Runtime, "%s returned an empty message", c.Runtime)
+			failure := details
+			failure.FailureClass = FailureClassSchemaMismatch
+			return "", NewDependencyUnavailableWithDetails(failure, "%s returned an empty message", c.Runtime)
 		}
 		return text, nil
 	})
+}
+
+func (c *Client) RequestFailureDetails(requestType string) FailureDetails {
+	return FailureDetails{
+		Runtime:     strings.TrimSpace(c.Runtime),
+		Provider:    strings.TrimSpace(c.Provider),
+		Model:       strings.TrimSpace(c.Model),
+		Endpoint:    strings.TrimSpace(c.Endpoint),
+		RequestType: strings.TrimSpace(requestType),
+		TimeoutMS:   c.TimeoutMS,
+		MaxRetries:  c.MaxRetries,
+	}
 }
 
 func ExtractMessageText(raw json.RawMessage) string {
@@ -169,7 +211,7 @@ func ExtractMessageText(raw json.RawMessage) string {
 	return strings.TrimSpace(string(raw))
 }
 
-func doWithRetries[T any](ctx context.Context, client *Client, path string, body []byte, decode func(*http.Response, []byte) (T, error)) (T, error) {
+func doWithRetries[T any](ctx context.Context, client *Client, path string, body []byte, details FailureDetails, decode func(*http.Response, []byte) (T, error)) (T, error) {
 	var zero T
 	var lastErr error
 
@@ -188,7 +230,8 @@ func doWithRetries[T any](ctx context.Context, client *Client, path string, body
 			if errors.Is(err, context.Canceled) || (errors.Is(err, context.DeadlineExceeded) && ctx.Err() != nil) {
 				return zero, err
 			}
-			lastErr = NewDependencyUnavailable(client.Runtime, "call %s endpoint %s: %v", client.Runtime, client.Endpoint, err)
+			failure := classifiedFailureDetails(details, 0, err, err.Error())
+			lastErr = NewDependencyUnavailableWithDetails(failure, "call %s endpoint %s: %v", client.Runtime, client.Endpoint, err)
 			if shouldRetry(err, 0) && attempt < client.MaxRetries {
 				if waitErr := waitBeforeRetry(ctx, attempt, 0); waitErr != nil {
 					return zero, waitErr
@@ -202,7 +245,8 @@ func doWithRetries[T any](ctx context.Context, client *Client, path string, body
 		responseBody, readErr := io.ReadAll(io.LimitReader(resp.Body, responseSizeLimit))
 		closeErr := resp.Body.Close()
 		if readErr != nil {
-			err = NewDependencyUnavailable(client.Runtime, "read %s response: %v", client.Runtime, readErr)
+			failure := classifiedFailureDetails(details, 0, readErr, readErr.Error())
+			err = NewDependencyUnavailableWithDetails(failure, "read %s response: %v", client.Runtime, readErr)
 		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			message := ExtractErrorMessage(responseBody)
 			if message == "" {
@@ -211,19 +255,22 @@ func doWithRetries[T any](ctx context.Context, client *Client, path string, body
 			if message == "" {
 				message = http.StatusText(resp.StatusCode)
 			}
-			err = NewDependencyUnavailableStatus(client.Runtime, resp.StatusCode, "%s endpoint %s returned %s: %s", client.Runtime, resp.Request.URL, resp.Status, message)
+			failure := classifiedFailureDetails(details, resp.StatusCode, nil, message)
+			err = NewDependencyUnavailableStatusWithDetails(failure, resp.StatusCode, "%s endpoint %s returned %s: %s", client.Runtime, resp.Request.URL, resp.Status, message)
 		} else {
 			value, decodeErr := decode(resp, responseBody)
 			if decodeErr == nil {
 				if closeErr != nil {
-					return zero, NewDependencyUnavailable(client.Runtime, "close %s response: %v", client.Runtime, closeErr)
+					failure := classifiedFailureDetails(details, 0, closeErr, closeErr.Error())
+					return zero, NewDependencyUnavailableWithDetails(failure, "close %s response: %v", client.Runtime, closeErr)
 				}
 				return value, nil
 			}
 			err = decodeErr
 		}
 		if closeErr != nil && err == nil {
-			err = NewDependencyUnavailable(client.Runtime, "close %s response: %v", client.Runtime, closeErr)
+			failure := classifiedFailureDetails(details, 0, closeErr, closeErr.Error())
+			err = NewDependencyUnavailableWithDetails(failure, "close %s response: %v", client.Runtime, closeErr)
 		}
 
 		lastErr = err
@@ -258,6 +305,86 @@ func shouldRetry(err error, statusCode int) bool {
 	return strings.Contains(lower, "connection refused") ||
 		strings.Contains(lower, "connection reset") ||
 		strings.Contains(lower, "broken pipe")
+}
+
+func classifiedFailureDetails(details FailureDetails, statusCode int, err error, message string) FailureDetails {
+	failure := details
+	failure.HTTPStatus = statusCode
+	failure.FailureClass = normalizeFailureClass(statusCode, err, message)
+	return failure
+}
+
+func normalizeFailureClass(statusCode int, err error, message string) string {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return FailureClassAuth
+	case http.StatusTooManyRequests:
+		return FailureClassRateLimit
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		return FailureClassTimeout
+	}
+	if statusCode >= http.StatusInternalServerError {
+		return FailureClassServer
+	}
+
+	lower := strings.ToLower(strings.TrimSpace(message))
+	switch {
+	case mentionsAuthFailure(lower):
+		return FailureClassAuth
+	case mentionsRateLimit(lower):
+		return FailureClassRateLimit
+	case isTimeoutFailure(err, lower):
+		return FailureClassTimeout
+	case isTransportFailure(err, lower):
+		return FailureClassTransport
+	default:
+		return FailureClassDependency
+	}
+}
+
+func mentionsAuthFailure(message string) bool {
+	return strings.Contains(message, "api key") ||
+		strings.Contains(message, "apikey") ||
+		strings.Contains(message, "auth") ||
+		strings.Contains(message, "unauthorized") ||
+		strings.Contains(message, "forbidden")
+}
+
+func mentionsRateLimit(message string) bool {
+	return strings.Contains(message, "rate limit") ||
+		strings.Contains(message, "too many requests") ||
+		strings.Contains(message, "quota exceeded")
+}
+
+func isTimeoutFailure(err error, message string) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return strings.Contains(message, "context deadline exceeded") ||
+		strings.Contains(message, "client.timeout exceeded") ||
+		strings.Contains(message, "timeout awaiting response headers") ||
+		strings.Contains(message, "i/o timeout") ||
+		strings.Contains(message, "timed out")
+}
+
+func isTransportFailure(err error, message string) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	return strings.Contains(message, "connection refused") ||
+		strings.Contains(message, "connection reset") ||
+		strings.Contains(message, "broken pipe") ||
+		strings.Contains(message, "couldn't connect to server") ||
+		strings.Contains(message, "failed to connect") ||
+		strings.Contains(message, "no such host") ||
+		strings.Contains(message, "network is unreachable") ||
+		strings.Contains(message, "unexpected eof") ||
+		message == "eof"
 }
 
 func retryAfterDuration(value string) time.Duration {

--- a/internal/openaicompat/client_test.go
+++ b/internal/openaicompat/client_test.go
@@ -71,7 +71,7 @@ func TestDoWithRetriesReturnsCloseErrorOnSuccessfulResponse(t *testing.T) {
 		},
 	}
 
-	_, err := doWithRetries(context.Background(), client, "/v1/test", []byte(`{}`), func(resp *http.Response, body []byte) (string, error) {
+	_, err := doWithRetries(context.Background(), client, "/v1/test", []byte(`{}`), client.RequestFailureDetails("test"), func(resp *http.Response, body []byte) (string, error) {
 		return "ok", nil
 	})
 	if err == nil {

--- a/internal/openaicompat/errors.go
+++ b/internal/openaicompat/errors.go
@@ -6,12 +6,80 @@ import (
 	"strings"
 )
 
+const (
+	FailureClassAuth           = "auth"
+	FailureClassDependency     = "dependency_unavailable"
+	FailureClassRateLimit      = "rate_limit"
+	FailureClassSchemaMismatch = "schema_mismatch"
+	FailureClassServer         = "server"
+	FailureClassTimeout        = "timeout"
+	FailureClassTransport      = "transport"
+)
+
+// FailureDetails captures structured runtime metadata for provider failures.
+type FailureDetails struct {
+	Runtime      string
+	Provider     string
+	Model        string
+	Endpoint     string
+	RequestType  string
+	FailureClass string
+	HTTPStatus   int
+	TimeoutMS    int
+	MaxRetries   int
+	BatchSize    int
+	InputCount   int
+}
+
+// Map returns the details as a JSON-friendly object with empty fields omitted.
+func (d FailureDetails) Map() map[string]any {
+	values := map[string]any{}
+	if value := strings.TrimSpace(d.Runtime); value != "" {
+		values["runtime"] = value
+	}
+	if value := strings.TrimSpace(d.Provider); value != "" {
+		values["provider"] = value
+	}
+	if value := strings.TrimSpace(d.Model); value != "" {
+		values["model"] = value
+	}
+	if value := strings.TrimSpace(d.Endpoint); value != "" {
+		values["endpoint"] = value
+	}
+	if value := strings.TrimSpace(d.RequestType); value != "" {
+		values["request_type"] = value
+	}
+	if value := strings.TrimSpace(d.FailureClass); value != "" {
+		values["failure_class"] = value
+	}
+	if d.HTTPStatus > 0 {
+		values["http_status"] = d.HTTPStatus
+	}
+	if d.TimeoutMS > 0 {
+		values["timeout_ms"] = d.TimeoutMS
+	}
+	if d.MaxRetries > 0 {
+		values["max_retries"] = d.MaxRetries
+	}
+	if d.BatchSize > 0 {
+		values["batch_size"] = d.BatchSize
+	}
+	if d.InputCount > 0 {
+		values["input_count"] = d.InputCount
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
 // DependencyUnavailableError indicates that an OpenAI-compatible runtime could
 // not satisfy the current request.
 type DependencyUnavailableError struct {
 	Runtime    string
 	Message    string
 	HTTPStatus int
+	Details    *FailureDetails
 }
 
 func (e *DependencyUnavailableError) Error() string {
@@ -29,6 +97,21 @@ func (e *DependencyUnavailableError) HTTPStatusCode() int {
 	return e.HTTPStatus
 }
 
+// DiagnosticFields returns normalized structured diagnostics when available.
+func (e *DependencyUnavailableError) DiagnosticFields() map[string]any {
+	if e == nil || e.Details == nil {
+		return nil
+	}
+	details := *e.Details
+	if strings.TrimSpace(details.Runtime) == "" {
+		details.Runtime = e.Runtime
+	}
+	if details.HTTPStatus == 0 {
+		details.HTTPStatus = e.HTTPStatus
+	}
+	return details.Map()
+}
+
 // NewDependencyUnavailable formats a dependency-unavailable runtime error.
 func NewDependencyUnavailable(runtime, format string, args ...any) *DependencyUnavailableError {
 	return &DependencyUnavailableError{
@@ -44,6 +127,26 @@ func NewDependencyUnavailableStatus(runtime string, status int, format string, a
 		Runtime:    runtime,
 		Message:    fmt.Sprintf(format, args...),
 		HTTPStatus: status,
+	}
+}
+
+// NewDependencyUnavailableWithDetails records structured failure metadata.
+func NewDependencyUnavailableWithDetails(details FailureDetails, format string, args ...any) *DependencyUnavailableError {
+	return &DependencyUnavailableError{
+		Runtime: details.Runtime,
+		Message: fmt.Sprintf(format, args...),
+		Details: &details,
+	}
+}
+
+// NewDependencyUnavailableStatusWithDetails records structured failure metadata plus an HTTP status.
+func NewDependencyUnavailableStatusWithDetails(details FailureDetails, status int, format string, args ...any) *DependencyUnavailableError {
+	details.HTTPStatus = status
+	return &DependencyUnavailableError{
+		Runtime:    details.Runtime,
+		Message:    fmt.Sprintf(format, args...),
+		HTTPStatus: status,
+		Details:    &details,
 	}
 }
 


### PR DESCRIPTION
## Summary
- add structured diagnostic metadata and normalized failure classes for OpenAI-compatible runtime failures
- preserve dependency diagnostics through app responses and CLI JSON errors
- cover embeddings, analysis, and status JSON output with focused tests

Closes #211