### PR TITLE
Add multi-repo workspace indexing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,6 +108,8 @@ include = ["**/*.md"]
 
 This keeps the first ship explicit and easy to reason about. The indexed config remains explicit even as the repo grows into inferred-contract sources: `pituitary discover` may propose a local `.pituitary/pituitary.toml`, but it must stay conservative, inspectable before write, and never introduce hidden indexing behavior behind the user's back.
 
+When one logical workspace spans multiple repositories, the primary `workspace.root` may also declare `workspace.repo_id`, extra `[[workspace.repos]]` roots, and per-source `repo = "..."` bindings. Search, drift, impact, status, and rebuild outputs must then surface repo identity alongside source-relative paths so duplicate filenames from sibling repos remain distinguishable.
+
 When the config schema changes, Pituitary should detect older known shapes explicitly and provide a migration path instead of failing with a generic unsupported-section error. The current schema is versioned with `schema_version = 3`, and legacy `[project]` configs should be rewritten through `pituitary migrate-config`. Schema `3` also reserves `[sources.options]` for adapter-specific typed settings while keeping the kernel-owned source fields explicit.
 
 Inferred `markdown_contract` records must preserve confidence metadata alongside the normalized artifact so result surfaces can distinguish strong explicit extraction from weaker path/default fallbacks. Search should expose those confidence signals inline, while higher-stakes outputs such as impact and doc-drift should elevate weak inference as warnings instead of silently treating it as equally strong.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ pituitary status                       # index health at a glance
 
 All commands output JSON with `--format json`. Agents can set `PITUITARY_FORMAT=json`, and redirected stdout defaults to JSON automatically. `review-spec` also supports `--format markdown` and `--format html` for shareable reports with full evidence chains.
 
+One `pituitary.toml` can also span multiple repository roots. Bind a source to a named repo root with `repo = "..."`, and Pituitary carries that repo identity through search, drift, impact, status, and index output so cross-repo results stay unambiguous.
+
 For agent integrations, use `pituitary schema <command> --format json` to inspect request/response contracts, and prefer `--request-file PATH|-` on analysis commands when shell escaping would be brittle. Results that include raw repo excerpts or evidence now carry `result.content_trust` metadata so callers can treat returned workspace text as untrusted input instead of executable instructions.
 
 See the [cheatsheet](docs/cheatsheet.md) for every command, the [full reference](docs/reference.md) for configuration/runtime/spec details, the reusable multi-editor package at [skills/pituitary-cli/README.md](skills/pituitary-cli/README.md), and [AGENTS.md](AGENTS.md) for repo-native agent instructions.

--- a/cmd/analyze_impact_test.go
+++ b/cmd/analyze_impact_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -216,5 +217,37 @@ func TestRunAnalyzeImpactWithRequestFileJSON(t *testing.T) {
 	}
 	if len(payload.Errors) != 0 {
 		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
+func TestRunAnalyzeImpactTextIncludesCrossRepoArtifacts(t *testing.T) {
+	repo := writeMultiRepoSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runAnalyzeImpact([]string{"--spec-ref", "SPEC-100"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runAnalyzeImpact() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runAnalyzeImpact() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"affected specs: 1",
+		"SPEC-200 | repo: shared | depends_on | Shared Repo Rollout",
+		"affected docs:",
+		"doc://shared/guides/api-rate-limits | repo: shared | source: docs/guides/api-rate-limits.md",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("runAnalyzeImpact() output %q does not contain %q", out, want)
+		}
 	}
 }

--- a/cmd/check_doc_drift_test.go
+++ b/cmd/check_doc_drift_test.go
@@ -218,6 +218,37 @@ func TestRunCheckDocDriftTextIncludesRemediation(t *testing.T) {
 	}
 }
 
+func TestRunCheckDocDriftTextIncludesRepoIdentity(t *testing.T) {
+	repo := writeMultiRepoSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runCheckDocDrift([]string{"--scope", "all"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckDocDrift() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckDocDrift() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"[shared] docs/guides/api-rate-limits.md",
+		"██ DRIFT",
+		"deterministic remediation is available, but `pituitary fix --path` only targets primary-workspace docs",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("runCheckDocDrift() output %q does not contain %q", out, want)
+		}
+	}
+}
+
 func TestRunCheckDocDriftWarnsOnWeakAcceptedContracts(t *testing.T) {
 	repo := writeWeakAcceptedContractWorkspace(t)
 

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -46,6 +46,30 @@ path = "specs"
 	}
 }
 
+func TestRunIndexReportsRepoCoverage(t *testing.T) {
+	repo := writeMultiRepoSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"repo: primary | items: 2 | specs: 1 | docs: 1",
+		"repo: shared | items: 2 | specs: 1 | docs: 1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("runIndex() output %q does not contain %q", out, want)
+		}
+	}
+}
+
 func TestRunIndexRequiresRebuild(t *testing.T) {
 	repo := t.TempDir()
 	mustWriteIndexFixture(t, repo, `

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -130,6 +130,7 @@ func renderIndexResult(w io.Writer, result *index.RebuildResult) {
 		fmt.Fprintf(w, "dry run validated %d artifact(s), %d chunk(s), and %d edge(s)\n", result.ArtifactCount, result.ChunkCount, result.EdgeCount)
 		fmt.Fprintf(w, "index path: %s\n", result.IndexPath)
 		renderIndexReuseSummary(w, result)
+		renderIndexRepoCoverage(w, result.Repos)
 		renderIndexSourceSummaries(w, result.Sources)
 		fmt.Fprintln(w, "database write: skipped")
 		return
@@ -137,6 +138,7 @@ func renderIndexResult(w io.Writer, result *index.RebuildResult) {
 	fmt.Fprintf(w, "indexed %d artifact(s), %d chunk(s), and %d edge(s)\n", result.ArtifactCount, result.ChunkCount, result.EdgeCount)
 	fmt.Fprintf(w, "database: %s\n", result.IndexPath)
 	renderIndexReuseSummary(w, result)
+	renderIndexRepoCoverage(w, result.Repos)
 	renderIndexSourceSummaries(w, result.Sources)
 }
 
@@ -299,6 +301,9 @@ func renderIndexSourceSummaries(w io.Writer, sources []source.LoadSourceSummary)
 		if summary.DocCount > 0 {
 			fmt.Fprintf(w, " | docs: %d", summary.DocCount)
 		}
+		if summary.Repo != "" {
+			fmt.Fprintf(w, " | repo: %s", summary.Repo)
+		}
 		fmt.Fprintln(w)
 	}
 }
@@ -350,6 +355,12 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 		fmt.Fprintf(w, "  %s %s\n", p.dim("index:"), p.green("present"))
 	} else {
 		fmt.Fprintf(w, "  %s %s\n", p.dim("index:"), p.red("missing"))
+	}
+	if len(result.Repos) > 0 {
+		fmt.Fprintf(w, "  %s\n", p.white("REPO COVERAGE"))
+		for i, repo := range result.Repos {
+			fmt.Fprintf(w, "  %s %s\n", p.treeItem(i == len(result.Repos)-1), renderRepoCoverageLine(repo))
+		}
 	}
 	if result.Freshness != nil {
 		fmt.Fprintf(w, "  %s %s\n", p.dim("index freshness:"), renderFreshnessLabel(p, result.Freshness.State))
@@ -515,6 +526,9 @@ func renderSearchSpecsResult(w io.Writer, result *index.SearchSpecResult) {
 
 	for i, match := range result.Matches {
 		fmt.Fprintf(w, "%d. %s | %s | %.3f\n", i+1, match.Ref, match.SectionHeading, match.Score)
+		if details := searchMatchDetailLine(match); details != "" {
+			fmt.Fprintf(w, "   %s\n", details)
+		}
 		if match.Excerpt != "" {
 			fmt.Fprintln(w, match.Excerpt)
 		}
@@ -531,14 +545,16 @@ func renderSearchSpecsTable(w io.Writer, result *index.SearchSpecResult) {
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "REF\tTITLE\tSECTION\tSCORE")
+	fmt.Fprintln(tw, "REF\tREPO\tTITLE\tSECTION\tSOURCE\tSCORE")
 	for _, match := range result.Matches {
 		fmt.Fprintf(
 			tw,
-			"%s\t%s\t%s\t%.3f\n",
+			"%s\t%s\t%s\t%s\t%s\t%.3f\n",
 			renderTableValue(match.Ref, 12),
+			renderTableValue(match.Repo, 16),
 			renderTableValue(match.Title, 28),
 			renderTableValue(match.SectionHeading, 36),
+			renderTableValue(displaySourcePath(match.SourceRef), 40),
 			match.Score,
 		)
 	}
@@ -561,6 +577,34 @@ func renderTableValue(value string, maxWidth int) string {
 		return string(runes[:maxWidth])
 	}
 	return string(runes[:maxWidth-3]) + "..."
+}
+
+func searchMatchDetailLine(match index.SearchSpecMatch) string {
+	parts := make([]string, 0, 2)
+	if match.Repo != "" {
+		parts = append(parts, "repo: "+match.Repo)
+	}
+	if match.SourceRef != "" {
+		parts = append(parts, "source: "+displaySourcePath(match.SourceRef))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func renderIndexRepoCoverage(w io.Writer, repos []index.RepoCoverage) {
+	for _, repo := range repos {
+		fmt.Fprintf(w, "repo: %s\n", renderRepoCoverageLine(repo))
+	}
+}
+
+func renderRepoCoverageLine(repo index.RepoCoverage) string {
+	line := fmt.Sprintf("%s | items: %d", repo.Repo, repo.ItemCount)
+	if repo.SpecCount > 0 {
+		line += fmt.Sprintf(" | specs: %d", repo.SpecCount)
+	}
+	if repo.DocCount > 0 {
+		line += fmt.Sprintf(" | docs: %d", repo.DocCount)
+	}
+	return line
 }
 
 func renderOverlapResult(w io.Writer, result *analysis.OverlapResult) {
@@ -602,8 +646,39 @@ func renderCompareResult(w io.Writer, result *analysis.CompareResult) {
 func renderAnalyzeImpactResult(w io.Writer, result *analysis.AnalyzeImpactResult) {
 	fmt.Fprintf(w, "spec: %s | change_type: %s\n", result.SpecRef, result.ChangeType)
 	fmt.Fprintf(w, "affected specs: %d\n", len(result.AffectedSpecs))
+	for _, item := range result.AffectedSpecs {
+		fmt.Fprintf(w, "- %s", item.Ref)
+		if item.Repo != "" {
+			fmt.Fprintf(w, " | repo: %s", item.Repo)
+		}
+		fmt.Fprintf(w, " | %s", item.Relationship)
+		if item.Historical {
+			fmt.Fprint(w, " | historical")
+		}
+		if item.Title != "" {
+			fmt.Fprintf(w, " | %s", item.Title)
+		}
+		fmt.Fprintln(w)
+	}
 	fmt.Fprintf(w, "affected refs: %d\n", len(result.AffectedRefs))
+	for _, item := range result.AffectedRefs {
+		fmt.Fprintf(w, "- %s | %s\n", item.Ref, item.Kind)
+	}
 	fmt.Fprintf(w, "affected docs: %d\n", len(result.AffectedDocs))
+	for _, item := range result.AffectedDocs {
+		fmt.Fprintf(w, "- %s", item.Ref)
+		if item.Repo != "" {
+			fmt.Fprintf(w, " | repo: %s", item.Repo)
+		}
+		if item.SourceRef != "" {
+			fmt.Fprintf(w, " | source: %s", displaySourcePath(item.SourceRef))
+		}
+		fmt.Fprintf(w, " | %.3f", item.Score)
+		if item.Title != "" {
+			fmt.Fprintf(w, " | %s", item.Title)
+		}
+		fmt.Fprintln(w)
+	}
 }
 
 func renderComplianceResult(w io.Writer, result *analysis.ComplianceResult) {
@@ -716,7 +791,7 @@ func renderDocDriftResult(w io.Writer, result *analysis.DocDriftResult) {
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
-		docLabel := preferredDocLabel(assessment.DocRef, assessment.SourceRef)
+		docLabel := repoPathLabel(assessment.Repo, preferredDocLabel(assessment.DocRef, assessment.SourceRef))
 		fmt.Fprintf(w, "  %s", p.cyan(docLabel))
 		if padding := docDriftPadding(docLabel); padding > 0 {
 			fmt.Fprint(w, strings.Repeat(" ", padding))
@@ -739,12 +814,17 @@ func renderDocDriftResult(w io.Writer, result *analysis.DocDriftResult) {
 			fmt.Fprintf(w, "\n    %s %s\n", p.arrow(), assessment.Rationale)
 		}
 		if suggestions := remediation[assessment.DocRef]; len(suggestions) > 0 {
-			pathArg := docLabel
+			pathArg := preferredDocLabel(assessment.DocRef, assessment.SourceRef)
 			if assessment.SourceRef != "" {
-				pathArg = assessment.SourceRef
+				pathArg = displaySourcePath(assessment.SourceRef)
 			}
-			fmt.Fprintf(w, "\n    %s pituitary fix --path %s %s\n", p.green("fix:"), pathArg, p.dim(fmt.Sprintf("(%d edits)", len(suggestions))))
-			fmt.Fprintf(w, "    %s  run `pituitary review-spec --format html --path <spec>` for the full evidence report\n", p.info())
+			if isNonPrimaryRepoDoc(assessment.DocRef, assessment.Repo) {
+				fmt.Fprintf(w, "\n    %s  deterministic remediation is available, but `pituitary fix --path` only targets primary-workspace docs; inspect %s manually\n", p.info(), p.cyan(docLabel))
+				fmt.Fprintf(w, "    %s  run `pituitary review-spec --format html --path <spec>` for the full evidence report\n", p.info())
+			} else {
+				fmt.Fprintf(w, "\n    %s pituitary fix --path %s %s\n", p.green("fix:"), pathArg, p.dim(fmt.Sprintf("(%d edits)", len(suggestions))))
+				fmt.Fprintf(w, "    %s  run `pituitary review-spec --format html --path <spec>` for the full evidence report\n", p.info())
+			}
 		} else if assessment.Status == "drift" || assessment.Status == "possible_drift" {
 			fmt.Fprintf(w, "\n    %s  run `pituitary review-spec --format html --path <spec>` for the full evidence chain (no deterministic fix available)\n", p.info())
 		}
@@ -844,7 +924,7 @@ func renderReviewResult(w io.Writer, result *analysis.ReviewResult) {
 		fmt.Fprintf(w, "  %s %s\n", p.treeLast(), p.dim("no drifting docs detected"))
 	} else {
 		for i, assessment := range driftAssessments {
-			fmt.Fprintf(w, "  %s %s  %s\n", p.treeBranch(i == len(driftAssessments)-1), p.cyan(preferredDocLabel(assessment.DocRef, assessment.SourceRef)), driftAssessmentBadge(p, assessment.Status))
+			fmt.Fprintf(w, "  %s %s  %s\n", p.treeBranch(i == len(driftAssessments)-1), p.cyan(repoPathLabel(assessment.Repo, preferredDocLabel(assessment.DocRef, assessment.SourceRef))), driftAssessmentBadge(p, assessment.Status))
 			if suggestions := remediationItemsByDocRef(result.DocRemediation)[assessment.DocRef]; len(suggestions) > 0 {
 				fmt.Fprintf(w, "     %s %d suggested edits %s\n", p.arrow(), len(suggestions), p.dim("(see check-doc-drift for detail)"))
 			}
@@ -941,6 +1021,9 @@ func renderReviewMarkdown(w io.Writer, result *analysis.ReviewResult) {
 			fmt.Fprintln(w, "- Top impacted specs:")
 			for _, item := range topImpactedSpecs(result.Impact.AffectedSpecs, 3) {
 				fmt.Fprintf(w, "  - `%s` %s (%s", item.Ref, item.Title, item.Relationship)
+				if item.Repo != "" {
+					fmt.Fprintf(w, ", repo %s", item.Repo)
+				}
 				if item.Historical {
 					fmt.Fprint(w, ", historical")
 				}
@@ -956,6 +1039,9 @@ func renderReviewMarkdown(w io.Writer, result *analysis.ReviewResult) {
 			fmt.Fprintln(w, "- Top impacted docs:")
 			for _, item := range topImpactedDocs(result.Impact.AffectedDocs, 3) {
 				fmt.Fprintf(w, "  - `%s` %s (score %.3f", item.Ref, item.Title, item.Score)
+				if item.Repo != "" {
+					fmt.Fprintf(w, ", repo %s", item.Repo)
+				}
 				if item.SourceRef != "" {
 					fmt.Fprintf(w, ", %s", item.SourceRef)
 				}
@@ -1608,9 +1694,38 @@ func complianceBadge(p renderPresentation, label string) string {
 
 func preferredDocLabel(docRef, sourceRef string) string {
 	if strings.TrimSpace(sourceRef) != "" {
-		return sourceRef
+		return displaySourcePath(sourceRef)
 	}
 	return docRef
+}
+
+func displaySourcePath(sourceRef string) string {
+	sourceRef = strings.TrimSpace(sourceRef)
+	if sourceRef == "" {
+		return ""
+	}
+	return strings.TrimPrefix(sourceRef, "file://")
+}
+
+func repoPathLabel(repo, label string) string {
+	repo = strings.TrimSpace(repo)
+	label = strings.TrimSpace(label)
+	switch {
+	case repo == "":
+		return label
+	case label == "":
+		return repo
+	default:
+		return fmt.Sprintf("[%s] %s", repo, label)
+	}
+}
+
+func isNonPrimaryRepoDoc(docRef, repo string) bool {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(docRef), "doc://"+repo+"/")
 }
 
 func docDriftPadding(label string) int {
@@ -1675,6 +1790,9 @@ func reviewImpactLines(result *analysis.AnalyzeImpactResult) []string {
 	lines := make([]string, 0, 6)
 	for _, item := range topImpactedSpecs(result.AffectedSpecs, 2) {
 		line := fmt.Sprintf("%s  %s · %s", item.Ref, item.Title, item.Relationship)
+		if item.Repo != "" {
+			line += " · repo: " + item.Repo
+		}
 		if item.Historical {
 			line += " · historical"
 		}
@@ -1682,6 +1800,12 @@ func reviewImpactLines(result *analysis.AnalyzeImpactResult) []string {
 	}
 	for _, item := range topImpactedDocs(result.AffectedDocs, 2) {
 		line := fmt.Sprintf("%s  %.3f", item.Ref, item.Score)
+		if item.Repo != "" {
+			line += " · repo: " + item.Repo
+		}
+		if item.SourceRef != "" {
+			line += " · " + displaySourcePath(item.SourceRef)
+		}
 		lines = append(lines, line)
 	}
 	return lines
@@ -1797,6 +1921,7 @@ func driftAssessmentsFromItems(items []analysis.DriftItem) []analysis.DocDriftAs
 		result = append(result, analysis.DocDriftAssessment{
 			DocRef:    item.DocRef,
 			Title:     item.Title,
+			Repo:      item.Repo,
 			SourceRef: item.SourceRef,
 			Status:    "drift",
 			SpecRefs:  append([]string(nil), item.SpecRefs...),

--- a/cmd/search_specs_test.go
+++ b/cmd/search_specs_test.go
@@ -68,6 +68,51 @@ func TestRunSearchSpecsJSON(t *testing.T) {
 	}
 }
 
+func TestRunSearchSpecsJSONIncludesRepoAndSource(t *testing.T) {
+	repo := writeMultiRepoSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runSearchSpecs([]string{"--query", "shared repo rollout", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runSearchSpecs() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runSearchSpecs() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Matches []struct {
+				Ref       string `json:"ref"`
+				Repo      string `json:"repo"`
+				SourceRef string `json:"source_ref"`
+			} `json:"matches"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal search payload: %v", err)
+	}
+	if len(payload.Result.Matches) == 0 {
+		t.Fatal("payload returned no matches")
+	}
+	if got, want := payload.Result.Matches[0].Ref, "SPEC-200"; got != want {
+		t.Fatalf("top match ref = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.Matches[0].Repo, "shared"; got != want {
+		t.Fatalf("top match repo = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.Matches[0].SourceRef, "file://specs/shared-rollout/spec.toml"; got != want {
+		t.Fatalf("top match source_ref = %q, want %q", got, want)
+	}
+}
+
 func TestRunSearchSpecsTable(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 
@@ -378,6 +423,102 @@ kind = "markdown_docs"
 path = "docs"
 include = ["guides/*.md", "runbooks/*.md"]
 	`)
+	return root
+}
+
+func writeMultiRepoSearchWorkspace(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	primary := filepath.Join(root, "primary")
+	shared := filepath.Join(root, "shared")
+	mustWriteIndexFixture(t, root, `
+[workspace]
+root = "`+filepath.ToSlash(primary)+`"
+repo_id = "primary"
+index_path = "`+filepath.ToSlash(filepath.Join(root, ".pituitary", "pituitary.db"))+`"
+
+[[workspace.repos]]
+id = "shared"
+root = "`+filepath.ToSlash(shared)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "primary-specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "primary-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+
+[[sources]]
+name = "shared-specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+repo = "shared"
+path = "specs"
+
+[[sources]]
+name = "shared-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+repo = "shared"
+path = "docs"
+include = ["guides/*.md"]
+	`)
+	mustWriteFileCmd(t, filepath.Join(primary, "specs", "tenant-rate-limits", "spec.toml"), `
+id = "SPEC-100"
+title = "Tenant Rate Limits"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFileCmd(t, filepath.Join(primary, "specs", "tenant-rate-limits", "body.md"), `
+# Tenant Rate Limits
+
+## Defaults
+
+The default rate limit is 200 requests per minute.
+`)
+	mustWriteFileCmd(t, filepath.Join(primary, "docs", "guides", "api-rate-limits.md"), `
+# API Rate Limits
+
+The default rate limit is 200 requests per minute.
+`)
+	mustWriteFileCmd(t, filepath.Join(shared, "specs", "shared-rollout", "spec.toml"), `
+id = "SPEC-200"
+title = "Shared Repo Rollout"
+status = "accepted"
+domain = "api"
+body = "body.md"
+depends_on = ["SPEC-100"]
+`)
+	mustWriteFileCmd(t, filepath.Join(shared, "specs", "shared-rollout", "body.md"), `
+# Shared Repo Rollout
+
+## Dependencies
+
+This rollout depends on SPEC-100.
+
+## Tasks
+
+Update shared consumers to respect the 200 requests per minute tenant default.
+`)
+	mustWriteFileCmd(t, filepath.Join(shared, "docs", "guides", "api-rate-limits.md"), `
+# API Rate Limits
+
+The default rate limit is 100 requests per minute.
+`)
 	return root
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -30,6 +30,7 @@ type statusResult struct {
 	SpecCount         int                        `json:"spec_count"`
 	DocCount          int                        `json:"doc_count"`
 	ChunkCount        int                        `json:"chunk_count"`
+	Repos             []index.RepoCoverage       `json:"repo_coverage,omitempty"`
 	ArtifactLocations *statusArtifactLocation    `json:"artifact_locations,omitempty"`
 	RelationGraph     *index.RelationGraphStatus `json:"relation_graph,omitempty"`
 	Runtime           *runtimeprobe.Result       `json:"runtime,omitempty"`
@@ -129,6 +130,7 @@ func newStatusResult(result *app.StatusResult, resolution *configResolution) *st
 		SpecCount:         result.Index.SpecCount,
 		DocCount:          result.Index.DocCount,
 		ChunkCount:        result.Index.ChunkCount,
+		Repos:             append([]index.RepoCoverage(nil), result.Index.Repos...),
 		ArtifactLocations: buildStatusArtifactLocations(result.WorkspaceRoot, result.Index.IndexPath),
 		RelationGraph:     result.RelationGraph,
 		Runtime:           result.Runtime,

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -172,6 +172,56 @@ func TestRunStatusJSON(t *testing.T) {
 	}
 }
 
+func TestRunStatusJSONIncludesRepoCoverage(t *testing.T) {
+	repo := writeMultiRepoSearchWorkspace(t)
+
+	var rebuildStdout bytes.Buffer
+	var rebuildStderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &rebuildStdout, &rebuildStderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr: %q)", exitCode, rebuildStderr.String())
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode = withWorkingDir(t, repo, func() int {
+		return runStatus([]string{"--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runStatus() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Repos []struct {
+				Repo      string `json:"repo"`
+				ItemCount int    `json:"item_count"`
+				SpecCount int    `json:"spec_count"`
+				DocCount  int    `json:"doc_count"`
+			} `json:"repo_coverage"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status payload: %v", err)
+	}
+	if got, want := len(payload.Result.Repos), 2; got != want {
+		t.Fatalf("repo coverage = %+v, want %d repos", payload.Result.Repos, want)
+	}
+	for _, repo := range payload.Result.Repos {
+		if repo.Repo != "primary" && repo.Repo != "shared" {
+			t.Fatalf("unexpected repo coverage entry %+v", repo)
+		}
+		if repo.ItemCount != 2 || repo.SpecCount != 1 || repo.DocCount != 1 {
+			t.Fatalf("repo coverage entry %+v, want 2 items / 1 spec / 1 doc", repo)
+		}
+	}
+}
+
 func TestRunStatusReportsStaleIndexFreshness(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,29 @@ path = "rfcs"
 include = ["**/*.md"]
 ```
 
+`workspace.root` is the primary repo root for the logical workspace. For cross-repo analysis, name it with `workspace.repo_id`, declare additional roots under `[[workspace.repos]]`, and bind a source to a secondary root with `repo = "..."`:
+
+```toml
+[workspace]
+root = "."
+repo_id = "product-docs"
+index_path = ".pituitary/pituitary.db"
+
+[[workspace.repos]]
+id = "runtime"
+root = "../runtime"
+
+[[sources]]
+name = "runtime-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+repo = "runtime"
+path = "docs"
+include = ["guides/*.md"]
+```
+
+Pituitary keeps source paths repo-relative, adds `repo` to search/drift/impact/status JSON, and scopes non-primary generated doc refs as `doc://<repo>/...` so duplicate paths from sibling repos stay distinct.
+
 ### Example: Optional GitHub issues source
 
 Schema `3` also supports adapter-specific typed options under `[sources.options]`:

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -81,6 +81,7 @@ type DriftFinding struct {
 type DriftItem struct {
 	DocRef    string         `json:"doc_ref"`
 	Title     string         `json:"title"`
+	Repo      string         `json:"repo,omitempty"`
 	SourceRef string         `json:"source_ref"`
 	SpecRefs  []string       `json:"spec_refs"`
 	Findings  []DriftFinding `json:"findings"`
@@ -90,6 +91,7 @@ type DriftItem struct {
 type DocDriftAssessment struct {
 	DocRef     string           `json:"doc_ref"`
 	Title      string           `json:"title"`
+	Repo       string           `json:"repo,omitempty"`
 	SourceRef  string           `json:"source_ref"`
 	Status     string           `json:"status"`
 	SpecRefs   []string         `json:"spec_refs,omitempty"`
@@ -129,6 +131,7 @@ type DocRemediationSuggestion struct {
 type DocRemediationItem struct {
 	DocRef      string                     `json:"doc_ref"`
 	Title       string                     `json:"title"`
+	Repo        string                     `json:"repo,omitempty"`
 	SourceRef   string                     `json:"source_ref"`
 	Suggestions []DocRemediationSuggestion `json:"suggestions"`
 }
@@ -539,6 +542,7 @@ func driftAgainstAcceptedSpecs(doc docDocument, relevant []specDocument) (*Drift
 	item := &DriftItem{
 		DocRef:    doc.Record.Ref,
 		Title:     doc.Record.Title,
+		Repo:      artifactRepoID(doc.Record.Metadata),
 		SourceRef: doc.Record.SourceRef,
 		SpecRefs:  uniqueStrings(specRefs),
 		Findings:  findings,
@@ -562,6 +566,7 @@ func assessDocDrift(doc docDocument, relevant []specDocument, item *DriftItem) *
 		assessment := &DocDriftAssessment{
 			DocRef:    item.DocRef,
 			Title:     item.Title,
+			Repo:      item.Repo,
 			SourceRef: item.SourceRef,
 			Status:    "drift",
 			SpecRefs:  append([]string(nil), item.SpecRefs...),
@@ -589,6 +594,7 @@ func assessDocDrift(doc docDocument, relevant []specDocument, item *DriftItem) *
 	return &DocDriftAssessment{
 		DocRef:     doc.Record.Ref,
 		Title:      doc.Record.Title,
+		Repo:       artifactRepoID(doc.Record.Metadata),
 		SourceRef:  doc.Record.SourceRef,
 		Status:     "aligned",
 		SpecRefs:   []string{candidate.spec.Record.Ref},
@@ -610,6 +616,7 @@ func possibleDriftAssessment(doc docDocument, specs map[string]specDocument) *Do
 	return &DocDriftAssessment{
 		DocRef:     doc.Record.Ref,
 		Title:      doc.Record.Title,
+		Repo:       artifactRepoID(doc.Record.Metadata),
 		SourceRef:  doc.Record.SourceRef,
 		Status:     "possible_drift",
 		SpecRefs:   []string{bestSpec.Record.Ref},
@@ -684,6 +691,7 @@ func buildDocRemediationItem(doc docDocument, specs map[string]specDocument, fin
 	return &DocRemediationItem{
 		DocRef:      doc.Record.Ref,
 		Title:       doc.Record.Title,
+		Repo:        artifactRepoID(doc.Record.Metadata),
 		SourceRef:   doc.Record.SourceRef,
 		Suggestions: suggestions,
 	}
@@ -743,6 +751,7 @@ func historicalDocAssessment(doc docDocument, relevant []specDocument) *DocDrift
 	assessment := &DocDriftAssessment{
 		DocRef:    doc.Record.Ref,
 		Title:     doc.Record.Title,
+		Repo:      artifactRepoID(doc.Record.Metadata),
 		SourceRef: doc.Record.SourceRef,
 		Status:    "aligned",
 		Rationale: "doc source is marked historical, so historical terminology and superseded behavior are tolerated during drift checks",

--- a/internal/analysis/doc_drift_test.go
+++ b/internal/analysis/doc_drift_test.go
@@ -195,6 +195,55 @@ func TestCheckDocDriftFlagsStaleNamedArtifacts(t *testing.T) {
 	}
 }
 
+func TestCheckDocDriftIncludesRepoIdentity(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadMultiRepoAnalysisConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := CheckDocDrift(cfg, DocDriftRequest{Scope: "all"})
+	if err != nil {
+		t.Fatalf("CheckDocDrift() error = %v", err)
+	}
+
+	var foundSharedDrift, foundSharedAssessment, foundSharedRemediation bool
+	for _, item := range result.DriftItems {
+		if item.DocRef == "doc://shared/guides/api-rate-limits" {
+			foundSharedDrift = true
+			if got, want := item.Repo, "shared"; got != want {
+				t.Fatalf("shared drift repo = %q, want %q", got, want)
+			}
+		}
+	}
+	for _, assessment := range result.Assessments {
+		if assessment.DocRef == "doc://shared/guides/api-rate-limits" {
+			foundSharedAssessment = true
+			if got, want := assessment.Repo, "shared"; got != want {
+				t.Fatalf("shared assessment repo = %q, want %q", got, want)
+			}
+		}
+	}
+	if result.Remediation != nil {
+		for _, item := range result.Remediation.Items {
+			if item.DocRef == "doc://shared/guides/api-rate-limits" {
+				foundSharedRemediation = true
+				if got, want := item.Repo, "shared"; got != want {
+					t.Fatalf("shared remediation repo = %q, want %q", got, want)
+				}
+			}
+		}
+	}
+	if !foundSharedDrift || !foundSharedAssessment || !foundSharedRemediation {
+		t.Fatalf("doc drift result = %+v, want shared repo drift, assessment, and remediation", result)
+	}
+}
+
 func TestCheckDocDriftUsesAnalysisProviderWhenEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -20,6 +20,7 @@ type AnalyzeImpactRequest struct {
 type ImpactedSpec struct {
 	Ref          string                     `json:"ref"`
 	Title        string                     `json:"title"`
+	Repo         string                     `json:"repo,omitempty"`
 	Status       string                     `json:"status,omitempty"`
 	Relationship string                     `json:"relationship"`
 	Historical   bool                       `json:"historical"`
@@ -36,6 +37,7 @@ type ImpactedRef struct {
 type ImpactedDoc struct {
 	Ref       string  `json:"ref"`
 	Title     string  `json:"title"`
+	Repo      string  `json:"repo,omitempty"`
 	SourceRef string  `json:"source_ref"`
 	Score     float64 `json:"score"`
 }
@@ -137,6 +139,7 @@ func impactedSpecs(candidate model.SpecRecord, specs map[string]specDocument) []
 			result = append(result, ImpactedSpec{
 				Ref:          spec.Record.Ref,
 				Title:        spec.Record.Title,
+				Repo:         artifactRepoID(spec.Record.Metadata),
 				Status:       spec.Record.Status,
 				Relationship: string(model.RelationDependsOn),
 				Historical:   false,
@@ -146,6 +149,7 @@ func impactedSpecs(candidate model.SpecRecord, specs map[string]specDocument) []
 			result = append(result, ImpactedSpec{
 				Ref:          spec.Record.Ref,
 				Title:        spec.Record.Title,
+				Repo:         artifactRepoID(spec.Record.Metadata),
 				Status:       spec.Record.Status,
 				Relationship: string(model.RelationSupersedes),
 				Historical:   true,
@@ -207,6 +211,7 @@ func impactedDocs(candidate specDocument, docs map[string]docDocument) []Impacte
 		result = append(result, ImpactedDoc{
 			Ref:       doc.Record.Ref,
 			Title:     doc.Record.Title,
+			Repo:      artifactRepoID(doc.Record.Metadata),
 			SourceRef: doc.Record.SourceRef,
 			Score:     roundScore(score),
 		})

--- a/internal/analysis/impact_test.go
+++ b/internal/analysis/impact_test.go
@@ -1,8 +1,11 @@
 package analysis
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
+	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
@@ -93,4 +96,156 @@ func TestAnalyzeImpactSupportsDraftSpecRecord(t *testing.T) {
 	if len(result.AffectedRefs) == 0 || len(result.AffectedDocs) == 0 {
 		t.Fatalf("draft impact = %+v, want refs and docs", result)
 	}
+}
+
+func TestAnalyzeImpactIncludesCrossRepoArtifacts(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadMultiRepoAnalysisConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := AnalyzeImpact(cfg, AnalyzeImpactRequest{
+		SpecRef:    "SPEC-100",
+		ChangeType: "accepted",
+	})
+	if err != nil {
+		t.Fatalf("AnalyzeImpact() error = %v", err)
+	}
+
+	var foundSharedSpec, foundSharedDoc bool
+	for _, spec := range result.AffectedSpecs {
+		if spec.Ref == "SPEC-200" {
+			foundSharedSpec = true
+			if got, want := spec.Repo, "shared"; got != want {
+				t.Fatalf("shared spec repo = %q, want %q", got, want)
+			}
+		}
+	}
+	for _, doc := range result.AffectedDocs {
+		if doc.Ref == "doc://shared/guides/api-rate-limits" {
+			foundSharedDoc = true
+			if got, want := doc.Repo, "shared"; got != want {
+				t.Fatalf("shared doc repo = %q, want %q", got, want)
+			}
+			if got, want := doc.SourceRef, "file://docs/guides/api-rate-limits.md"; got != want {
+				t.Fatalf("shared doc source_ref = %q, want %q", got, want)
+			}
+		}
+	}
+	if !foundSharedSpec || !foundSharedDoc {
+		t.Fatalf("impact = %+v, want shared repo spec and doc", result)
+	}
+}
+
+func loadMultiRepoAnalysisConfig(tb testing.TB) *config.Config {
+	tb.Helper()
+
+	root := tb.TempDir()
+	primary := filepath.Join(root, "primary")
+	shared := filepath.Join(root, "shared")
+	indexPath := filepath.Join(root, "pituitary.db")
+	configPath := filepath.Join(root, "pituitary.toml")
+	mustWriteFile(tb, configPath, fmt.Sprintf(`
+[workspace]
+root = "%s"
+repo_id = "primary"
+index_path = "%s"
+
+[[workspace.repos]]
+id = "shared"
+root = "%s"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "primary-specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "primary-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+
+[[sources]]
+name = "shared-specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+repo = "shared"
+path = "specs"
+
+[[sources]]
+name = "shared-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+repo = "shared"
+path = "docs"
+include = ["guides/*.md"]
+`, filepath.ToSlash(primary), filepath.ToSlash(indexPath), filepath.ToSlash(shared)))
+	mustWriteFile(tb, filepath.Join(primary, "specs", "tenant-rate-limits", "spec.toml"), `
+id = "SPEC-100"
+title = "Tenant Rate Limits"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(tb, filepath.Join(primary, "specs", "tenant-rate-limits", "body.md"), `
+# Tenant Rate Limits
+
+## Defaults
+
+The default rate limit is 200 requests per minute.
+
+## Rollout
+
+All consumers must keep tenant-scoped defaults aligned.
+`)
+	mustWriteFile(tb, filepath.Join(primary, "docs", "guides", "api-rate-limits.md"), `
+# API Rate Limits
+
+The default rate limit is 200 requests per minute.
+`)
+	mustWriteFile(tb, filepath.Join(shared, "specs", "shared-rollout", "spec.toml"), `
+id = "SPEC-200"
+title = "Shared Repo Rollout"
+status = "accepted"
+domain = "api"
+body = "body.md"
+depends_on = ["SPEC-100"]
+`)
+	mustWriteFile(tb, filepath.Join(shared, "specs", "shared-rollout", "body.md"), `
+# Shared Repo Rollout
+
+## Dependencies
+
+This rollout depends on SPEC-100.
+
+## Tasks
+
+Update shared consumers to respect the 200 requests per minute tenant default.
+`)
+	mustWriteFile(tb, filepath.Join(shared, "docs", "guides", "api-rate-limits.md"), `
+# API Rate Limits
+
+The default rate limit is 100 requests per minute.
+`)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
 }

--- a/internal/analysis/repository.go
+++ b/internal/analysis/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
@@ -211,4 +212,11 @@ func missingDocRefs(source map[string]docDocument, refs []string) []string {
 		}
 	}
 	return missing
+}
+
+func artifactRepoID(metadata map[string]string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(metadata["repo_id"])
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/dusk-network/pituitary/sdk"
 )
@@ -46,9 +47,19 @@ type Config struct {
 // Workspace describes the configured workspace root and index path.
 type Workspace struct {
 	Root              string
+	RepoID            string
 	RootPath          string
 	IndexPath         string
 	ResolvedIndexPath string
+	Repos             []WorkspaceRepo
+}
+
+// WorkspaceRepo describes one additional repo root that participates in the
+// logical multi-repo workspace.
+type WorkspaceRepo struct {
+	ID       string
+	Root     string
+	RootPath string
 }
 
 // Source describes one configured input source.
@@ -57,11 +68,15 @@ type Source struct {
 	Adapter      string
 	Kind         string
 	Role         string
+	Repo         string
 	Path         string
 	Files        []string
 	Include      []string
 	Exclude      []string
 	Options      map[string]any
+	ResolvedRepo string
+	PrimaryRepo  string
+	RepoRootPath string
 	ResolvedPath string
 }
 
@@ -89,8 +104,15 @@ type rawConfig struct {
 }
 
 type rawWorkspace struct {
-	Root      string `toml:"root"`
-	IndexPath string `toml:"index_path"`
+	Root      string             `toml:"root"`
+	RepoID    string             `toml:"repo_id"`
+	IndexPath string             `toml:"index_path"`
+	Repos     []rawWorkspaceRepo `toml:"repos"`
+}
+
+type rawWorkspaceRepo struct {
+	ID   string `toml:"id"`
+	Root string `toml:"root"`
 }
 
 type rawRuntime struct {
@@ -103,6 +125,7 @@ type rawSource struct {
 	Adapter string         `toml:"adapter"`
 	Kind    string         `toml:"kind"`
 	Role    string         `toml:"role"`
+	Repo    string         `toml:"repo"`
 	Path    string         `toml:"path"`
 	Files   []string       `toml:"files"`
 	Include []string       `toml:"include"`
@@ -188,7 +211,9 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 		ConfigDir:     configBaseDir(configPath),
 		Workspace: Workspace{
 			Root:      raw.Workspace.Root,
+			RepoID:    strings.TrimSpace(raw.Workspace.RepoID),
 			IndexPath: raw.Workspace.IndexPath,
+			Repos:     make([]WorkspaceRepo, 0, len(raw.Workspace.Repos)),
 		},
 		Runtime: Runtime{
 			Embedder: RuntimeProvider{
@@ -210,12 +235,19 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 		},
 		Sources: make([]Source, 0, len(raw.Sources)),
 	}
+	for _, repo := range raw.Workspace.Repos {
+		cfg.Workspace.Repos = append(cfg.Workspace.Repos, WorkspaceRepo{
+			ID:   strings.TrimSpace(repo.ID),
+			Root: repo.Root,
+		})
+	}
 	for _, source := range raw.Sources {
 		cfg.Sources = append(cfg.Sources, Source{
 			Name:    source.Name,
 			Adapter: source.Adapter,
 			Kind:    source.Kind,
 			Role:    NormalizeSourceRole(source.Role),
+			Repo:    strings.TrimSpace(source.Repo),
 			Path:    source.Path,
 			Files:   append([]string(nil), source.Files...),
 			Include: append([]string(nil), source.Include...),
@@ -338,6 +370,42 @@ func validate(cfg *Config) error {
 		}
 	}
 
+	if cfg.Workspace.RepoID != "" && !isValidRepoID(cfg.Workspace.RepoID) {
+		errs.add("workspace.repo_id: unsupported repo id %q", cfg.Workspace.RepoID)
+	}
+	primaryRepoID := effectiveWorkspaceRepoID(cfg.Workspace)
+	seenRepoIDs := map[string]struct{}{}
+	if primaryRepoID != "" {
+		seenRepoIDs[primaryRepoID] = struct{}{}
+	}
+	for i := range cfg.Workspace.Repos {
+		repo := &cfg.Workspace.Repos[i]
+		label := fmt.Sprintf("workspace.repos[%d]", i)
+		if repo.ID == "" {
+			errs.add("%s.id: value is required", label)
+		} else {
+			if !isValidRepoID(repo.ID) {
+				errs.add("%s.id: unsupported repo id %q", label, repo.ID)
+			} else if _, exists := seenRepoIDs[repo.ID]; exists {
+				errs.add("%s.id: %q is duplicated", label, repo.ID)
+			} else {
+				seenRepoIDs[repo.ID] = struct{}{}
+			}
+		}
+		if repo.Root == "" {
+			errs.add("%s.root: value is required", label)
+			continue
+		}
+		repo.RootPath = resolvePath(cfg.ConfigDir, repo.Root)
+		info, err := os.Stat(repo.RootPath)
+		switch {
+		case err == nil && !info.IsDir():
+			errs.add("%s.root: %q is not a directory", label, repo.Root)
+		case err != nil:
+			errs.add("%s.root: %q does not exist", label, repo.Root)
+		}
+	}
+
 	if cfg.Workspace.IndexPath == "" {
 		errs.add("workspace.index_path: value is required")
 	} else if cfg.Workspace.RootPath != "" {
@@ -381,6 +449,9 @@ func validate(cfg *Config) error {
 		}
 		if source.Role != "" && !IsValidSourceRole(source.Role) {
 			errs.add("%s.role: unsupported role %q", label, source.Role)
+		}
+		if source.Repo != "" && !isValidRepoID(source.Repo) {
+			errs.add("%s.repo: unsupported repo id %q", label, source.Repo)
 		}
 
 		filesystemSource := source.Adapter == AdapterFilesystem
@@ -434,8 +505,22 @@ func validate(cfg *Config) error {
 		if cfg.Workspace.RootPath == "" {
 			continue
 		}
+		repoID := primaryRepoID
+		repoRootPath := cfg.Workspace.RootPath
+		if source.Repo != "" {
+			repoID = source.Repo
+			resolved, ok := lookupWorkspaceRepoRoot(cfg.Workspace, repoID)
+			if !ok {
+				errs.add("%s.repo: unknown repo %q", label, source.Repo)
+				continue
+			}
+			repoRootPath = resolved
+		}
+		source.ResolvedRepo = repoID
+		source.PrimaryRepo = primaryRepoID
+		source.RepoRootPath = repoRootPath
 		if strings.TrimSpace(source.Path) != "" {
-			source.ResolvedPath = resolvePath(cfg.Workspace.RootPath, source.Path)
+			source.ResolvedPath = resolvePath(repoRootPath, source.Path)
 		}
 		if filesystemSource && source.ResolvedPath != "" {
 			info, err := os.Stat(source.ResolvedPath)
@@ -463,6 +548,58 @@ func validate(cfg *Config) error {
 	}
 
 	return errs.err()
+}
+
+func effectiveWorkspaceRepoID(workspace Workspace) string {
+	if explicit := strings.TrimSpace(workspace.RepoID); explicit != "" {
+		return explicit
+	}
+	candidate := strings.TrimSpace(filepath.Base(workspace.RootPath))
+	if isValidRepoID(candidate) {
+		return candidate
+	}
+	return "workspace"
+}
+
+// PrimaryRepoID returns the effective repo identity for the configured primary
+// workspace root.
+func PrimaryRepoID(cfg *Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return effectiveWorkspaceRepoID(cfg.Workspace)
+}
+
+func lookupWorkspaceRepoRoot(workspace Workspace, repoID string) (string, bool) {
+	repoID = strings.TrimSpace(repoID)
+	if repoID == "" {
+		return "", false
+	}
+	if repoID == effectiveWorkspaceRepoID(workspace) {
+		return workspace.RootPath, workspace.RootPath != ""
+	}
+	for _, repo := range workspace.Repos {
+		if strings.TrimSpace(repo.ID) == repoID {
+			return repo.RootPath, repo.RootPath != ""
+		}
+	}
+	return "", false
+}
+
+func isValidRepoID(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+		case r == '-', r == '_', r == '.':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeSourceFileSelector(value string) (string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,6 +62,74 @@ path = "docs"
 	}
 }
 
+func TestLoadResolvesMultiRepoSources(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	primary := filepath.Join(root, "primary")
+	shared := filepath.Join(root, "shared")
+	mustMkdirAll(t, filepath.Join(primary, "specs"))
+	mustMkdirAll(t, filepath.Join(shared, "docs"))
+
+	configPath := filepath.Join(root, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "primary"
+repo_id = "primary"
+index_path = ".pituitary/pituitary.db"
+
+[[workspace.repos]]
+id = "shared"
+root = "shared"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "shared-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+repo = "shared"
+path = "docs"
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got, want := cfg.Workspace.RootPath, filepath.Clean(primary); got != want {
+		t.Fatalf("workspace root path = %q, want %q", got, want)
+	}
+	if got, want := cfg.Workspace.RepoID, "primary"; got != want {
+		t.Fatalf("workspace repo_id = %q, want %q", got, want)
+	}
+	if got, want := len(cfg.Workspace.Repos), 1; got != want {
+		t.Fatalf("workspace repos = %d, want %d", got, want)
+	}
+	if got, want := cfg.Workspace.Repos[0].RootPath, filepath.Clean(shared); got != want {
+		t.Fatalf("workspace repo root path = %q, want %q", got, want)
+	}
+	if got, want := cfg.Sources[0].ResolvedRepo, "primary"; got != want {
+		t.Fatalf("primary source repo = %q, want %q", got, want)
+	}
+	if got, want := cfg.Sources[0].RepoRootPath, filepath.Clean(primary); got != want {
+		t.Fatalf("primary source repo root = %q, want %q", got, want)
+	}
+	if got, want := cfg.Sources[1].ResolvedRepo, "shared"; got != want {
+		t.Fatalf("shared source repo = %q, want %q", got, want)
+	}
+	if got, want := cfg.Sources[1].RepoRootPath, filepath.Clean(shared); got != want {
+		t.Fatalf("shared source repo root = %q, want %q", got, want)
+	}
+	if got, want := cfg.Sources[1].ResolvedPath, filepath.Join(shared, "docs"); got != want {
+		t.Fatalf("shared source path = %q, want %q", got, want)
+	}
+}
+
 func TestLoadResolvesLocalPituitaryConfigRelativeToRepoRoot(t *testing.T) {
 	t.Parallel()
 
@@ -945,6 +1013,77 @@ func TestRenderRoundTripsSourceRole(t *testing.T) {
 	}
 	if got, want := loaded.Sources[0].Role, SourceRoleMirror; got != want {
 		t.Fatalf("loaded role = %q, want %q", got, want)
+	}
+}
+
+func TestRenderRoundTripsWorkspaceRepos(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	primary := filepath.Join(root, "primary")
+	shared := filepath.Join(root, "shared")
+	mustMkdirAll(t, filepath.Join(primary, "specs"))
+	mustMkdirAll(t, filepath.Join(shared, "docs"))
+
+	configPath := filepath.Join(root, "pituitary.toml")
+	cfg := &Config{
+		SchemaVersion: CurrentSchemaVersion,
+		ConfigPath:    configPath,
+		ConfigDir:     root,
+		Workspace: Workspace{
+			Root:      "primary",
+			RepoID:    "primary",
+			IndexPath: ".pituitary/pituitary.db",
+			Repos: []WorkspaceRepo{
+				{ID: "shared", Root: "shared"},
+			},
+		},
+		Sources: []Source{
+			{
+				Name:    "specs",
+				Adapter: AdapterFilesystem,
+				Kind:    SourceKindSpecBundle,
+				Path:    "specs",
+			},
+			{
+				Name:    "shared-docs",
+				Adapter: AdapterFilesystem,
+				Kind:    SourceKindMarkdownDocs,
+				Repo:    "shared",
+				Path:    "docs",
+			},
+		},
+	}
+
+	rendered, err := Render(cfg)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if !strings.Contains(rendered, "repo_id = \"primary\"") {
+		t.Fatalf("rendered config %q does not contain workspace repo_id", rendered)
+	}
+	if !strings.Contains(rendered, "[[workspace.repos]]") || !strings.Contains(rendered, "id = \"shared\"") {
+		t.Fatalf("rendered config %q does not contain workspace.repos entry", rendered)
+	}
+	if !strings.Contains(rendered, "repo = \"shared\"") {
+		t.Fatalf("rendered config %q does not contain source repo", rendered)
+	}
+
+	loaded, err := LoadFromText(rendered, configPath)
+	if err != nil {
+		t.Fatalf("LoadFromText() error = %v", err)
+	}
+	if got, want := loaded.Workspace.RepoID, "primary"; got != want {
+		t.Fatalf("loaded workspace repo_id = %q, want %q", got, want)
+	}
+	if got, want := len(loaded.Workspace.Repos), 1; got != want {
+		t.Fatalf("loaded workspace repos = %d, want %d", got, want)
+	}
+	if got, want := loaded.Workspace.Repos[0].ID, "shared"; got != want {
+		t.Fatalf("loaded workspace repo id = %q, want %q", got, want)
+	}
+	if got, want := loaded.Sources[1].Repo, "shared"; got != want {
+		t.Fatalf("loaded source repo = %q, want %q", got, want)
 	}
 }
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -18,7 +18,15 @@ func Render(cfg *Config) (string, error) {
 	fmt.Fprintf(&builder, "schema_version = %d\n\n", CurrentSchemaVersion)
 	fmt.Fprintf(&builder, "[workspace]\n")
 	fmt.Fprintf(&builder, "root = %s\n", strconv.Quote(cfg.Workspace.Root))
+	if repoID := strings.TrimSpace(cfg.Workspace.RepoID); repoID != "" {
+		fmt.Fprintf(&builder, "repo_id = %s\n", strconv.Quote(repoID))
+	}
 	fmt.Fprintf(&builder, "index_path = %s\n", strconv.Quote(cfg.Workspace.IndexPath))
+	for _, repo := range cfg.Workspace.Repos {
+		builder.WriteString("\n[[workspace.repos]]\n")
+		fmt.Fprintf(&builder, "id = %s\n", strconv.Quote(repo.ID))
+		fmt.Fprintf(&builder, "root = %s\n", strconv.Quote(repo.Root))
+	}
 
 	builder.WriteString("\n[runtime.embedder]\n")
 	fmt.Fprintf(&builder, "provider = %s\n", strconv.Quote(cfg.Runtime.Embedder.Provider))
@@ -55,6 +63,9 @@ func Render(cfg *Config) (string, error) {
 		fmt.Fprintf(&builder, "kind = %s\n", strconv.Quote(source.Kind))
 		if source.Role != "" {
 			fmt.Fprintf(&builder, "role = %s\n", strconv.Quote(source.Role))
+		}
+		if source.Repo != "" {
+			fmt.Fprintf(&builder, "repo = %s\n", strconv.Quote(source.Repo))
 		}
 		if source.Path != "" {
 			fmt.Fprintf(&builder, "path = %s\n", strconv.Quote(source.Path))

--- a/internal/index/freshness.go
+++ b/internal/index/freshness.go
@@ -268,7 +268,11 @@ func sourceFingerprint(cfg *config.Config) string {
 	if cfg == nil {
 		return ""
 	}
-	parts := make([]string, 0, len(cfg.Sources))
+	parts := make([]string, 0, len(cfg.Sources)+len(cfg.Workspace.Repos)+1)
+	parts = append(parts, "workspace_repo_id="+config.PrimaryRepoID(cfg))
+	for _, repo := range cfg.Workspace.Repos {
+		parts = append(parts, "workspace_repo="+strings.TrimSpace(repo.ID)+"|"+filepath.ToSlash(strings.TrimSpace(repo.Root))+"|"+filepath.ToSlash(strings.TrimSpace(repo.RootPath)))
+	}
 	for _, src := range cfg.Sources {
 		files := append([]string(nil), src.Files...)
 		include := append([]string(nil), src.Include...)
@@ -282,6 +286,9 @@ func sourceFingerprint(cfg *config.Config) string {
 			src.Name,
 			src.Adapter,
 			src.Kind,
+			src.Repo,
+			src.ResolvedRepo,
+			filepath.ToSlash(src.RepoRootPath),
 			filepath.ToSlash(src.Path),
 			filepath.ToSlash(src.ResolvedPath),
 			strings.Join(files, ","),

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -36,6 +36,7 @@ type RebuildResult struct {
 	ReusedChunkCount    int                        `json:"reused_chunk_count,omitempty"`
 	EmbeddedChunkCount  int                        `json:"embedded_chunk_count,omitempty"`
 	ContentFingerprint  string                     `json:"content_fingerprint"`
+	Repos               []RepoCoverage             `json:"repo_coverage,omitempty"`
 	Sources             []source.LoadSourceSummary `json:"sources,omitempty"`
 }
 
@@ -382,6 +383,7 @@ func buildStagingContext(ctx context.Context, db *sql.DB, cfg *config.Config, di
 	result := &RebuildResult{
 		EmbedderDimension: dimension,
 		FullRebuild:       options.Full,
+		Repos:             repoCoverageFromRecords(records),
 		Sources:           append([]source.LoadSourceSummary(nil), records.Sources...),
 	}
 	totalArtifacts := len(records.Specs) + len(records.Docs)

--- a/internal/index/repo_coverage.go
+++ b/internal/index/repo_coverage.go
@@ -1,0 +1,97 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/model"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+// RepoCoverage summarizes indexed artifact coverage for one repo identity.
+type RepoCoverage struct {
+	Repo      string `json:"repo"`
+	ItemCount int    `json:"item_count"`
+	SpecCount int    `json:"spec_count,omitempty"`
+	DocCount  int    `json:"doc_count,omitempty"`
+}
+
+func repoCoverageFromRecords(records *source.LoadResult) []RepoCoverage {
+	if records == nil {
+		return nil
+	}
+	counts := map[string]*RepoCoverage{}
+	for _, spec := range records.Specs {
+		appendRepoCoverage(counts, strings.TrimSpace(spec.Metadata["repo_id"]), model.ArtifactKindSpec)
+	}
+	for _, doc := range records.Docs {
+		appendRepoCoverage(counts, strings.TrimSpace(doc.Metadata["repo_id"]), model.ArtifactKindDoc)
+	}
+	return sortedRepoCoverage(counts)
+}
+
+func repoCoverageFromDBContext(ctx context.Context, db *sql.DB) ([]RepoCoverage, error) {
+	rows, err := db.QueryContext(ctx, `SELECT kind, metadata_json FROM artifacts`)
+	if err != nil {
+		return nil, fmt.Errorf("query repo coverage: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]*RepoCoverage{}
+	for rows.Next() {
+		var kind string
+		var rawMetadata string
+		if err := rows.Scan(&kind, &rawMetadata); err != nil {
+			return nil, fmt.Errorf("scan repo coverage: %w", err)
+		}
+		if strings.TrimSpace(rawMetadata) == "" {
+			continue
+		}
+		metadata := map[string]string{}
+		if err := json.Unmarshal([]byte(rawMetadata), &metadata); err != nil {
+			return nil, fmt.Errorf("parse repo coverage metadata: %w", err)
+		}
+		appendRepoCoverage(counts, strings.TrimSpace(metadata["repo_id"]), kind)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate repo coverage: %w", err)
+	}
+	return sortedRepoCoverage(counts), nil
+}
+
+func appendRepoCoverage(counts map[string]*RepoCoverage, repoID, kind string) {
+	repoID = strings.TrimSpace(repoID)
+	if repoID == "" {
+		return
+	}
+	entry, ok := counts[repoID]
+	if !ok {
+		entry = &RepoCoverage{Repo: repoID}
+		counts[repoID] = entry
+	}
+	entry.ItemCount++
+	switch kind {
+	case model.ArtifactKindSpec:
+		entry.SpecCount++
+	case model.ArtifactKindDoc:
+		entry.DocCount++
+	}
+}
+
+func sortedRepoCoverage(counts map[string]*RepoCoverage) []RepoCoverage {
+	if len(counts) == 0 {
+		return nil
+	}
+	result := make([]RepoCoverage, 0, len(counts))
+	for _, coverage := range counts {
+		result = append(result, *coverage)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Repo < result[j].Repo
+	})
+	return result
+}

--- a/internal/index/reuse.go
+++ b/internal/index/reuse.go
@@ -208,6 +208,7 @@ func summarizeRebuild(records *source.LoadResult, dimension int, state *reuseSta
 		DocCount:          len(records.Docs),
 		EmbedderDimension: dimension,
 		FullRebuild:       options.Full,
+		Repos:             repoCoverageFromRecords(records),
 		Sources:           append([]source.LoadSourceSummary(nil), records.Sources...),
 	}
 

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -48,6 +48,7 @@ type SearchSpecMatch struct {
 	Title          string                     `json:"title"`
 	SectionHeading string                     `json:"section_heading"`
 	Excerpt        string                     `json:"excerpt"`
+	Repo           string                     `json:"repo,omitempty"`
 	SourceRef      string                     `json:"source_ref"`
 	Kind           string                     `json:"kind,omitempty"`
 	Status         string                     `json:"status,omitempty"`
@@ -68,6 +69,7 @@ type chunkCandidate struct {
 	Title          string
 	SectionHeading string
 	Content        string
+	Repo           string
 	SourceRef      string
 	Kind           string
 	Status         string
@@ -173,6 +175,7 @@ func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpe
 			Title:          candidate.Title,
 			SectionHeading: candidate.SectionHeading,
 			Excerpt:        excerpt(candidate.Content),
+			Repo:           candidate.Repo,
 			SourceRef:      candidate.SourceRef,
 			Kind:           candidate.Kind,
 			Status:         candidate.Status,
@@ -312,6 +315,7 @@ func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, query SearchSp
 			if err := json.Unmarshal([]byte(rawMetadata), &metadata); err != nil {
 				return nil, fmt.Errorf("parse search metadata for %s: %w", candidate.Ref, err)
 			}
+			candidate.Repo = strings.TrimSpace(metadata["repo_id"])
 			candidate.Inference, err = model.DecodeInferenceConfidence(metadata)
 			if err != nil {
 				return nil, fmt.Errorf("decode search inference for %s: %w", candidate.Ref, err)

--- a/internal/index/search_test.go
+++ b/internal/index/search_test.go
@@ -116,6 +116,33 @@ func TestSearchSpecsAppliesDomainFilter(t *testing.T) {
 	}
 }
 
+func TestSearchSpecsIncludesRepoIdentity(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadMultiRepoFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	result, err := SearchSpecs(cfg, SearchSpecQuery{Query: "shared repo rollout", Limit: 5})
+	if err != nil {
+		t.Fatalf("SearchSpecs() error = %v", err)
+	}
+	if len(result.Matches) == 0 {
+		t.Fatal("SearchSpecs() returned no matches")
+	}
+	if got, want := result.Matches[0].Repo, "shared"; got != want {
+		t.Fatalf("top match repo = %q, want %q", got, want)
+	}
+	if got, want := result.Matches[0].SourceRef, "file://specs/shared-rollout/spec.toml"; got != want {
+		t.Fatalf("top match source_ref = %q, want %q", got, want)
+	}
+}
+
 func TestSearchSpecsRejectsInvalidStatuses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/index/status.go
+++ b/internal/index/status.go
@@ -10,11 +10,12 @@ import (
 
 // Status reports whether the configured index exists and its basic counts.
 type Status struct {
-	IndexPath  string `json:"index_path"`
-	Exists     bool   `json:"index_exists"`
-	SpecCount  int    `json:"spec_count"`
-	DocCount   int    `json:"doc_count"`
-	ChunkCount int    `json:"chunk_count"`
+	IndexPath  string         `json:"index_path"`
+	Exists     bool           `json:"index_exists"`
+	SpecCount  int            `json:"spec_count"`
+	DocCount   int            `json:"doc_count"`
+	ChunkCount int            `json:"chunk_count"`
+	Repos      []RepoCoverage `json:"repo_coverage,omitempty"`
 }
 
 // ReadStatus inspects the configured index path and returns basic counts.
@@ -51,6 +52,10 @@ func ReadStatusContext(ctx context.Context, path string) (*Status, error) {
 	}
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks`).Scan(&status.ChunkCount); err != nil {
 		return nil, fmt.Errorf("count indexed chunks: %w", err)
+	}
+	status.Repos, err = repoCoverageFromDBContext(ctx, db)
+	if err != nil {
+		return nil, err
 	}
 
 	return status, nil

--- a/internal/index/status_test.go
+++ b/internal/index/status_test.go
@@ -1,8 +1,11 @@
 package index
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
+	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
 )
 
@@ -47,4 +50,152 @@ func TestReadStatusReadsFixtureCounts(t *testing.T) {
 	if status.SpecCount != 3 || status.DocCount != 2 || status.ChunkCount != 17 {
 		t.Fatalf("status = %+v, want 3 specs, 2 docs, 17 chunks", status)
 	}
+}
+
+func TestReadStatusReportsRepoCoverage(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadMultiRepoFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	status, err := ReadStatus(cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("ReadStatus() error = %v", err)
+	}
+	if got, want := len(status.Repos), 2; got != want {
+		t.Fatalf("repo coverage = %+v, want %d repos", status.Repos, want)
+	}
+
+	repos := map[string]RepoCoverage{}
+	for _, repo := range status.Repos {
+		repos[repo.Repo] = repo
+	}
+	for _, repoID := range []string{"primary", "shared"} {
+		repo, ok := repos[repoID]
+		if !ok {
+			t.Fatalf("repo coverage = %+v, want repo %q", status.Repos, repoID)
+		}
+		if got, want := repo.ItemCount, 2; got != want {
+			t.Fatalf("repo %q item_count = %d, want %d", repoID, got, want)
+		}
+		if got, want := repo.SpecCount, 1; got != want {
+			t.Fatalf("repo %q spec_count = %d, want %d", repoID, got, want)
+		}
+		if got, want := repo.DocCount, 1; got != want {
+			t.Fatalf("repo %q doc_count = %d, want %d", repoID, got, want)
+		}
+	}
+}
+
+func loadMultiRepoFixtureConfig(tb testing.TB) *config.Config {
+	tb.Helper()
+
+	root := tb.TempDir()
+	primary := filepath.Join(root, "primary")
+	shared := filepath.Join(root, "shared")
+	indexPath := filepath.Join(root, "pituitary.db")
+	configPath := filepath.Join(root, "pituitary.toml")
+	mustWriteFile(tb, configPath, fmt.Sprintf(`
+[workspace]
+root = "%s"
+repo_id = "primary"
+index_path = "%s"
+
+[[workspace.repos]]
+id = "shared"
+root = "%s"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "primary-specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "primary-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+
+[[sources]]
+name = "shared-specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+repo = "shared"
+path = "specs"
+
+[[sources]]
+name = "shared-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+repo = "shared"
+path = "docs"
+include = ["guides/*.md"]
+`, filepath.ToSlash(primary), filepath.ToSlash(indexPath), filepath.ToSlash(shared)))
+	mustWriteFile(tb, filepath.Join(primary, "specs", "tenant-rate-limits", "spec.toml"), `
+id = "SPEC-100"
+title = "Tenant Rate Limits"
+status = "accepted"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(tb, filepath.Join(primary, "specs", "tenant-rate-limits", "body.md"), `
+# Tenant Rate Limits
+
+## Defaults
+
+The default rate limit is 200 requests per minute.
+
+## Rollout
+
+All consumers must keep tenant-scoped defaults aligned.
+`)
+	mustWriteFile(tb, filepath.Join(primary, "docs", "guides", "api-rate-limits.md"), `
+# API Rate Limits
+
+The default rate limit is 200 requests per minute.
+`)
+	mustWriteFile(tb, filepath.Join(shared, "specs", "shared-rollout", "spec.toml"), `
+id = "SPEC-200"
+title = "Shared Repo Rollout"
+status = "accepted"
+domain = "api"
+body = "body.md"
+depends_on = ["SPEC-100"]
+`)
+	mustWriteFile(tb, filepath.Join(shared, "specs", "shared-rollout", "body.md"), `
+# Shared Repo Rollout
+
+## Dependencies
+
+This rollout depends on SPEC-100.
+
+## Tasks
+
+Update shared consumers to respect the 200 requests per minute tenant default.
+`)
+	mustWriteFile(tb, filepath.Join(shared, "docs", "guides", "api-rate-limits.md"), `
+# API Rate Limits
+
+The default rate limit is 100 requests per minute.
+`)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
 }

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -437,7 +437,7 @@ func discoverMarkdownContractIdentity(workspaceRoot, path string, body []byte) (
 	ref := strings.TrimSpace(fields.Ref)
 	if ref == "" {
 		var err error
-		ref, err = markdownContractRefForPath(workspaceRoot, path)
+		ref, err = markdownContractRefForPath(workspaceRoot, path, "", "")
 		if err != nil {
 			return "", "", err
 		}

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -33,11 +33,15 @@ func (a *filesystemAdapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sd
 		Name:         cfg.Name,
 		Adapter:      cfg.Adapter,
 		Kind:         cfg.Kind,
+		Repo:         cfg.Repo,
 		Path:         cfg.Path,
 		Files:        append([]string(nil), cfg.Files...),
 		Include:      append([]string(nil), cfg.Include...),
 		Exclude:      append([]string(nil), cfg.Exclude...),
 		Options:      config.CloneSourceOptions(cfg.Options),
+		ResolvedRepo: strings.TrimSpace(cfg.Repo),
+		PrimaryRepo:  strings.TrimSpace(cfg.PrimaryRepoID),
+		RepoRootPath: cfg.WorkspaceRoot,
 		ResolvedPath: resolveFilesystemSourcePath(cfg.WorkspaceRoot, cfg.Path),
 	}
 
@@ -81,6 +85,7 @@ func resolveFilesystemSourcePath(workspaceRoot, sourcePath string) string {
 
 type artifactOrigin struct {
 	sourceName string
+	repoID     string
 	sourcePath string
 	itemPath   string
 }
@@ -121,6 +126,7 @@ func specOrigin(source config.Source, record model.SpecRecord) artifactOrigin {
 	}
 	return artifactOrigin{
 		sourceName: source.Name,
+		repoID:     source.ResolvedRepo,
 		sourcePath: source.Path,
 		itemPath:   itemPath,
 	}
@@ -129,12 +135,16 @@ func specOrigin(source config.Source, record model.SpecRecord) artifactOrigin {
 func docOrigin(source config.Source, record model.DocRecord) artifactOrigin {
 	return artifactOrigin{
 		sourceName: source.Name,
+		repoID:     source.ResolvedRepo,
 		sourcePath: source.Path,
 		itemPath:   record.Metadata["path"],
 	}
 }
 
 func describeOrigin(itemLabel string, origin artifactOrigin) string {
+	if origin.repoID != "" {
+		return fmt.Sprintf("source %q repo %q path %q %s %q", origin.sourceName, origin.repoID, origin.sourcePath, itemLabel, origin.itemPath)
+	}
 	return fmt.Sprintf("source %q path %q %s %q", origin.sourceName, origin.sourcePath, itemLabel, origin.itemPath)
 }
 
@@ -343,7 +353,7 @@ func loadMarkdownDocs(workspaceRoot string, source config.Source) ([]model.DocRe
 		if err != nil {
 			return nil, fmt.Errorf("source %q doc %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
 		}
-		docRef, err := docRefForPath(source.ResolvedPath, match.AbsolutePath)
+		docRef, err := docRefForPath(source.ResolvedPath, match.AbsolutePath, source.ResolvedRepo, source.PrimaryRepo)
 		if err != nil {
 			return nil, fmt.Errorf("source %q doc %q: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
 		}
@@ -432,7 +442,7 @@ func sourcePathAllowed(source config.Source, relPath string) (bool, error) {
 	return selection.Selected, nil
 }
 
-func docRefForPath(sourceRoot, path string) (string, error) {
+func docRefForPath(sourceRoot, path, repoID, primaryRepoID string) (string, error) {
 	rel, err := filepath.Rel(sourceRoot, path)
 	if err != nil {
 		return "", err
@@ -440,7 +450,7 @@ func docRefForPath(sourceRoot, path string) (string, error) {
 	if filepath.Ext(rel) != ".md" {
 		return "", fmt.Errorf("doc path %q is not markdown", rel)
 	}
-	return "doc://" + strings.TrimSuffix(filepath.ToSlash(rel), ".md"), nil
+	return repoScopedArtifactRef("doc://", strings.TrimSuffix(filepath.ToSlash(rel), ".md"), repoID, primaryRepoID), nil
 }
 
 func docTitle(path string, body []byte) string {
@@ -474,7 +484,7 @@ type markdownContractFields struct {
 
 func inferMarkdownContract(workspaceRoot string, source config.Source, path string, body []byte) (model.SpecRecord, error) {
 	fields := inferMarkdownContractFields(body)
-	fallbackRef, err := markdownContractRefForPath(workspaceRoot, path)
+	fallbackRef, err := markdownContractRefForPath(workspaceRoot, path, source.ResolvedRepo, source.PrimaryRepo)
 	if err != nil {
 		return model.SpecRecord{}, err
 	}
@@ -791,7 +801,7 @@ func uniqueStringValues(values []string) []string {
 	return result
 }
 
-func markdownContractRefForPath(workspaceRoot, path string) (string, error) {
+func markdownContractRefForPath(workspaceRoot, path, repoID, primaryRepoID string) (string, error) {
 	rel, err := filepath.Rel(workspaceRoot, path)
 	if err != nil {
 		return "", err
@@ -799,7 +809,17 @@ func markdownContractRefForPath(workspaceRoot, path string) (string, error) {
 	if filepath.Ext(rel) != ".md" {
 		return "", fmt.Errorf("contract path %q is not markdown", rel)
 	}
-	return "contract://" + strings.TrimSuffix(filepath.ToSlash(rel), ".md"), nil
+	return repoScopedArtifactRef("contract://", strings.TrimSuffix(filepath.ToSlash(rel), ".md"), repoID, primaryRepoID), nil
+}
+
+func repoScopedArtifactRef(prefix, relativePath, repoID, primaryRepoID string) string {
+	relativePath = strings.TrimPrefix(strings.TrimSpace(relativePath), "/")
+	repoID = strings.TrimSpace(repoID)
+	primaryRepoID = strings.TrimSpace(primaryRepoID)
+	if repoID == "" || repoID == primaryRepoID {
+		return prefix + relativePath
+	}
+	return prefix + repoID + "/" + relativePath
 }
 
 func parseSpecBundle(contents []byte) (rawSpecBundle, error) {

--- a/internal/source/filesystem_test.go
+++ b/internal/source/filesystem_test.go
@@ -551,6 +551,87 @@ path = "docs-b"
 	}
 }
 
+func TestLoadFromConfigScopesDocRefsByRepo(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	primary := filepath.Join(root, "primary")
+	shared := filepath.Join(root, "shared")
+	mustWriteFile(t, filepath.Join(root, "pituitary.toml"), `
+[workspace]
+root = "primary"
+repo_id = "primary"
+index_path = ".pituitary/pituitary.db"
+
+[[workspace.repos]]
+id = "shared"
+root = "shared"
+
+[[sources]]
+name = "primary-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+
+[[sources]]
+name = "shared-docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+repo = "shared"
+path = "docs"
+`)
+	mustWriteFile(t, filepath.Join(primary, "docs", "guides", "api-rate-limits.md"), "# Primary Guide\n")
+	mustWriteFile(t, filepath.Join(shared, "docs", "guides", "api-rate-limits.md"), "# Shared Guide\n")
+
+	cfg, err := config.Load(filepath.Join(root, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("LoadFromConfig() error = %v", err)
+	}
+	if got, want := len(result.Docs), 2; got != want {
+		t.Fatalf("doc count = %d, want %d", got, want)
+	}
+	if got, want := len(result.Sources), 2; got != want {
+		t.Fatalf("source count = %d, want %d", got, want)
+	}
+	if got, want := result.Sources[0].Repo, "primary"; got != want {
+		t.Fatalf("primary source repo = %q, want %q", got, want)
+	}
+	if got, want := result.Sources[1].Repo, "shared"; got != want {
+		t.Fatalf("shared source repo = %q, want %q", got, want)
+	}
+
+	docsByRef := map[string]model.DocRecord{}
+	for _, doc := range result.Docs {
+		docsByRef[doc.Ref] = doc
+	}
+	primaryDoc, ok := docsByRef["doc://guides/api-rate-limits"]
+	if !ok {
+		t.Fatalf("docs = %+v, want primary doc ref", result.Docs)
+	}
+	if got, want := primaryDoc.Metadata["repo_id"], "primary"; got != want {
+		t.Fatalf("primary doc repo metadata = %q, want %q", got, want)
+	}
+	if got, want := primaryDoc.SourceRef, "file://docs/guides/api-rate-limits.md"; got != want {
+		t.Fatalf("primary doc source_ref = %q, want %q", got, want)
+	}
+
+	sharedDoc, ok := docsByRef["doc://shared/guides/api-rate-limits"]
+	if !ok {
+		t.Fatalf("docs = %+v, want shared doc ref", result.Docs)
+	}
+	if got, want := sharedDoc.Metadata["repo_id"], "shared"; got != want {
+		t.Fatalf("shared doc repo metadata = %q, want %q", got, want)
+	}
+	if got, want := sharedDoc.SourceRef, "file://docs/guides/api-rate-limits.md"; got != want {
+		t.Fatalf("shared doc source_ref = %q, want %q", got, want)
+	}
+}
+
 func TestLoadFromConfigFiltersMarkdownDocsBySelectors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -23,6 +23,7 @@ type LoadResult struct {
 // LoadSourceSummary describes the records contributed by one configured source.
 type LoadSourceSummary struct {
 	Name      string `json:"name"`
+	Repo      string `json:"repo,omitempty"`
 	Adapter   string `json:"adapter"`
 	Kind      string `json:"kind"`
 	Path      string `json:"path"`
@@ -52,9 +53,22 @@ func LoadFromConfigWithOptions(cfg *config.Config, options LoadOptions) (*LoadRe
 	logger.Infof("source", "loading %d configured source(s)", len(cfg.Sources))
 
 	for _, source := range cfg.Sources {
-		logger.Debugf("source", "loading source %q (%s %s)", source.Name, source.Kind, filepath.ToSlash(source.Path))
+		resolvedRepo := strings.TrimSpace(source.ResolvedRepo)
+		if resolvedRepo == "" {
+			resolvedRepo = config.PrimaryRepoID(cfg)
+		}
+		primaryRepoID := strings.TrimSpace(source.PrimaryRepo)
+		if primaryRepoID == "" {
+			primaryRepoID = config.PrimaryRepoID(cfg)
+		}
+		repoRootPath := strings.TrimSpace(source.RepoRootPath)
+		if repoRootPath == "" {
+			repoRootPath = cfg.Workspace.RootPath
+		}
+		logger.Debugf("source", "loading %s (%s %s)", sourceDisplayName(source), source.Kind, filepath.ToSlash(source.Path))
 		summary := LoadSourceSummary{
 			Name:    source.Name,
+			Repo:    resolvedRepo,
 			Adapter: source.Adapter,
 			Kind:    source.Kind,
 			Path:    source.Path,
@@ -68,17 +82,20 @@ func LoadFromConfigWithOptions(cfg *config.Config, options LoadOptions) (*LoadRe
 			Name:          source.Name,
 			Adapter:       source.Adapter,
 			Kind:          source.Kind,
+			Repo:          resolvedRepo,
 			Path:          source.Path,
 			Files:         append([]string(nil), source.Files...),
 			Include:       append([]string(nil), source.Include...),
 			Exclude:       append([]string(nil), source.Exclude...),
 			Options:       config.CloneSourceOptions(source.Options),
-			WorkspaceRoot: cfg.Workspace.RootPath,
+			WorkspaceRoot: repoRootPath,
+			PrimaryRepoID: primaryRepoID,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("source %q: %w", source.Name, err)
+			return nil, fmt.Errorf("%s: %w", sourceDisplayName(source), err)
 		}
 		annotateSourceRoleMetadata(source.Role, adapterResult)
+		annotateSourceRepoMetadata(resolvedRepo, adapterResult)
 
 		if err := appendUniqueSpecRecords(result, seenSpecs, source, adapterResult.Specs); err != nil {
 			return nil, err
@@ -92,13 +109,13 @@ func LoadFromConfigWithOptions(cfg *config.Config, options LoadOptions) (*LoadRe
 
 		result.Sources = append(result.Sources, summary)
 		if summary.ItemCount == 0 {
-			logger.Warnf("source", "source %q (%s %s) matched 0 item(s)", source.Name, source.Kind, filepath.ToSlash(source.Path))
+			logger.Warnf("source", "%s (%s %s) matched 0 item(s)", sourceDisplayName(source), source.Kind, filepath.ToSlash(source.Path))
 			continue
 		}
 		logger.Infof(
 			"source",
-			"source %q (%s %s) loaded %d item(s) (%d spec(s), %d doc(s))",
-			source.Name,
+			"%s (%s %s) loaded %d item(s) (%d spec(s), %d doc(s))",
+			sourceDisplayName(source),
 			source.Kind,
 			filepath.ToSlash(source.Path),
 			summary.ItemCount,
@@ -149,4 +166,32 @@ func withSourceRole(metadata map[string]string, role string) map[string]string {
 	}
 	metadata["source_role"] = role
 	return metadata
+}
+
+func annotateSourceRepoMetadata(repoID string, result *sdk.AdapterResult) {
+	repoID = strings.TrimSpace(repoID)
+	if repoID == "" || result == nil {
+		return
+	}
+	for i := range result.Specs {
+		result.Specs[i].Metadata = withSourceRepo(result.Specs[i].Metadata, repoID)
+	}
+	for i := range result.Docs {
+		result.Docs[i].Metadata = withSourceRepo(result.Docs[i].Metadata, repoID)
+	}
+}
+
+func withSourceRepo(metadata map[string]string, repoID string) map[string]string {
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+	metadata["repo_id"] = repoID
+	return metadata
+}
+
+func sourceDisplayName(source config.Source) string {
+	if strings.TrimSpace(source.Repo) != "" {
+		return fmt.Sprintf("source %q repo %q", source.Name, source.ResolvedRepo)
+	}
+	return fmt.Sprintf("source %q", source.Name)
 }

--- a/sdk/adapter.go
+++ b/sdk/adapter.go
@@ -21,6 +21,7 @@ type SourceConfig struct {
 	Name    string         `json:"name"`
 	Adapter string         `json:"adapter"`
 	Kind    string         `json:"kind"`
+	Repo    string         `json:"repo,omitempty"`
 	Path    string         `json:"path,omitempty"`
 	Files   []string       `json:"files,omitempty"`
 	Include []string       `json:"include,omitempty"`
@@ -29,4 +30,5 @@ type SourceConfig struct {
 
 	// WorkspaceRoot is the absolute workspace root path.
 	WorkspaceRoot string `json:"-"`
+	PrimaryRepoID string `json:"-"`
 }


### PR DESCRIPTION
Closes #208

## Summary
- add first-class multi-repo workspace config with named repo roots and per-source repo binding
- carry repo identity through source metadata, search/drift/impact results, and index/status repo coverage
- update text output and docs for cross-repo search, drift, impact, and rebuild/status reporting

## Validation
- go test ./internal/config ./internal/source ./internal/index ./internal/analysis ./cmd
- make ci