### PR TITLE
Add named runtime profiles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -411,16 +411,19 @@ Step 6: Atomic Swap
 - Unsupported runtime providers should fail during config validation with clear, intentional errors.
 - Provider-backed embeddings and bounded provider-backed analysis are both now part of the runtime contract.
 
-V1 runtime configuration should be explicit in `pituitary.toml` under `[runtime.embedder]` and `[runtime.analysis]`:
+V1 runtime configuration should be explicit in `pituitary.toml` under `[runtime.embedder]` and `[runtime.analysis]`, with optional reusable named bases under `[runtime.profiles.<name>]`:
 
 | Field | Embedder | Analysis | Notes |
 |---|---|---|---|
 | `provider` | optional, defaults to `fixture` | optional, defaults to `disabled` | Embedder and analysis currently support `openai_compatible`; analysis also supports `disabled` |
+| `profile` | optional | optional | Selects one named reusable runtime profile and then applies per-block overrides on top |
 | `model` | defaults to `fixture-8d` for `fixture`; required for `openai_compatible` | required for `openai_compatible`, ignored when disabled | Part of the embedder fingerprint stored in index metadata |
 | `endpoint` | required for `openai_compatible`, ignored for `fixture` | required for `openai_compatible`, ignored when disabled | Expected to point at an OpenAI-compatible API root such as `http://host:1234/v1` |
 | `api_key_env` | optional | optional | Optional so local servers such as LM Studio can run without credentials |
 | `timeout_ms` | optional, defaults to `1000` | optional, defaults to `1000` | Active for `openai_compatible` embedding requests |
 | `max_retries` | optional, defaults to `0` | optional, defaults to `0` | Active for retryable `openai_compatible` runtime failures |
+
+`pituitary status` should surface the resolved runtime assumptions actually in force: active profile, provider, model, endpoint, timeout, and retry settings for both embedder and analysis. `pituitary status --check-runtime ...` should probe those same resolved values rather than a hidden alternate contract.
 
 Degraded behavior rules:
 

--- a/README.md
+++ b/README.md
@@ -162,20 +162,23 @@ endpoint = "https://api.openai.com/v1"
 api_key_env = "OPENAI_API_KEY"
 ```
 
-**Local: LM Studio or Ollama** (no data leaves your machine)
+**Named runtime profiles** (recommended when embedder and analysis share the same host assumptions)
 
 ```toml
-[runtime.embedder]
+[runtime.profiles.local-lm-studio]
 provider = "openai_compatible"
-model = "nomic-embed-text-v1.5"
-endpoint = "http://127.0.0.1:1234/v1"
-
-[runtime.analysis]
-provider = "openai_compatible"
-model = "your-analysis-model"
 endpoint = "http://127.0.0.1:1234/v1"
 timeout_ms = 30000
 max_retries = 1
+
+[runtime.embedder]
+profile = "local-lm-studio"
+model = "nomic-embed-text-v1.5"
+
+[runtime.analysis]
+profile = "local-lm-studio"
+model = "your-analysis-model"
+timeout_ms = 120000
 ```
 
 For `runtime.analysis`, prefer a text model that is good at bounded adjudication rather than a generic embedding or agent stack:
@@ -190,9 +193,12 @@ Examples today include recent instruct models from the Qwen and Mistral families
 Then validate and rebuild:
 
 ```sh
+pituitary status
 pituitary status --check-runtime all
 pituitary index --rebuild
 ```
+
+`pituitary status` now shows the active runtime profile plus the resolved provider, model, endpoint, timeout, and retry settings for both embedder and analysis. `--check-runtime` probes those resolved settings directly.
 
 Retrieval remains deterministic. The analysis model only sees narrowly shortlisted context for `compare-specs` and `check-doc-drift`. Any OpenAI-compatible embedding or analysis API works. See [runtime docs](docs/runtime.md) for full setup.
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -388,15 +388,36 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 			fmt.Fprintf(w, "  %s %s\n", p.arrow(), hint)
 		}
 	}
+	if result.RuntimeConfig != nil {
+		fmt.Fprintf(w, "  %s\n", p.white("RUNTIME CONFIG"))
+		for i, item := range []struct {
+			Name     string
+			Provider statusRuntimeProvider
+		}{
+			{Name: "runtime.embedder", Provider: result.RuntimeConfig.Embedder},
+			{Name: "runtime.analysis", Provider: result.RuntimeConfig.Analysis},
+		} {
+			fmt.Fprintf(w, "  %s %s\n", p.treeItem(i == 1), renderRuntimeProviderSummary(item.Name, item.Provider))
+		}
+	}
 	if result.Runtime != nil {
 		fmt.Fprintf(w, "  %s %s\n", p.dim("runtime probe:"), result.Runtime.Scope)
 		for _, check := range result.Runtime.Checks {
 			fmt.Fprintf(w, "  %s %s %s | %s | provider: %s", p.dim("runtime:"), runtimeCheckGlyph(p, check.Status), check.Name, check.Status, check.Provider)
+			if check.Profile != "" {
+				fmt.Fprintf(w, " | profile: %s", check.Profile)
+			}
 			if check.Model != "" {
 				fmt.Fprintf(w, " | model: %s", check.Model)
 			}
 			if check.Endpoint != "" {
 				fmt.Fprintf(w, " | endpoint: %s", check.Endpoint)
+			}
+			if check.Timeout > 0 {
+				fmt.Fprintf(w, " | timeout_ms: %d", check.Timeout)
+			}
+			if check.Retries > 0 {
+				fmt.Fprintf(w, " | max_retries: %d", check.Retries)
 			}
 			fmt.Fprintln(w)
 			if check.Message != "" {
@@ -407,6 +428,29 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 	for _, guidance := range result.Guidance {
 		fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
 	}
+}
+
+func renderRuntimeProviderSummary(name string, provider statusRuntimeProvider) string {
+	parts := []string{name}
+	if provider.Profile != "" {
+		parts = append(parts, "profile: "+provider.Profile)
+	}
+	if provider.Provider != "" {
+		parts = append(parts, "provider: "+provider.Provider)
+	}
+	if provider.Model != "" {
+		parts = append(parts, "model: "+provider.Model)
+	}
+	if provider.Endpoint != "" {
+		parts = append(parts, "endpoint: "+provider.Endpoint)
+	}
+	if provider.TimeoutMS > 0 {
+		parts = append(parts, fmt.Sprintf("timeout_ms: %d", provider.TimeoutMS))
+	}
+	if provider.MaxRetries > 0 {
+		parts = append(parts, fmt.Sprintf("max_retries: %d", provider.MaxRetries))
+	}
+	return strings.Join(parts, " | ")
 }
 
 func renderVersionResult(w io.Writer, result *versionResult) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -23,6 +23,7 @@ type statusResult struct {
 	ConfigPath        string                     `json:"config_path"`
 	EmbedderProvider  string                     `json:"embedder_provider,omitempty"`
 	AnalysisProvider  string                     `json:"analysis_provider,omitempty"`
+	RuntimeConfig     *statusRuntimeConfig       `json:"runtime_config,omitempty"`
 	ConfigResolution  *configResolution          `json:"config_resolution,omitempty"`
 	IndexPath         string                     `json:"index_path"`
 	IndexExists       bool                       `json:"index_exists"`
@@ -35,6 +36,20 @@ type statusResult struct {
 	RelationGraph     *index.RelationGraphStatus `json:"relation_graph,omitempty"`
 	Runtime           *runtimeprobe.Result       `json:"runtime,omitempty"`
 	Guidance          []string                   `json:"guidance,omitempty"`
+}
+
+type statusRuntimeConfig struct {
+	Embedder statusRuntimeProvider `json:"embedder"`
+	Analysis statusRuntimeProvider `json:"analysis"`
+}
+
+type statusRuntimeProvider struct {
+	Profile    string `json:"profile,omitempty"`
+	Provider   string `json:"provider,omitempty"`
+	Model      string `json:"model,omitempty"`
+	Endpoint   string `json:"endpoint,omitempty"`
+	TimeoutMS  int    `json:"timeout_ms,omitempty"`
+	MaxRetries int    `json:"max_retries,omitempty"`
 }
 
 type statusArtifactLocation struct {
@@ -123,6 +138,7 @@ func newStatusResult(result *app.StatusResult, resolution *configResolution) *st
 		ConfigPath:        result.ConfigPath,
 		EmbedderProvider:  result.EmbedderProvider,
 		AnalysisProvider:  result.AnalysisProvider,
+		RuntimeConfig:     newStatusRuntimeConfig(result.RuntimeConfig),
 		ConfigResolution:  resolution,
 		IndexPath:         result.Index.IndexPath,
 		IndexExists:       result.Index.Exists,
@@ -135,6 +151,30 @@ func newStatusResult(result *app.StatusResult, resolution *configResolution) *st
 		RelationGraph:     result.RelationGraph,
 		Runtime:           result.Runtime,
 		Guidance:          append([]string(nil), result.Guidance...),
+	}
+}
+
+func newStatusRuntimeConfig(runtimeConfig *app.RuntimeConfigStatus) *statusRuntimeConfig {
+	if runtimeConfig == nil {
+		return nil
+	}
+	return &statusRuntimeConfig{
+		Embedder: statusRuntimeProvider{
+			Profile:    runtimeConfig.Embedder.Profile,
+			Provider:   runtimeConfig.Embedder.Provider,
+			Model:      runtimeConfig.Embedder.Model,
+			Endpoint:   runtimeConfig.Embedder.Endpoint,
+			TimeoutMS:  runtimeConfig.Embedder.TimeoutMS,
+			MaxRetries: runtimeConfig.Embedder.MaxRetries,
+		},
+		Analysis: statusRuntimeProvider{
+			Profile:    runtimeConfig.Analysis.Profile,
+			Provider:   runtimeConfig.Analysis.Provider,
+			Model:      runtimeConfig.Analysis.Model,
+			Endpoint:   runtimeConfig.Analysis.Endpoint,
+			TimeoutMS:  runtimeConfig.Analysis.TimeoutMS,
+			MaxRetries: runtimeConfig.Analysis.MaxRetries,
+		},
 	}
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -102,8 +102,18 @@ func TestRunStatusJSON(t *testing.T) {
 	var payload struct {
 		Request struct{} `json:"request"`
 		Result  struct {
-			WorkspaceRoot    string `json:"workspace_root"`
-			ConfigPath       string `json:"config_path"`
+			WorkspaceRoot string `json:"workspace_root"`
+			ConfigPath    string `json:"config_path"`
+			RuntimeConfig struct {
+				Embedder struct {
+					Provider  string `json:"provider"`
+					Model     string `json:"model"`
+					TimeoutMS int    `json:"timeout_ms"`
+				} `json:"embedder"`
+				Analysis struct {
+					Provider string `json:"provider"`
+				} `json:"analysis"`
+			} `json:"runtime_config"`
 			ConfigResolution struct {
 				SelectedBy string `json:"selected_by"`
 				Reason     string `json:"reason"`
@@ -140,6 +150,18 @@ func TestRunStatusJSON(t *testing.T) {
 	}
 	if payload.Result.WorkspaceRoot == "" || payload.Result.ConfigPath == "" || payload.Result.IndexPath == "" {
 		t.Fatalf("result = %+v, want non-empty workspace, config, and index paths", payload.Result)
+	}
+	if got, want := payload.Result.RuntimeConfig.Embedder.Provider, "fixture"; got != want {
+		t.Fatalf("result.runtime_config.embedder.provider = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.RuntimeConfig.Embedder.Model, "fixture-8d"; got != want {
+		t.Fatalf("result.runtime_config.embedder.model = %q, want %q", got, want)
+	}
+	if payload.Result.RuntimeConfig.Embedder.TimeoutMS == 0 {
+		t.Fatalf("result.runtime_config.embedder.timeout_ms = %d, want non-zero default", payload.Result.RuntimeConfig.Embedder.TimeoutMS)
+	}
+	if got, want := payload.Result.RuntimeConfig.Analysis.Provider, "disabled"; got != want {
+		t.Fatalf("result.runtime_config.analysis.provider = %q, want %q", got, want)
 	}
 	if !payload.Result.IndexExists {
 		t.Fatalf("result = %+v, want index_exists=true", payload.Result)
@@ -287,7 +309,9 @@ func TestRunStatusJSONIncludesRuntimeProbeResults(t *testing.T) {
 				Scope  string `json:"scope"`
 				Checks []struct {
 					Name     string `json:"name"`
+					Profile  string `json:"profile"`
 					Provider string `json:"provider"`
+					Timeout  int    `json:"timeout_ms"`
 					Status   string `json:"status"`
 					Message  string `json:"message"`
 				} `json:"checks"`
@@ -316,11 +340,162 @@ func TestRunStatusJSONIncludesRuntimeProbeResults(t *testing.T) {
 	if got, want := payload.Result.Runtime.Checks[0].Status, "ready"; got != want {
 		t.Fatalf("checks[0].status = %q, want %q", got, want)
 	}
+	if payload.Result.Runtime.Checks[0].Profile != "" {
+		t.Fatalf("checks[0].profile = %q, want empty for fixture default config", payload.Result.Runtime.Checks[0].Profile)
+	}
+	if payload.Result.Runtime.Checks[0].Timeout == 0 {
+		t.Fatalf("checks[0].timeout_ms = %d, want non-zero default", payload.Result.Runtime.Checks[0].Timeout)
+	}
 	if got, want := payload.Result.Runtime.Checks[1].Name, "runtime.analysis"; got != want {
 		t.Fatalf("checks[1].name = %q, want %q", got, want)
 	}
 	if got, want := payload.Result.Runtime.Checks[1].Status, "disabled"; got != want {
 		t.Fatalf("checks[1].status = %q, want %q", got, want)
+	}
+}
+
+func TestRunStatusJSONIncludesResolvedRuntimeProfiles(t *testing.T) {
+	repo := t.TempDir()
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.profiles.local-lm-studio]
+provider = "openai_compatible"
+endpoint = "http://127.0.0.1:1234/v1"
+timeout_ms = 30000
+max_retries = 1
+
+[runtime.embedder]
+profile = "local-lm-studio"
+model = "nomic-embed-text-v1.5"
+
+[runtime.analysis]
+profile = "local-lm-studio"
+model = "qwen3.5-35b"
+timeout_ms = 120000
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus([]string{"--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runStatus() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			RuntimeConfig struct {
+				Embedder struct {
+					Profile    string `json:"profile"`
+					Provider   string `json:"provider"`
+					Model      string `json:"model"`
+					Endpoint   string `json:"endpoint"`
+					TimeoutMS  int    `json:"timeout_ms"`
+					MaxRetries int    `json:"max_retries"`
+				} `json:"embedder"`
+				Analysis struct {
+					Profile   string `json:"profile"`
+					Provider  string `json:"provider"`
+					Model     string `json:"model"`
+					Endpoint  string `json:"endpoint"`
+					TimeoutMS int    `json:"timeout_ms"`
+				} `json:"analysis"`
+			} `json:"runtime_config"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if got, want := payload.Result.RuntimeConfig.Embedder.Profile, "local-lm-studio"; got != want {
+		t.Fatalf("result.runtime_config.embedder.profile = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.RuntimeConfig.Embedder.Provider, "openai_compatible"; got != want {
+		t.Fatalf("result.runtime_config.embedder.provider = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.RuntimeConfig.Embedder.TimeoutMS, 30000; got != want {
+		t.Fatalf("result.runtime_config.embedder.timeout_ms = %d, want %d", got, want)
+	}
+	if got, want := payload.Result.RuntimeConfig.Analysis.Profile, "local-lm-studio"; got != want {
+		t.Fatalf("result.runtime_config.analysis.profile = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.RuntimeConfig.Analysis.Model, "qwen3.5-35b"; got != want {
+		t.Fatalf("result.runtime_config.analysis.model = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.RuntimeConfig.Analysis.TimeoutMS, 120000; got != want {
+		t.Fatalf("result.runtime_config.analysis.timeout_ms = %d, want %d", got, want)
+	}
+}
+
+func TestRunStatusTextIncludesResolvedRuntimeProfiles(t *testing.T) {
+	repo := t.TempDir()
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.profiles.local-lm-studio]
+provider = "openai_compatible"
+endpoint = "http://127.0.0.1:1234/v1"
+timeout_ms = 30000
+max_retries = 1
+
+[runtime.embedder]
+profile = "local-lm-studio"
+model = "nomic-embed-text-v1.5"
+
+[runtime.analysis]
+profile = "local-lm-studio"
+model = "qwen3.5-35b"
+timeout_ms = 120000
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus(nil, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runStatus() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"RUNTIME CONFIG",
+		"profile: local-lm-studio",
+		"model: nomic-embed-text-v1.5",
+		"timeout_ms: 120000",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("runStatus() output %q does not contain %q", out, want)
+		}
 	}
 }
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -19,7 +19,7 @@ pituitary explain-file README.md                # why is this file in/out of sco
 pituitary index --rebuild                       # build/rebuild, reuse unchanged embeddings
 pituitary index --rebuild --full                # force complete re-embed
 pituitary index --dry-run                       # validate without writing
-pituitary status                                # index health, config, freshness
+pituitary status                                # index health + resolved runtime config
 pituitary status --check-runtime embedder       # probe embedder readiness
 pituitary status --check-runtime all            # probe embedder + analysis readiness
 pituitary schema review-spec --format json      # machine-readable command contract

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,29 @@ include = ["guides/*.md"]
 
 Pituitary keeps source paths repo-relative, adds `repo` to search/drift/impact/status JSON, and scopes non-primary generated doc refs as `doc://<repo>/...` so duplicate paths from sibling repos stay distinct.
 
+### Runtime Profiles
+
+Runtime config also supports reusable named profiles under `[runtime.profiles.<name>]`. Select one from `[runtime.embedder]` or `[runtime.analysis]` with `profile = "..."`, then override only the fields that differ:
+
+```toml
+[runtime.profiles.local-lm-studio]
+provider = "openai_compatible"
+endpoint = "http://127.0.0.1:1234/v1"
+timeout_ms = 30000
+max_retries = 1
+
+[runtime.embedder]
+profile = "local-lm-studio"
+model = "nomic-embed-text-v1.5"
+
+[runtime.analysis]
+profile = "local-lm-studio"
+model = "qwen3.5-35b"
+timeout_ms = 120000
+```
+
+`pituitary status` reports the resolved runtime config, including the selected profile plus the effective provider, model, endpoint, timeout, and retry settings that commands will use.
+
 ### Example: Optional GitHub issues source
 
 Schema `3` also supports adapter-specific typed options under `[sources.options]`:

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -17,6 +17,20 @@ timeout_ms = 30000
 max_retries = 1
 ```
 
+If your embedder and analysis runtimes share a host or retry policy, prefer a named profile and select it from each runtime surface:
+
+```toml
+[runtime.profiles.local-lm-studio]
+provider = "openai_compatible"
+endpoint = "http://127.0.0.1:1234/v1"
+timeout_ms = 30000
+max_retries = 1
+
+[runtime.embedder]
+profile = "local-lm-studio"
+model = "nomic-embed-text-v1.5"
+```
+
 A practical setup: load `nomic-embed-text-v1.5` in [LM Studio](https://lmstudio.ai), expose it on `localhost:1234`, then:
 
 ```sh
@@ -28,11 +42,9 @@ For provider-backed qualitative analysis used by `compare-specs` and `check-doc-
 
 ```toml
 [runtime.analysis]
-provider = "openai_compatible"
+profile = "local-lm-studio"
 model = "your-analysis-model"
-endpoint = "http://127.0.0.1:1234/v1"
-timeout_ms = 30000
-max_retries = 1
+timeout_ms = 120000
 ```
 
 Retrieval stays deterministic. The analysis model only touches narrowly shortlisted context.
@@ -50,8 +62,11 @@ Examples today include recent instruct-capable Qwen and Mistral models, but Pitu
 Validate both runtimes with:
 
 ```sh
+pituitary status
 pituitary status --check-runtime all
 ```
+
+`pituitary status` reports the resolved runtime config for `runtime.embedder` and `runtime.analysis`, including the active profile name when one is selected. `pituitary status --check-runtime ...` uses those resolved values for the live probe and echoes the same profile / provider / model / endpoint / timeout assumptions in the probe output.
 
 For Nomic-compatible models, Pituitary automatically applies the required `search_document:` / `search_query:` prefixes.
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -21,11 +21,26 @@ type StatusResult struct {
 	ConfigPath       string
 	EmbedderProvider string
 	AnalysisProvider string
+	RuntimeConfig    *RuntimeConfigStatus
 	Index            *index.Status
 	Freshness        *index.FreshnessStatus
 	RelationGraph    *index.RelationGraphStatus
 	Runtime          *runtimeprobe.Result
 	Guidance         []string
+}
+
+type RuntimeConfigStatus struct {
+	Embedder RuntimeProviderStatus
+	Analysis RuntimeProviderStatus
+}
+
+type RuntimeProviderStatus struct {
+	Profile    string
+	Provider   string
+	Model      string
+	Endpoint   string
+	TimeoutMS  int
+	MaxRetries int
 }
 
 // Status loads config, inspects the current index, and optionally probes runtime dependencies.
@@ -58,11 +73,15 @@ func Status(ctx context.Context, configPath string, request StatusRequest) Respo
 			ConfigPath:       cfg.ConfigPath,
 			EmbedderProvider: cfg.Runtime.Embedder.Provider,
 			AnalysisProvider: cfg.Runtime.Analysis.Provider,
-			Index:            status,
-			Freshness:        freshness,
-			RelationGraph:    index.InspectRelationGraph(records.Specs),
-			Runtime:          runtimeResult,
-			Guidance:         fixtureEmbedderGuidance(cfg, status),
+			RuntimeConfig: &RuntimeConfigStatus{
+				Embedder: runtimeProviderStatus(cfg.Runtime.Embedder),
+				Analysis: runtimeProviderStatus(cfg.Runtime.Analysis),
+			},
+			Index:         status,
+			Freshness:     freshness,
+			RelationGraph: index.InspectRelationGraph(records.Specs),
+			Runtime:       runtimeResult,
+			Guidance:      fixtureEmbedderGuidance(cfg, status),
 		}, nil
 	}, classifyStatusError)
 }
@@ -85,6 +104,17 @@ func fixtureEmbedderGuidance(cfg *config.Config, status *index.Status) []string 
 			totalArtifacts,
 			config.RuntimeProviderOpenAI,
 		),
+	}
+}
+
+func runtimeProviderStatus(provider config.RuntimeProvider) RuntimeProviderStatus {
+	return RuntimeProviderStatus{
+		Profile:    provider.Profile,
+		Provider:   provider.Provider,
+		Model:      provider.Model,
+		Endpoint:   provider.Endpoint,
+		TimeoutMS:  provider.TimeoutMS,
+		MaxRetries: provider.MaxRetries,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,18 +82,27 @@ type Source struct {
 
 // Runtime captures provider configuration needed by later pipeline stages.
 type Runtime struct {
+	Profiles map[string]RuntimeProvider
 	Embedder RuntimeProvider
 	Analysis RuntimeProvider
 }
 
 // RuntimeProvider describes one configured runtime dependency.
 type RuntimeProvider struct {
+	Profile    string
 	Provider   string
 	Model      string
 	Endpoint   string
 	APIKeyEnv  string
 	TimeoutMS  int
 	MaxRetries int
+
+	providerSet   bool
+	modelSet      bool
+	endpointSet   bool
+	apiKeyEnvSet  bool
+	timeoutMSSet  bool
+	maxRetriesSet bool
 }
 
 type rawConfig struct {
@@ -116,8 +125,9 @@ type rawWorkspaceRepo struct {
 }
 
 type rawRuntime struct {
-	Embedder rawRuntimeProvider `toml:"embedder"`
-	Analysis rawRuntimeProvider `toml:"analysis"`
+	Profiles map[string]rawRuntimeProvider `toml:"profiles"`
+	Embedder rawRuntimeProvider            `toml:"embedder"`
+	Analysis rawRuntimeProvider            `toml:"analysis"`
 }
 
 type rawSource struct {
@@ -134,6 +144,7 @@ type rawSource struct {
 }
 
 type rawRuntimeProvider struct {
+	Profile    string `toml:"profile"`
 	Provider   string `toml:"provider"`
 	Model      string `toml:"model"`
 	Endpoint   string `toml:"endpoint"`
@@ -216,24 +227,14 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 			Repos:     make([]WorkspaceRepo, 0, len(raw.Workspace.Repos)),
 		},
 		Runtime: Runtime{
-			Embedder: RuntimeProvider{
-				Provider:   defaultString(raw.Runtime.Embedder.Provider, RuntimeProviderFixture),
-				Model:      raw.Runtime.Embedder.Model,
-				Endpoint:   raw.Runtime.Embedder.Endpoint,
-				APIKeyEnv:  raw.Runtime.Embedder.APIKeyEnv,
-				TimeoutMS:  defaultOptionalInt(raw.Runtime.Embedder.TimeoutMS, 1000),
-				MaxRetries: defaultOptionalInt(raw.Runtime.Embedder.MaxRetries, 0),
-			},
-			Analysis: RuntimeProvider{
-				Provider:   defaultString(raw.Runtime.Analysis.Provider, RuntimeProviderDisabled),
-				Model:      raw.Runtime.Analysis.Model,
-				Endpoint:   raw.Runtime.Analysis.Endpoint,
-				APIKeyEnv:  raw.Runtime.Analysis.APIKeyEnv,
-				TimeoutMS:  defaultOptionalInt(raw.Runtime.Analysis.TimeoutMS, 1000),
-				MaxRetries: defaultOptionalInt(raw.Runtime.Analysis.MaxRetries, 0),
-			},
+			Profiles: make(map[string]RuntimeProvider, len(raw.Runtime.Profiles)),
+			Embedder: buildRuntimeProvider(raw.Runtime.Embedder, RuntimeProviderFixture),
+			Analysis: buildRuntimeProvider(raw.Runtime.Analysis, RuntimeProviderDisabled),
 		},
 		Sources: make([]Source, 0, len(raw.Sources)),
+	}
+	for name, profile := range raw.Runtime.Profiles {
+		cfg.Runtime.Profiles[strings.TrimSpace(name)] = buildRuntimeProvider(profile, "")
 	}
 	for _, repo := range raw.Workspace.Repos {
 		cfg.Workspace.Repos = append(cfg.Workspace.Repos, WorkspaceRepo{
@@ -254,9 +255,6 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 			Exclude: append([]string(nil), source.Exclude...),
 			Options: CloneSourceOptions(source.Options),
 		})
-	}
-	if cfg.Runtime.Embedder.Provider == RuntimeProviderFixture && strings.TrimSpace(cfg.Runtime.Embedder.Model) == "" {
-		cfg.Runtime.Embedder.Model = "fixture-8d"
 	}
 	if cfg.SchemaVersion == 0 {
 		cfg.SchemaVersion = CurrentSchemaVersion
@@ -543,7 +541,7 @@ func validate(cfg *Config) error {
 		}
 	}
 
-	if err := validateRuntime(cfg.Runtime); err != nil {
+	if err := validateRuntime(&cfg.Runtime); err != nil {
 		errs.items = append(errs.items, err.Error())
 	}
 
@@ -640,8 +638,29 @@ func IsValidSourceRole(role string) bool {
 	}
 }
 
-func validateRuntime(runtime Runtime) error {
+func validateRuntime(runtime *Runtime) error {
 	var errs validationErrors
+	if runtime == nil {
+		return nil
+	}
+
+	for name, profile := range runtime.Profiles {
+		label := fmt.Sprintf("runtime.profiles.%s", name)
+		if !isValidRuntimeProfileName(name) {
+			errs.add("%s: unsupported profile name %q", label, name)
+		}
+		if strings.TrimSpace(profile.Profile) != "" {
+			errs.add("%s.profile: nested profile references are not supported", label)
+		}
+		validateRuntimeProfileFields(&errs, label, profile)
+	}
+
+	runtime.Embedder = resolveRuntimeProvider(runtime.Embedder, runtime.Profiles, RuntimeProviderFixture)
+	if profile := strings.TrimSpace(runtime.Embedder.Profile); profile != "" {
+		if _, ok := runtime.Profiles[profile]; !ok {
+			errs.add("runtime.embedder.profile: unknown profile %q", profile)
+		}
+	}
 
 	if runtime.Embedder.Provider == "" {
 		errs.add("runtime.embedder.provider: value is required")
@@ -684,6 +703,13 @@ func validateRuntime(runtime Runtime) error {
 		errs.add("runtime.embedder.max_retries: must be >= 0")
 	}
 
+	runtime.Analysis = resolveRuntimeProvider(runtime.Analysis, runtime.Profiles, RuntimeProviderDisabled)
+	if profile := strings.TrimSpace(runtime.Analysis.Profile); profile != "" {
+		if _, ok := runtime.Profiles[profile]; !ok {
+			errs.add("runtime.analysis.profile: unknown profile %q", profile)
+		}
+	}
+
 	if runtime.Analysis.Provider == "" {
 		errs.add("runtime.analysis.provider: value is required")
 	} else {
@@ -722,6 +748,116 @@ func validateRuntime(runtime Runtime) error {
 		errs.add("runtime.analysis.max_retries: must be >= 0")
 	}
 	return errs.err()
+}
+
+func buildRuntimeProvider(raw rawRuntimeProvider, defaultProvider string) RuntimeProvider {
+	return RuntimeProvider{
+		Profile:       strings.TrimSpace(raw.Profile),
+		Provider:      defaultString(strings.TrimSpace(raw.Provider), defaultProvider),
+		Model:         strings.TrimSpace(raw.Model),
+		Endpoint:      strings.TrimSpace(raw.Endpoint),
+		APIKeyEnv:     strings.TrimSpace(raw.APIKeyEnv),
+		TimeoutMS:     defaultOptionalInt(raw.TimeoutMS, 1000),
+		MaxRetries:    defaultOptionalInt(raw.MaxRetries, 0),
+		providerSet:   strings.TrimSpace(raw.Provider) != "",
+		modelSet:      strings.TrimSpace(raw.Model) != "",
+		endpointSet:   strings.TrimSpace(raw.Endpoint) != "",
+		apiKeyEnvSet:  strings.TrimSpace(raw.APIKeyEnv) != "",
+		timeoutMSSet:  raw.TimeoutMS != nil,
+		maxRetriesSet: raw.MaxRetries != nil,
+	}
+}
+
+func resolveRuntimeProvider(provider RuntimeProvider, profiles map[string]RuntimeProvider, defaultProvider string) RuntimeProvider {
+	profile := RuntimeProvider{}
+	hasProfile := false
+	if name := strings.TrimSpace(provider.Profile); name != "" {
+		profile, hasProfile = profiles[name]
+	}
+
+	resolved := provider
+	providerResolved := provider.providerSet
+	modelResolved := provider.modelSet
+	endpointResolved := provider.endpointSet
+	apiKeyEnvResolved := provider.apiKeyEnvSet
+	timeoutResolved := provider.timeoutMSSet
+	maxRetriesResolved := provider.maxRetriesSet
+
+	if !providerResolved && hasProfile && profile.providerSet {
+		resolved.Provider = profile.Provider
+		providerResolved = true
+	}
+	if !modelResolved && hasProfile && profile.modelSet {
+		resolved.Model = profile.Model
+		modelResolved = true
+	}
+	if !endpointResolved && hasProfile && profile.endpointSet {
+		resolved.Endpoint = profile.Endpoint
+		endpointResolved = true
+	}
+	if !apiKeyEnvResolved && hasProfile && profile.apiKeyEnvSet {
+		resolved.APIKeyEnv = profile.APIKeyEnv
+		apiKeyEnvResolved = true
+	}
+	if !timeoutResolved && hasProfile && profile.timeoutMSSet {
+		resolved.TimeoutMS = profile.TimeoutMS
+		timeoutResolved = true
+	}
+	if !maxRetriesResolved && hasProfile && profile.maxRetriesSet {
+		resolved.MaxRetries = profile.MaxRetries
+		maxRetriesResolved = true
+	}
+	if !providerResolved {
+		resolved.Provider = defaultProvider
+	}
+	if !timeoutResolved {
+		resolved.TimeoutMS = 1000
+	}
+	if !maxRetriesResolved {
+		resolved.MaxRetries = 0
+	}
+	if strings.TrimSpace(resolved.Provider) == RuntimeProviderFixture && !modelResolved {
+		resolved.Model = "fixture-8d"
+	}
+	return resolved
+}
+
+func validateRuntimeProfileFields(errs *validationErrors, label string, profile RuntimeProvider) {
+	if provider := strings.TrimSpace(profile.Provider); provider != "" {
+		switch provider {
+		case RuntimeProviderFixture, RuntimeProviderOpenAI, RuntimeProviderDisabled:
+		default:
+			errs.add(
+				"%s.provider: unsupported provider %q (supported providers: %q, %q, %q)",
+				label,
+				provider,
+				RuntimeProviderFixture,
+				RuntimeProviderOpenAI,
+				RuntimeProviderDisabled,
+			)
+		}
+	}
+	if endpoint := strings.TrimSpace(profile.Endpoint); endpoint != "" {
+		parsed, err := url.Parse(endpoint)
+		switch {
+		case err != nil:
+			errs.add("%s.endpoint: invalid URL %q: %v", label, profile.Endpoint, err)
+		case !parsed.IsAbs() || parsed.Host == "":
+			errs.add("%s.endpoint: %q must be an absolute URL", label, profile.Endpoint)
+		case parsed.Scheme != "http" && parsed.Scheme != "https":
+			errs.add("%s.endpoint: %q must use http or https", label, profile.Endpoint)
+		}
+	}
+	if profile.TimeoutMS < 0 {
+		errs.add("%s.timeout_ms: must be >= 0", label)
+	}
+	if profile.MaxRetries < 0 {
+		errs.add("%s.max_retries: must be >= 0", label)
+	}
+}
+
+func isValidRuntimeProfileName(value string) bool {
+	return isValidRepoID(value)
 }
 
 func resolvePath(base, value string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -213,6 +213,104 @@ path = "specs"
 	}
 }
 
+func TestLoadResolvesRuntimeProfiles(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.profiles.local-lm-studio]
+provider = "openai_compatible"
+endpoint = "http://127.0.0.1:1234/v1"
+timeout_ms = 30000
+max_retries = 1
+
+[runtime.embedder]
+profile = "local-lm-studio"
+model = "nomic-embed-text-v1.5"
+
+[runtime.analysis]
+profile = "local-lm-studio"
+model = "qwen3.5-35b"
+timeout_ms = 120000
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got, want := len(cfg.Runtime.Profiles), 1; got != want {
+		t.Fatalf("len(runtime.profiles) = %d, want %d", got, want)
+	}
+	profile := cfg.Runtime.Profiles["local-lm-studio"]
+	if got, want := profile.Provider, RuntimeProviderOpenAI; got != want {
+		t.Fatalf("runtime.profiles[local-lm-studio].provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Runtime.Embedder.Profile, "local-lm-studio"; got != want {
+		t.Fatalf("runtime.embedder.profile = %q, want %q", got, want)
+	}
+	if got, want := cfg.Runtime.Embedder.Provider, RuntimeProviderOpenAI; got != want {
+		t.Fatalf("runtime.embedder.provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Runtime.Embedder.Endpoint, "http://127.0.0.1:1234/v1"; got != want {
+		t.Fatalf("runtime.embedder.endpoint = %q, want %q", got, want)
+	}
+	if got, want := cfg.Runtime.Embedder.TimeoutMS, 30000; got != want {
+		t.Fatalf("runtime.embedder.timeout_ms = %d, want %d", got, want)
+	}
+	if got, want := cfg.Runtime.Analysis.Profile, "local-lm-studio"; got != want {
+		t.Fatalf("runtime.analysis.profile = %q, want %q", got, want)
+	}
+	if got, want := cfg.Runtime.Analysis.Provider, RuntimeProviderOpenAI; got != want {
+		t.Fatalf("runtime.analysis.provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Runtime.Analysis.TimeoutMS, 120000; got != want {
+		t.Fatalf("runtime.analysis.timeout_ms = %d, want %d", got, want)
+	}
+}
+
+func TestLoadRejectsUnknownRuntimeProfile(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+profile = "missing"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), `runtime.embedder.profile: unknown profile "missing"`) {
+		t.Fatalf("Load() error = %q, want unknown profile detail", err)
+	}
+}
+
 func TestParseRejectsDuplicateKeys(t *testing.T) {
 	t.Parallel()
 
@@ -1084,6 +1182,82 @@ func TestRenderRoundTripsWorkspaceRepos(t *testing.T) {
 	}
 	if got, want := loaded.Sources[1].Repo, "shared"; got != want {
 		t.Fatalf("loaded source repo = %q, want %q", got, want)
+	}
+}
+
+func TestRenderRoundTripsRuntimeProfiles(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	cfg := &Config{
+		SchemaVersion: CurrentSchemaVersion,
+		ConfigPath:    configPath,
+		ConfigDir:     repo,
+		Workspace: Workspace{
+			Root:      ".",
+			IndexPath: ".pituitary/pituitary.db",
+		},
+		Runtime: Runtime{
+			Profiles: map[string]RuntimeProvider{
+				"local-lm-studio": {
+					Provider:   RuntimeProviderOpenAI,
+					Endpoint:   "http://127.0.0.1:1234/v1",
+					TimeoutMS:  30000,
+					MaxRetries: 1,
+				},
+			},
+			Embedder: RuntimeProvider{
+				Profile:    "local-lm-studio",
+				Provider:   RuntimeProviderOpenAI,
+				Model:      "nomic-embed-text-v1.5",
+				Endpoint:   "http://127.0.0.1:1234/v1",
+				TimeoutMS:  30000,
+				MaxRetries: 1,
+			},
+			Analysis: RuntimeProvider{
+				Profile:    "local-lm-studio",
+				Provider:   RuntimeProviderOpenAI,
+				Model:      "qwen3.5-35b",
+				Endpoint:   "http://127.0.0.1:1234/v1",
+				TimeoutMS:  120000,
+				MaxRetries: 1,
+			},
+		},
+		Sources: []Source{
+			{
+				Name:    "specs",
+				Adapter: AdapterFilesystem,
+				Kind:    SourceKindSpecBundle,
+				Path:    "specs",
+			},
+		},
+	}
+
+	rendered, err := Render(cfg)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if !strings.Contains(rendered, "[runtime.profiles.local-lm-studio]") {
+		t.Fatalf("rendered config %q does not contain runtime profile table", rendered)
+	}
+	if !strings.Contains(rendered, "profile = \"local-lm-studio\"") {
+		t.Fatalf("rendered config %q does not contain runtime profile selection", rendered)
+	}
+
+	loaded, err := LoadFromText(rendered, configPath)
+	if err != nil {
+		t.Fatalf("LoadFromText() error = %v", err)
+	}
+	if got, want := loaded.Runtime.Embedder.Profile, "local-lm-studio"; got != want {
+		t.Fatalf("loaded runtime.embedder.profile = %q, want %q", got, want)
+	}
+	if got, want := loaded.Runtime.Embedder.Endpoint, "http://127.0.0.1:1234/v1"; got != want {
+		t.Fatalf("loaded runtime.embedder.endpoint = %q, want %q", got, want)
+	}
+	if got, want := loaded.Runtime.Analysis.TimeoutMS, 120000; got != want {
+		t.Fatalf("loaded runtime.analysis.timeout_ms = %d, want %d", got, want)
 	}
 }
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -28,32 +28,24 @@ func Render(cfg *Config) (string, error) {
 		fmt.Fprintf(&builder, "root = %s\n", strconv.Quote(repo.Root))
 	}
 
-	builder.WriteString("\n[runtime.embedder]\n")
-	fmt.Fprintf(&builder, "provider = %s\n", strconv.Quote(cfg.Runtime.Embedder.Provider))
-	fmt.Fprintf(&builder, "model = %s\n", strconv.Quote(cfg.Runtime.Embedder.Model))
-	if cfg.Runtime.Embedder.Endpoint != "" {
-		fmt.Fprintf(&builder, "endpoint = %s\n", strconv.Quote(cfg.Runtime.Embedder.Endpoint))
+	profileNames := make([]string, 0, len(cfg.Runtime.Profiles))
+	for name := range cfg.Runtime.Profiles {
+		profileNames = append(profileNames, name)
 	}
-	if cfg.Runtime.Embedder.APIKeyEnv != "" {
-		fmt.Fprintf(&builder, "api_key_env = %s\n", strconv.Quote(cfg.Runtime.Embedder.APIKeyEnv))
+	sort.Strings(profileNames)
+	for _, name := range profileNames {
+		builder.WriteString("\n[runtime.profiles.")
+		builder.WriteString(name)
+		builder.WriteString("]\n")
+		writeRuntimeProviderConfig(&builder, cfg.Runtime.Profiles[name], nil)
 	}
-	fmt.Fprintf(&builder, "timeout_ms = %d\n", cfg.Runtime.Embedder.TimeoutMS)
-	fmt.Fprintf(&builder, "max_retries = %d\n", cfg.Runtime.Embedder.MaxRetries)
 
-	if provider := strings.TrimSpace(cfg.Runtime.Analysis.Provider); provider != "" && provider != "disabled" {
+	builder.WriteString("\n[runtime.embedder]\n")
+	writeRuntimeProviderConfig(&builder, cfg.Runtime.Embedder, runtimeProfileBase(cfg.Runtime.Profiles, cfg.Runtime.Embedder.Profile))
+
+	if provider := strings.TrimSpace(cfg.Runtime.Analysis.Provider); provider != "" && (provider != RuntimeProviderDisabled || strings.TrimSpace(cfg.Runtime.Analysis.Profile) != "") {
 		builder.WriteString("\n[runtime.analysis]\n")
-		fmt.Fprintf(&builder, "provider = %s\n", strconv.Quote(provider))
-		if cfg.Runtime.Analysis.Model != "" {
-			fmt.Fprintf(&builder, "model = %s\n", strconv.Quote(cfg.Runtime.Analysis.Model))
-		}
-		if cfg.Runtime.Analysis.Endpoint != "" {
-			fmt.Fprintf(&builder, "endpoint = %s\n", strconv.Quote(cfg.Runtime.Analysis.Endpoint))
-		}
-		if cfg.Runtime.Analysis.APIKeyEnv != "" {
-			fmt.Fprintf(&builder, "api_key_env = %s\n", strconv.Quote(cfg.Runtime.Analysis.APIKeyEnv))
-		}
-		fmt.Fprintf(&builder, "timeout_ms = %d\n", cfg.Runtime.Analysis.TimeoutMS)
-		fmt.Fprintf(&builder, "max_retries = %d\n", cfg.Runtime.Analysis.MaxRetries)
+		writeRuntimeProviderConfig(&builder, cfg.Runtime.Analysis, runtimeProfileBase(cfg.Runtime.Profiles, cfg.Runtime.Analysis.Profile))
 	}
 
 	for _, source := range cfg.Sources {
@@ -79,6 +71,42 @@ func Render(cfg *Config) (string, error) {
 	}
 
 	return builder.String(), nil
+}
+
+func runtimeProfileBase(profiles map[string]RuntimeProvider, name string) *RuntimeProvider {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	profile, ok := profiles[name]
+	if !ok {
+		return nil
+	}
+	return &profile
+}
+
+func writeRuntimeProviderConfig(builder *strings.Builder, provider RuntimeProvider, base *RuntimeProvider) {
+	if profile := strings.TrimSpace(provider.Profile); profile != "" {
+		fmt.Fprintf(builder, "profile = %s\n", strconv.Quote(profile))
+	}
+	if base == nil || provider.Provider != base.Provider {
+		fmt.Fprintf(builder, "provider = %s\n", strconv.Quote(provider.Provider))
+	}
+	if provider.Model != "" && (base == nil || provider.Model != base.Model) {
+		fmt.Fprintf(builder, "model = %s\n", strconv.Quote(provider.Model))
+	}
+	if provider.Endpoint != "" && (base == nil || provider.Endpoint != base.Endpoint) {
+		fmt.Fprintf(builder, "endpoint = %s\n", strconv.Quote(provider.Endpoint))
+	}
+	if provider.APIKeyEnv != "" && (base == nil || provider.APIKeyEnv != base.APIKeyEnv) {
+		fmt.Fprintf(builder, "api_key_env = %s\n", strconv.Quote(provider.APIKeyEnv))
+	}
+	if base == nil || provider.TimeoutMS != base.TimeoutMS {
+		fmt.Fprintf(builder, "timeout_ms = %d\n", provider.TimeoutMS)
+	}
+	if base == nil || provider.MaxRetries != base.MaxRetries {
+		fmt.Fprintf(builder, "max_retries = %d\n", provider.MaxRetries)
+	}
 }
 
 func writeQuotedArray(builder *strings.Builder, key string, values []string) {

--- a/internal/runtimeprobe/probe.go
+++ b/internal/runtimeprobe/probe.go
@@ -29,9 +29,12 @@ type Result struct {
 
 type Check struct {
 	Name     string `json:"name"`
+	Profile  string `json:"profile,omitempty"`
 	Provider string `json:"provider"`
 	Model    string `json:"model,omitempty"`
 	Endpoint string `json:"endpoint,omitempty"`
+	Timeout  int    `json:"timeout_ms,omitempty"`
+	Retries  int    `json:"max_retries,omitempty"`
 	Status   string `json:"status"`
 	Message  string `json:"message,omitempty"`
 }
@@ -109,8 +112,11 @@ func probeAnalysis(ctx context.Context, provider config.RuntimeProvider) (Check,
 func configuredCheck(name string, provider config.RuntimeProvider) Check {
 	return Check{
 		Name:     name,
+		Profile:  strings.TrimSpace(provider.Profile),
 		Provider: strings.TrimSpace(provider.Provider),
 		Model:    strings.TrimSpace(provider.Model),
 		Endpoint: strings.TrimSpace(provider.Endpoint),
+		Timeout:  provider.TimeoutMS,
+		Retries:  provider.MaxRetries,
 	}
 }

--- a/internal/runtimeprobe/probe_test.go
+++ b/internal/runtimeprobe/probe_test.go
@@ -80,6 +80,7 @@ func TestRunAnalysisUsesLightweightProbe(t *testing.T) {
 	result, err := Run(context.Background(), &config.Config{
 		Runtime: config.Runtime{
 			Analysis: config.RuntimeProvider{
+				Profile:    "local-lm-studio",
 				Provider:   config.RuntimeProviderOpenAI,
 				Model:      "pituitary-analysis",
 				Endpoint:   server.URL,
@@ -96,6 +97,12 @@ func TestRunAnalysisUsesLightweightProbe(t *testing.T) {
 	}
 	if got, want := result.Checks[0].Status, StatusReady; got != want {
 		t.Fatalf("checks[0].status = %q, want %q", got, want)
+	}
+	if got, want := result.Checks[0].Profile, "local-lm-studio"; got != want {
+		t.Fatalf("checks[0].profile = %q, want %q", got, want)
+	}
+	if got, want := result.Checks[0].Timeout, 1000; got != want {
+		t.Fatalf("checks[0].timeout_ms = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add reusable `[runtime.profiles.<name>]` config blocks and let `runtime.embedder` / `runtime.analysis` select them with per-command overrides
- surface the resolved runtime profile, provider, model, endpoint, timeout, and retry settings in `pituitary status` and runtime probe output
- document the profile-based runtime workflow across the README, runtime/config docs, cheatsheet, and architecture notes

## Testing
- go test ./internal/config ./internal/runtimeprobe ./internal/app ./cmd
- make ci

Closes #210