### PR TITLE
feat: add pituitary compile command

### DIFF
--- a/cmd/compile.go
+++ b/cmd/compile.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/app"
+)
+
+type compileCLIRequest struct {
+	Scope  string `json:"scope,omitempty"`
+	DryRun bool   `json:"dry_run,omitempty"`
+	Yes    bool   `json:"yes,omitempty"`
+}
+
+func runCompile(args []string, stdout, stderr io.Writer) int {
+	return runCompileContext(context.Background(), args, stdout, stderr)
+}
+
+func runCompileContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("compile", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	help := newCommandHelp("compile", "pituitary [--config PATH] compile --scope SCOPE [--dry-run] [--yes] [--format FORMAT]")
+
+	var (
+		scope      string
+		dryRun     bool
+		yes        bool
+		format     string
+		configPath string
+	)
+	fs.StringVar(&scope, "scope", "", "target scope: accepted spec ref or all")
+	fs.BoolVar(&dryRun, "dry-run", false, "plan deterministic edits without writing files")
+	fs.BoolVar(&yes, "yes", false, "apply all planned edits without prompting")
+	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
+	fs.StringVar(&configPath, "config", "", "path to workspace config")
+
+	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
+		return writeCLIError(stdout, stderr, format, "compile", nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	} else if handled {
+		return 0
+	}
+	if fs.NArg() != 0 {
+		return writeCLIError(stdout, stderr, format, "compile", nil, cliIssue{
+			Code:    "validation_error",
+			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
+		}, 2)
+	}
+
+	request := compileCLIRequest{
+		Scope:  strings.TrimSpace(scope),
+		DryRun: dryRun,
+		Yes:    yes,
+	}
+	if err := validateCLIFormat("compile", format); err != nil {
+		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+	if request.Scope == "" {
+		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
+			Code:    "validation_error",
+			Message: "--scope is required",
+		}, 2)
+	}
+
+	if format != commandFormatText && !request.DryRun && !request.Yes {
+		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
+			Code:    "validation_error",
+			Message: "non-text compile runs require either --dry-run or --yes",
+		}, 2)
+	}
+
+	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	apply := request.Yes && !request.DryRun
+
+	// In text mode without --dry-run or --yes, default to dry-run behavior with a hint.
+	if format == commandFormatText && !request.DryRun && !request.Yes {
+		apply = false
+	}
+
+	response := app.CompileTerminology(ctx, resolvedConfigPath, app.CompileRequest{
+		Scope: request.Scope,
+		Apply: apply,
+	})
+	if response.Issue != nil {
+		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
+			Code:    response.Issue.Code,
+			Message: response.Issue.Message,
+		}, response.Issue.ExitCode)
+	}
+
+	if format == commandFormatText && !request.DryRun && !request.Yes && response.Result != nil {
+		response.Result.Guidance = append(response.Result.Guidance, "Showing planned edits (dry-run). Re-run with --yes to apply.")
+	}
+
+	return writeCLISuccess(stdout, stderr, format, "compile", request, response.Result, nil)
+}

--- a/cmd/compile_test.go
+++ b/cmd/compile_test.go
@@ -1,0 +1,253 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCompileDryRunJSONPlansEdits(t *testing.T) {
+	repo := writeCompileWorkspaceCmd(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runCompile([]string{"--scope", "all", "--dry-run", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCompile() exit code = %d, want 0\nstdout: %s\nstderr: %s", exitCode, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCompile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request struct {
+			Scope  string `json:"scope"`
+			DryRun bool   `json:"dry_run"`
+		} `json:"request"`
+		Result struct {
+			Scope            string `json:"scope"`
+			Applied          bool   `json:"applied"`
+			PlannedFileCount int    `json:"planned_file_count"`
+			PlannedEditCount int    `json:"planned_edit_count"`
+			Files            []struct {
+				Ref    string `json:"ref"`
+				Path   string `json:"path"`
+				Status string `json:"status"`
+				Edits  []struct {
+					Code   string `json:"code"`
+					Action string `json:"action"`
+					Before string `json:"before"`
+					After  string `json:"after"`
+				} `json:"edits"`
+				Reason string `json:"reason"`
+			} `json:"files"`
+			Guidance []string `json:"guidance"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\nraw: %s", err, stdout.String())
+	}
+	if payload.Request.Scope != "all" || !payload.Request.DryRun {
+		t.Fatalf("request = %+v, want scope=all and dry_run=true", payload.Request)
+	}
+	if payload.Result.Applied {
+		t.Fatalf("result.applied = true, want false")
+	}
+	if payload.Result.PlannedEditCount < 1 {
+		t.Fatalf("result.planned_edit_count = %d, want at least 1", payload.Result.PlannedEditCount)
+	}
+
+	// Verify we have at least one file with planned edits.
+	var foundPlanned bool
+	for _, file := range payload.Result.Files {
+		if file.Status == "planned" && len(file.Edits) > 0 {
+			foundPlanned = true
+			for _, edit := range file.Edits {
+				if edit.Action != "replace_term" {
+					t.Fatalf("edit.action = %q, want replace_term", edit.Action)
+				}
+			}
+		}
+	}
+	if !foundPlanned {
+		t.Fatalf("result.files = %+v, want at least one planned file with edits", payload.Result.Files)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
+func TestRunCompileYesAppliesEdits(t *testing.T) {
+	repo := writeCompileWorkspaceCmd(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runCompile([]string{"--scope", "all", "--yes", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCompile() exit code = %d, want 0\nstdout: %s\nstderr: %s", exitCode, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCompile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Applied          bool `json:"applied"`
+			AppliedFileCount int  `json:"applied_file_count"`
+			AppliedEditCount int  `json:"applied_edit_count"`
+			Files            []struct {
+				Path   string `json:"path"`
+				Status string `json:"status"`
+				Edits  []struct {
+					Before string `json:"before"`
+					After  string `json:"after"`
+				} `json:"edits"`
+			} `json:"files"`
+			Guidance []string `json:"guidance"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\nraw: %s", err, stdout.String())
+	}
+	if !payload.Result.Applied {
+		t.Fatalf("result.applied = false, want true")
+	}
+	if payload.Result.AppliedEditCount < 1 {
+		t.Fatalf("result.applied_edit_count = %d, want at least 1", payload.Result.AppliedEditCount)
+	}
+
+	// Verify at least one file was applied.
+	var foundApplied bool
+	for _, file := range payload.Result.Files {
+		if file.Status == "applied" {
+			foundApplied = true
+		}
+	}
+	if !foundApplied {
+		t.Fatalf("result.files = %+v, want at least one applied file", payload.Result.Files)
+	}
+
+	// Verify the doc file was actually changed on disk.
+	kernelDoc, err := os.ReadFile(filepath.Join(repo, "docs", "guides", "repo-kernel.md"))
+	if err != nil {
+		t.Fatalf("read updated doc: %v", err)
+	}
+	content := string(kernelDoc)
+	// The terminology policy says "repo" -> "locality", so the doc should contain "locality" now.
+	if !strings.Contains(content, "locality") {
+		t.Fatalf("updated doc %q does not contain expected replacement term 'locality'", content)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
+func TestRunCompileRequiresScopeFlag(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runCompile([]string{"--dry-run", "--format", "json"}, &stdout, &stderr)
+	if exitCode != 2 {
+		t.Fatalf("runCompile() exit code = %d, want 2", exitCode)
+	}
+
+	var payload struct {
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\nraw: %s", err, stdout.String())
+	}
+	if len(payload.Errors) == 0 {
+		t.Fatal("errors is empty, want scope validation error")
+	}
+	if !strings.Contains(payload.Errors[0].Message, "--scope") {
+		t.Fatalf("error message = %q, want --scope required", payload.Errors[0].Message)
+	}
+}
+
+func writeCompileWorkspaceCmd(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	mustWriteFileCmd(t, root+"/specs/kernel-locality/spec.toml", `
+id = "SPEC-LOCALITY"
+title = "Kernel Locality Contract"
+status = "accepted"
+domain = "kernel"
+body = "body.md"
+`)
+	mustWriteFileCmd(t, root+"/specs/kernel-locality/body.md", `
+# Kernel Locality Contract
+
+## Core Model
+
+The kernel keeps continuity in clone-local state.
+The runtime is locality-centric and treats repository adapters as optional extensions.
+`)
+	mustWriteFileCmd(t, root+"/docs/guides/repo-kernel.md", `
+# Repo Kernel Guide
+
+The kernel keeps workflow continuity in each repo.
+Repository storage is the default operator model.
+`)
+	mustWriteFileCmd(t, root+"/docs/guides/repo-compatibility.md", `
+# Repo Compatibility Notes
+
+Legacy repo references remain available only as a compatibility alias during migration to locality.
+`)
+	mustWriteIndexFixture(t, root, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[terminology.policies]]
+preferred = "locality"
+historical_aliases = ["repo"]
+forbidden_current = ["repository"]
+docs_severity = "error"
+specs_severity = "warning"
+
+[[terminology.policies]]
+preferred = "continuity"
+deprecated_terms = ["workflow"]
+docs_severity = "error"
+specs_severity = "warning"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+	return root
+}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -60,6 +60,8 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 		renderDocDriftResult(w, typed)
 	case *app.FixResult:
 		renderFixResult(w, typed)
+	case *app.CompileResult:
+		renderCompileResult(w, typed)
 	case *analysis.ReviewResult:
 		renderReviewResult(w, typed)
 	case *schemaCatalogResult:
@@ -75,7 +77,7 @@ func renderCommandResult(w io.Writer, command string, result any) error {
 
 func usesSemanticTextRendering(command string) bool {
 	switch command {
-	case "check-doc-drift", "check-overlap", "review-spec", "check-compliance", "status", "init", "fix":
+	case "check-doc-drift", "check-overlap", "review-spec", "check-compliance", "status", "init", "fix", "compile":
 		return true
 	default:
 		return false
@@ -987,6 +989,55 @@ func renderFixResult(w io.Writer, result *app.FixResult) {
 			fmt.Fprintln(w)
 		}
 		renderFixPromptFile(w, result.Selector, file)
+		if file.Status == "applied" {
+			fmt.Fprintf(w, "    %s applied %d edit%s\n", p.check(), len(file.Edits), pluralSuffix(len(file.Edits)))
+		}
+		if file.Reason != "" {
+			fmt.Fprintf(w, "    %s %s\n", p.arrow(), file.Reason)
+		}
+		for _, warning := range file.Warnings {
+			fmt.Fprintf(w, "    %s %s\n", p.arrow(), warning)
+		}
+	}
+	if len(result.Guidance) > 0 {
+		fmt.Fprintln(w)
+		for _, guidance := range result.Guidance {
+			fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
+		}
+	}
+}
+
+func renderCompileResult(w io.Writer, result *app.CompileResult) {
+	p := presentationForWriter(w)
+	suffix := ""
+	if strings.TrimSpace(result.Scope) != "" {
+		suffix = " " + p.dim(result.Scope)
+	}
+	fmt.Fprintln(w, p.headerLine("compile", suffix))
+	fmt.Fprintln(w)
+
+	if len(result.Files) == 0 {
+		fmt.Fprintf(w, "  %s no actionable terminology edits found\n", p.info())
+		for _, guidance := range result.Guidance {
+			fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
+		}
+		return
+	}
+
+	for i, file := range result.Files {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "  %s\n\n", p.dim(file.Path))
+		if len(file.Edits) == 0 {
+			fmt.Fprintf(w, "    %s %s\n", p.info(), "no unambiguous terminology edits available")
+			continue
+		}
+		for _, edit := range file.Edits {
+			fmt.Fprintf(w, "    %s %s\n", p.red("-"), edit.Before)
+			fmt.Fprintf(w, "    %s %s\n", p.green("+"), edit.After)
+			fmt.Fprintln(w)
+		}
 		if file.Status == "applied" {
 			fmt.Fprintf(w, "    %s applied %d edit%s\n", p.check(), len(file.Edits), pluralSuffix(len(file.Edits)))
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ func commandRegistry() map[string]commandSpec {
 		"check-terminology": {Description: "audit terminology consistency after conceptual changes", Formats: commandFormats(), Run: runCheckTerminologyContext},
 		"check-compliance":  {Description: "check code paths and diffs against accepted specs", Formats: commandFormats(), Run: runCheckComplianceContext},
 		"check-doc-drift":   {Description: "find docs that drift from specs", Formats: commandFormats(), Run: runCheckDocDriftContext},
+		"compile":           {Description: "apply terminology edits to align docs with governed terms", Formats: commandFormats(), Run: runCompileContext},
 		"fix":               {Description: "apply deterministic doc-drift remediations", Formats: commandFormats(), Run: runFixContext},
 		"review-spec":       {Description: "run the common spec-review workflow", Formats: commandFormats(commandFormatMarkdown, commandFormatHTML), Run: runReviewSpecContext},
 		"schema":            {Description: "describe machine-readable command contracts", Formats: commandFormats(), Run: runSchemaContext},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -32,10 +32,13 @@ func TestRunKnownCommandsStayCallable(t *testing.T) {
 				return
 			}
 
-			if name == "canonicalize" || name == "discover" || name == "init" || name == "new" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "fix" || name == "review-spec" || name == "schema" {
+			if name == "canonicalize" || name == "discover" || name == "init" || name == "new" || name == "migrate-config" || name == "index" || name == "status" || name == "version" || name == "preview-sources" || name == "explain-file" || name == "search-specs" || name == "check-overlap" || name == "compare-specs" || name == "analyze-impact" || name == "check-terminology" || name == "check-compliance" || name == "check-doc-drift" || name == "fix" || name == "compile" || name == "review-spec" || name == "schema" {
 				repoRoot := writeSearchWorkspace(t)
 				if name == "discover" || name == "init" || name == "canonicalize" {
 					repoRoot = writeDiscoveryWorkspace(t)
+				}
+				if name == "compile" {
+					repoRoot = writeCompileWorkspaceCmd(t)
 				}
 				if name == "canonicalize" {
 					args = []string{name, "--path", "rfcs/service-sla.md"}
@@ -133,6 +136,8 @@ func buildLimiter() {}
 						args = []string{name, "--path", "src/api/middleware/ratelimiter.go"}
 					} else if name == "fix" {
 						args = []string{name, "--path", "docs/guides/api-rate-limits.md", "--dry-run"}
+					} else if name == "compile" {
+						args = []string{name, "--scope", "all", "--dry-run"}
 					} else if name == "review-spec" {
 						args = []string{name, "--spec-ref", "SPEC-042"}
 					} else {

--- a/internal/app/compile.go
+++ b/internal/app/compile.go
@@ -177,6 +177,8 @@ func buildCompileFileResult(cfg *config.Config, finding analysis.TerminologyFind
 }
 
 func planCompileEdits(body string, finding analysis.TerminologyFinding) ([]plannedEdit, []string) {
+	codeRanges := buildCodeRanges(body)
+
 	// editByStart maps a start offset to the best (longest) edit at that position.
 	editByStart := make(map[int]plannedEdit)
 	warnings := make([]string, 0)
@@ -198,6 +200,17 @@ func planCompileEdits(body string, finding analysis.TerminologyFinding) ([]plann
 
 			for _, start := range indices {
 				end := start + len(match.Term)
+
+				// v2: skip matches inside code blocks or inline code spans.
+				if isInsideCodeRange(start, end, codeRanges) {
+					continue
+				}
+
+				// v2: skip matches that are part of a file path or compound identifier.
+				if isPathContext(body, start, end) {
+					continue
+				}
+
 				original := body[start:end]
 				replacement := preserveCase(original, match.Replacement)
 				line := 1 + strings.Count(body[:start], "\n")
@@ -251,6 +264,179 @@ func planCompileEdits(body string, finding analysis.TerminologyFinding) ([]plann
 	}
 
 	return resolved, warnings
+}
+
+// codeRange represents a byte range that is inside a code block or inline code span.
+type codeRange struct {
+	start, end int
+}
+
+// buildCodeRanges identifies all fenced code blocks (``` ... ```) and inline
+// code spans (` ... `) in the markdown body, returning their byte ranges.
+func buildCodeRanges(body string) []codeRange {
+	var ranges []codeRange
+
+	// Fenced code blocks: lines starting with ``` or ~~~
+	i := 0
+	for i < len(body) {
+		// Find start of fenced block.
+		lineStart := i
+		if i > 0 && body[i-1] != '\n' {
+			// Not at line start; advance to next line.
+			nl := strings.IndexByte(body[i:], '\n')
+			if nl < 0 {
+				break
+			}
+			i += nl + 1
+			continue
+		}
+
+		line := body[lineStart:]
+		if nl := strings.IndexByte(line, '\n'); nl >= 0 {
+			line = line[:nl]
+		}
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "```") && !strings.HasPrefix(trimmed, "~~~") {
+			nl := strings.IndexByte(body[i:], '\n')
+			if nl < 0 {
+				break
+			}
+			i += nl + 1
+			continue
+		}
+
+		fence := trimmed[:3]
+		fenceStart := lineStart
+
+		// Advance past opening fence line.
+		nl := strings.IndexByte(body[i:], '\n')
+		if nl < 0 {
+			ranges = append(ranges, codeRange{fenceStart, len(body)})
+			break
+		}
+		i += nl + 1
+
+		// Find closing fence.
+		closed := false
+		for i < len(body) {
+			closeLine := body[i:]
+			if nextNl := strings.IndexByte(closeLine, '\n'); nextNl >= 0 {
+				closeLine = closeLine[:nextNl]
+			}
+			closeEnd := i + len(closeLine)
+			if strings.IndexByte(closeLine, '\n') >= 0 {
+				closeEnd = i + strings.IndexByte(body[i:], '\n') + 1
+			} else {
+				closeEnd = len(body)
+			}
+
+			if strings.TrimSpace(closeLine) == fence {
+				ranges = append(ranges, codeRange{fenceStart, closeEnd})
+				nl2 := strings.IndexByte(body[i:], '\n')
+				if nl2 < 0 {
+					i = len(body)
+				} else {
+					i += nl2 + 1
+				}
+				closed = true
+				break
+			}
+
+			nl2 := strings.IndexByte(body[i:], '\n')
+			if nl2 < 0 {
+				i = len(body)
+				break
+			}
+			i += nl2 + 1
+		}
+		if !closed {
+			ranges = append(ranges, codeRange{fenceStart, len(body)})
+		}
+	}
+
+	// Inline code spans: `...` (not inside fenced blocks).
+	for idx := 0; idx < len(body); idx++ {
+		if body[idx] != '`' {
+			continue
+		}
+		// Skip if inside a fenced block.
+		if isInsideCodeRange(idx, idx+1, ranges) {
+			continue
+		}
+		// Find the closing backtick.
+		closeIdx := strings.IndexByte(body[idx+1:], '`')
+		if closeIdx < 0 {
+			break
+		}
+		closeIdx += idx + 1
+		// Only count single-backtick spans (not fenced).
+		if closeIdx > idx+1 {
+			ranges = append(ranges, codeRange{idx, closeIdx + 1})
+			idx = closeIdx
+		}
+	}
+
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[i].start < ranges[j].start
+	})
+	return ranges
+}
+
+// isInsideCodeRange checks if a byte span [start, end) falls inside any code range.
+func isInsideCodeRange(start, end int, ranges []codeRange) bool {
+	for _, r := range ranges {
+		if start >= r.start && end <= r.end {
+			return true
+		}
+		if r.start > end {
+			break
+		}
+	}
+	return false
+}
+
+// isPathContext checks if a match at [start, end) in body appears to be part
+// of a file path, URL, or compound identifier that should not be rewritten.
+func isPathContext(body string, start, end int) bool {
+	// Check characters immediately before the match.
+	if start > 0 {
+		prev := body[start-1]
+		// Part of a path: /openclaw, ~/.openclaw, .openclaw
+		if prev == '/' || prev == '.' {
+			return true
+		}
+		// Part of a hyphenated compound: openclaw-server, openclaw-bridge
+		if prev == '-' {
+			return true
+		}
+	}
+
+	// Check characters immediately after the match.
+	if end < len(body) {
+		next := body[end]
+		// Part of a path: openclaw/foo
+		if next == '/' {
+			return true
+		}
+		// Part of a file extension: openclaw.json, openclaw.toml
+		// But NOT end-of-sentence punctuation: "...openclaw." or "...openclaw,"
+		if next == '.' && end+1 < len(body) {
+			afterDot := body[end+1]
+			if afterDot != ' ' && afterDot != '\n' && afterDot != '\r' && afterDot != ')' && afterDot != '"' && afterDot != '\'' {
+				return true
+			}
+		}
+		// Part of a hyphenated compound: openclaw-server
+		if next == '-' {
+			return true
+		}
+		// Part of a compound with underscore: openclaw_auth_token
+		if next == '_' {
+			return true
+		}
+	}
+
+	return false
 }
 
 // preserveCase adjusts the replacement to match the casing pattern of the original text.

--- a/internal/app/compile.go
+++ b/internal/app/compile.go
@@ -275,109 +275,52 @@ type codeRange struct {
 // code spans (` ... `) in the markdown body, returning their byte ranges.
 func buildCodeRanges(body string) []codeRange {
 	var ranges []codeRange
+	lines := strings.SplitAfter(body, "\n")
 
-	// Fenced code blocks: lines starting with ``` or ~~~
-	i := 0
-	for i < len(body) {
-		// Find start of fenced block.
-		lineStart := i
-		if i > 0 && body[i-1] != '\n' {
-			// Not at line start; advance to next line.
-			nl := strings.IndexByte(body[i:], '\n')
-			if nl < 0 {
-				break
+	// Pass 1: fenced code blocks.
+	offset := 0
+	inFence := false
+	fenceStart := 0
+	fenceMarker := ""
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(strings.TrimRight(line, "\n\r"))
+		if !inFence {
+			if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+				inFence = true
+				fenceMarker = trimmed[:3]
+				fenceStart = offset
 			}
-			i += nl + 1
-			continue
+		} else if trimmed == fenceMarker {
+			ranges = append(ranges, codeRange{fenceStart, offset + len(line)})
+			inFence = false
 		}
-
-		line := body[lineStart:]
-		if nl := strings.IndexByte(line, '\n'); nl >= 0 {
-			line = line[:nl]
-		}
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "```") && !strings.HasPrefix(trimmed, "~~~") {
-			nl := strings.IndexByte(body[i:], '\n')
-			if nl < 0 {
-				break
-			}
-			i += nl + 1
-			continue
-		}
-
-		fence := trimmed[:3]
-		fenceStart := lineStart
-
-		// Advance past opening fence line.
-		nl := strings.IndexByte(body[i:], '\n')
-		if nl < 0 {
-			ranges = append(ranges, codeRange{fenceStart, len(body)})
-			break
-		}
-		i += nl + 1
-
-		// Find closing fence.
-		closed := false
-		for i < len(body) {
-			closeLine := body[i:]
-			if nextNl := strings.IndexByte(closeLine, '\n'); nextNl >= 0 {
-				closeLine = closeLine[:nextNl]
-			}
-			closeEnd := i + len(closeLine)
-			if strings.IndexByte(closeLine, '\n') >= 0 {
-				closeEnd = i + strings.IndexByte(body[i:], '\n') + 1
-			} else {
-				closeEnd = len(body)
-			}
-
-			if strings.TrimSpace(closeLine) == fence {
-				ranges = append(ranges, codeRange{fenceStart, closeEnd})
-				nl2 := strings.IndexByte(body[i:], '\n')
-				if nl2 < 0 {
-					i = len(body)
-				} else {
-					i += nl2 + 1
-				}
-				closed = true
-				break
-			}
-
-			nl2 := strings.IndexByte(body[i:], '\n')
-			if nl2 < 0 {
-				i = len(body)
-				break
-			}
-			i += nl2 + 1
-		}
-		if !closed {
-			ranges = append(ranges, codeRange{fenceStart, len(body)})
-		}
+		offset += len(line)
+	}
+	if inFence {
+		ranges = append(ranges, codeRange{fenceStart, len(body)})
 	}
 
-	// Inline code spans: `...` (not inside fenced blocks).
+	// Pass 2: inline code spans (not inside fenced blocks).
 	for idx := 0; idx < len(body); idx++ {
 		if body[idx] != '`' {
 			continue
 		}
-		// Skip if inside a fenced block.
 		if isInsideCodeRange(idx, idx+1, ranges) {
 			continue
 		}
-		// Find the closing backtick.
 		closeIdx := strings.IndexByte(body[idx+1:], '`')
 		if closeIdx < 0 {
 			break
 		}
 		closeIdx += idx + 1
-		// Only count single-backtick spans (not fenced).
 		if closeIdx > idx+1 {
 			ranges = append(ranges, codeRange{idx, closeIdx + 1})
 			idx = closeIdx
 		}
 	}
 
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].start < ranges[j].start
+	sort.Slice(ranges, func(a, b int) bool {
+		return ranges[a].start < ranges[b].start
 	})
 	return ranges
 }
@@ -405,8 +348,12 @@ func isPathContext(body string, start, end int) bool {
 		if prev == '/' || prev == '.' {
 			return true
 		}
-		// Part of a hyphenated compound: openclaw-server, openclaw-bridge
+		// Part of a hyphenated compound: openclaw-server, my-openclaw
 		if prev == '-' {
+			return true
+		}
+		// Part of an underscored compound: openclaw_auth, env_openclaw
+		if prev == '_' {
 			return true
 		}
 	}

--- a/internal/app/compile.go
+++ b/internal/app/compile.go
@@ -356,6 +356,10 @@ func isPathContext(body string, start, end int) bool {
 		if prev == '_' {
 			return true
 		}
+		// Part of a scoped name: @openclaw (npm scopes, git refs)
+		if prev == '@' {
+			return true
+		}
 	}
 
 	// Check characters immediately after the match.

--- a/internal/app/compile.go
+++ b/internal/app/compile.go
@@ -1,0 +1,301 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/dusk-network/pituitary/internal/analysis"
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+// CompileRequest is the normalized input for terminology compilation.
+type CompileRequest struct {
+	Scope string `json:"scope,omitempty"`
+	Apply bool   `json:"apply,omitempty"`
+}
+
+// CompileFileResult is the per-file result of a compile-terminology operation.
+type CompileFileResult struct {
+	Ref              string    `json:"ref"`
+	SourceRef        string    `json:"source_ref,omitempty"`
+	Path             string    `json:"path"`
+	Status           string    `json:"status"`
+	Reason           string    `json:"reason,omitempty"`
+	Warnings         []string  `json:"warnings,omitempty"`
+	Edits            []FixEdit `json:"edits,omitempty"`
+	originalContent  string
+	originalChecksum string
+}
+
+// CompileResult is the structured result of a compile-terminology operation.
+type CompileResult struct {
+	Scope            string              `json:"scope"`
+	Applied          bool                `json:"applied"`
+	Files            []CompileFileResult `json:"files"`
+	PlannedFileCount int                 `json:"planned_file_count"`
+	PlannedEditCount int                 `json:"planned_edit_count"`
+	AppliedFileCount int                 `json:"applied_file_count,omitempty"`
+	AppliedEditCount int                 `json:"applied_edit_count,omitempty"`
+	SkippedCount     int                 `json:"skipped_count,omitempty"`
+	Guidance         []string            `json:"guidance,omitempty"`
+}
+
+func runCompileTerminology(ctx context.Context, cfg *config.Config, request CompileRequest) (*CompileResult, error) {
+	scope := strings.TrimSpace(request.Scope)
+	if scope == "" {
+		scope = "all"
+	}
+
+	auditResult, err := analysis.CheckTerminologyContext(ctx, cfg, analysis.TerminologyAuditRequest{
+		Scope: scope,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &CompileResult{
+		Scope:   scope,
+		Applied: request.Apply,
+		Files:   make([]CompileFileResult, 0),
+	}
+
+	for _, finding := range auditResult.Findings {
+		fileResult, err := buildCompileFileResult(cfg, finding, request.Apply)
+		if err != nil {
+			return nil, err
+		}
+		result.Files = append(result.Files, fileResult)
+	}
+
+	sort.Slice(result.Files, func(i, j int) bool {
+		return result.Files[i].Path < result.Files[j].Path
+	})
+
+	for _, file := range result.Files {
+		switch file.Status {
+		case "planned", "applied":
+			if len(file.Edits) > 0 {
+				result.PlannedFileCount++
+				result.PlannedEditCount += len(file.Edits)
+			}
+			if file.Status == "applied" {
+				result.AppliedFileCount++
+				result.AppliedEditCount += len(file.Edits)
+			}
+		case "skipped":
+			result.SkippedCount++
+		}
+	}
+
+	if request.Apply {
+		result.Guidance = append(result.Guidance, "The workspace index is now stale; run `pituitary index --rebuild` before the next analysis command.")
+	} else if result.PlannedEditCount > 0 {
+		result.Guidance = append(result.Guidance, "Re-run with `--yes` to apply these deterministic edits.")
+	}
+	if len(result.Files) == 0 {
+		result.Guidance = append(result.Guidance, "No terminology compile edits were available for the selected scope.")
+	}
+
+	return result, nil
+}
+
+func buildCompileFileResult(cfg *config.Config, finding analysis.TerminologyFinding, apply bool) (CompileFileResult, error) {
+	path, err := resolveSourceFilePath(cfg.Workspace.RootPath, finding.SourceRef)
+	if err != nil {
+		return CompileFileResult{}, err
+	}
+
+	// #nosec G304 -- path is resolved from a workspace source reference before reading.
+	bodyBytes, err := os.ReadFile(path)
+	if err != nil {
+		return CompileFileResult{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	body := string(bodyBytes)
+
+	edits, warnings := planCompileEdits(body, finding)
+	fileResult := CompileFileResult{
+		Ref:              finding.Ref,
+		SourceRef:        finding.SourceRef,
+		Path:             filepath.ToSlash(path),
+		Status:           "planned",
+		Warnings:         warnings,
+		originalContent:  body,
+		originalChecksum: contentChecksum(body),
+	}
+
+	if len(edits) == 0 {
+		fileResult.Status = "skipped"
+		fileResult.Reason = "No deterministic terminology edits could be planned for this file."
+		return fileResult, nil
+	}
+
+	fileResult.Edits = make([]FixEdit, 0, len(edits))
+	for _, edit := range edits {
+		fileResult.Edits = append(fileResult.Edits, FixEdit{
+			Code:      "terminology_compile",
+			Summary:   fmt.Sprintf("Replace %q with %q", edit.Replace, edit.With),
+			Action:    "replace_term",
+			Replace:   edit.Replace,
+			With:      edit.With,
+			Line:      edit.Line,
+			StartByte: edit.StartByte,
+			EndByte:   edit.EndByte,
+			Before:    edit.Replace,
+			After:     edit.With,
+		})
+	}
+
+	if !apply {
+		return fileResult, nil
+	}
+
+	patchEdits := make([]plannedEdit, len(edits))
+	for i, e := range edits {
+		patchEdits[i] = e
+	}
+	if err := applyEdits(path, body, fileResult.originalChecksum, patchEdits); err != nil {
+		fileResult.Status = "skipped"
+		fileResult.Reason = err.Error()
+		return fileResult, nil
+	}
+	fileResult.Status = "applied"
+	return fileResult, nil
+}
+
+func planCompileEdits(body string, finding analysis.TerminologyFinding) ([]plannedEdit, []string) {
+	// editByStart maps a start offset to the best (longest) edit at that position.
+	editByStart := make(map[int]plannedEdit)
+	warnings := make([]string, 0)
+
+	for _, section := range finding.Sections {
+		for _, match := range section.Matches {
+			if match.Tolerated {
+				continue
+			}
+			if strings.TrimSpace(match.Replacement) == "" {
+				continue
+			}
+
+			indices := allMatchIndicesFold(body, match.Term)
+			if len(indices) == 0 {
+				warnings = append(warnings, fmt.Sprintf("Term %q no longer found in %s.", match.Term, finding.Ref))
+				continue
+			}
+
+			for _, start := range indices {
+				end := start + len(match.Term)
+				original := body[start:end]
+				replacement := preserveCase(original, match.Replacement)
+				line := 1 + strings.Count(body[:start], "\n")
+
+				candidate := plannedEdit{
+					Replace:   original,
+					With:      replacement,
+					Line:      line,
+					StartByte: start,
+					EndByte:   end,
+					start:     start,
+					end:       end,
+				}
+
+				if existing, ok := editByStart[start]; ok {
+					// Keep the longer (more specific) match at this offset.
+					if candidate.end > existing.end {
+						editByStart[start] = candidate
+					}
+					continue
+				}
+				editByStart[start] = candidate
+			}
+		}
+	}
+
+	edits := make([]plannedEdit, 0, len(editByStart))
+	for _, edit := range editByStart {
+		edits = append(edits, edit)
+	}
+
+	sort.Slice(edits, func(i, j int) bool {
+		return edits[i].start < edits[j].start
+	})
+
+	// Resolve overlaps: when a shorter match is fully contained in a longer
+	// one that starts at an earlier offset, keep only the longer match.
+	resolved := make([]plannedEdit, 0, len(edits))
+	for _, edit := range edits {
+		if len(resolved) > 0 && edit.start < resolved[len(resolved)-1].end {
+			prev := &resolved[len(resolved)-1]
+			// If the previous edit fully contains this one, skip the shorter.
+			if edit.end <= prev.end {
+				continue
+			}
+			// If this edit extends beyond the previous one, it's a genuine
+			// ambiguous overlap — bail out for safety.
+			return nil, []string{"Skipping file because planned terminology edits overlap."}
+		}
+		resolved = append(resolved, edit)
+	}
+
+	return resolved, warnings
+}
+
+// preserveCase adjusts the replacement to match the casing pattern of the original text.
+// If the original is ALL CAPS, the replacement is uppercased.
+// If the original is Title Case (first letter upper, rest lower), the replacement is title-cased.
+// Otherwise the replacement is returned as-is.
+func preserveCase(original, replacement string) string {
+	if original == "" || replacement == "" {
+		return replacement
+	}
+
+	if isAllUpper(original) {
+		return strings.ToUpper(replacement)
+	}
+
+	runes := []rune(original)
+	if unicode.IsUpper(runes[0]) && isRestLower(original) {
+		return titleCase(replacement)
+	}
+
+	return replacement
+}
+
+func isAllUpper(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) && !unicode.IsUpper(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isRestLower(s string) bool {
+	first := true
+	for _, r := range s {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		if first {
+			first = false
+			continue
+		}
+		if unicode.IsUpper(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
+}

--- a/internal/app/compile.go
+++ b/internal/app/compile.go
@@ -113,6 +113,15 @@ func buildCompileFileResult(cfg *config.Config, finding analysis.TerminologyFind
 	// #nosec G304 -- path is resolved from a workspace source reference before reading.
 	bodyBytes, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return CompileFileResult{
+				Ref:       finding.Ref,
+				SourceRef: finding.SourceRef,
+				Path:      filepath.ToSlash(path),
+				Status:    "skipped",
+				Reason:    "source file no longer exists",
+			}, nil
+		}
 		return CompileFileResult{}, fmt.Errorf("read %s: %w", path, err)
 	}
 	body := string(bodyBytes)

--- a/internal/app/compile_test.go
+++ b/internal/app/compile_test.go
@@ -166,6 +166,7 @@ body = "body.md"
 The kernel keeps continuity in clone-local state.
 `)
 	// Doc with term in prose, code block, inline code, and path context.
+	// Crucially: prose AFTER a code block must still be replaced.
 	mustWriteCompileFile(t, filepath.Join(repo, "docs", "guides", "mixed-contexts.md"), strings.Join([]string{
 		"# Mixed Contexts",
 		"",
@@ -180,6 +181,8 @@ The kernel keeps continuity in clone-local state.
 		"Check /opt/repo/bin for binaries.",
 		"",
 		"Also see repo-server for details.",
+		"",
+		"The repo after the code block should also change.",
 	}, "\n"))
 
 	configContent := strings.TrimSpace(`
@@ -269,6 +272,14 @@ include = ["guides/*.md"]
 	// Hyphenated compound should be unchanged.
 	if !strings.Contains(body, "repo-server") {
 		t.Error("hyphenated compound should not be modified")
+	}
+
+	// Prose AFTER a code block should be replaced (regression for fence-close bug).
+	if strings.Contains(body, "The repo after the code block") {
+		t.Error("prose after code block should be modified")
+	}
+	if !strings.Contains(body, "The locality after the code block") {
+		t.Error("expected 'locality' in prose after code block")
 	}
 }
 

--- a/internal/app/compile_test.go
+++ b/internal/app/compile_test.go
@@ -147,6 +147,131 @@ func TestCompileTerminologySkipsTolerated(t *testing.T) {
 	}
 }
 
+func TestCompileTerminologySkipsCodeBlocksAndPaths(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteCompileFile(t, filepath.Join(repo, "specs", "kernel-locality", "spec.toml"), `
+id = "SPEC-LOCALITY"
+title = "Kernel Locality Contract"
+status = "accepted"
+domain = "kernel"
+body = "body.md"
+`)
+	mustWriteCompileFile(t, filepath.Join(repo, "specs", "kernel-locality", "body.md"), `
+# Kernel Locality Contract
+
+## Core Model
+
+The kernel keeps continuity in clone-local state.
+`)
+	// Doc with term in prose, code block, inline code, and path context.
+	mustWriteCompileFile(t, filepath.Join(repo, "docs", "guides", "mixed-contexts.md"), strings.Join([]string{
+		"# Mixed Contexts",
+		"",
+		"The repo is the main workspace.",
+		"",
+		"```",
+		"cd ~/devel/repo/src",
+		"```",
+		"",
+		"See `repo.json` for config.",
+		"",
+		"Check /opt/repo/bin for binaries.",
+		"",
+		"Also see repo-server for details.",
+	}, "\n"))
+
+	configContent := strings.TrimSpace(`
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[terminology.policies]]
+preferred = "locality"
+historical_aliases = ["repo"]
+docs_severity = "error"
+specs_severity = "warning"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`) + "\n"
+
+	configPath := filepath.Join(repo, "pituitary.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig: %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild: %v", err)
+	}
+
+	operation := CompileTerminology(context.Background(), configPath, CompileRequest{
+		Scope: "all",
+		Apply: true,
+	})
+	if operation.Issue != nil {
+		t.Fatalf("CompileTerminology() issue = %+v", operation.Issue)
+	}
+
+	content, err := os.ReadFile(filepath.Join(repo, "docs", "guides", "mixed-contexts.md"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	body := string(content)
+
+	// Prose "repo" should be replaced.
+	if strings.Contains(body, "The repo is") {
+		t.Error("prose 'repo' should have been replaced")
+	}
+	if !strings.Contains(body, "The locality is") {
+		t.Error("expected 'locality' in prose position")
+	}
+
+	// Code block content should be unchanged.
+	if !strings.Contains(body, "cd ~/devel/repo/src") {
+		t.Error("code block content should not be modified")
+	}
+
+	// Inline code should be unchanged.
+	if !strings.Contains(body, "`repo.json`") {
+		t.Error("inline code should not be modified")
+	}
+
+	// Path context should be unchanged.
+	if !strings.Contains(body, "/opt/repo/bin") {
+		t.Error("path context should not be modified")
+	}
+
+	// Hyphenated compound should be unchanged.
+	if !strings.Contains(body, "repo-server") {
+		t.Error("hyphenated compound should not be modified")
+	}
+}
+
 func TestPreserveCase(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/compile_test.go
+++ b/internal/app/compile_test.go
@@ -1,0 +1,273 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+func TestCompileTerminologyPlansEdits(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeCompileTerminologyWorkspace(t)
+	operation := CompileTerminology(context.Background(), configPath, CompileRequest{
+		Scope: "docs",
+	})
+	if operation.Issue != nil {
+		t.Fatalf("CompileTerminology() issue = %+v, want nil", operation.Issue)
+	}
+	if operation.Result == nil {
+		t.Fatal("CompileTerminology() result = nil, want structured result")
+	}
+	if operation.Result.Applied {
+		t.Fatal("CompileTerminology() result.applied = true, want false")
+	}
+	if operation.Result.PlannedFileCount < 1 {
+		t.Fatalf("planned_file_count = %d, want at least 1", operation.Result.PlannedFileCount)
+	}
+	if operation.Result.PlannedEditCount < 1 {
+		t.Fatalf("planned_edit_count = %d, want at least 1", operation.Result.PlannedEditCount)
+	}
+
+	// Verify that the source file is unchanged (dry-run).
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	kernelPath := filepath.Join(cfg.Workspace.RootPath, "docs", "guides", "repo-kernel.md")
+	content, err := os.ReadFile(kernelPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(content), "repo") {
+		t.Fatal("dry-run should NOT have modified the file")
+	}
+
+	// Verify edits are structured correctly.
+	var foundEdits bool
+	for _, file := range operation.Result.Files {
+		for _, edit := range file.Edits {
+			foundEdits = true
+			if edit.Code != "terminology_compile" {
+				t.Fatalf("edit.code = %q, want terminology_compile", edit.Code)
+			}
+			if edit.Action != "replace_term" {
+				t.Fatalf("edit.action = %q, want replace_term", edit.Action)
+			}
+			if edit.Replace == "" || edit.With == "" {
+				t.Fatalf("edit replace=%q with=%q, want non-empty", edit.Replace, edit.With)
+			}
+		}
+	}
+	if !foundEdits {
+		t.Fatal("expected at least one edit in the result files")
+	}
+
+	if len(operation.Result.Guidance) == 0 || !strings.Contains(operation.Result.Guidance[0], "--yes") {
+		t.Fatalf("guidance = %v, want apply guidance", operation.Result.Guidance)
+	}
+}
+
+func TestCompileTerminologyAppliesEdits(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeCompileTerminologyWorkspace(t)
+	operation := CompileTerminology(context.Background(), configPath, CompileRequest{
+		Scope: "docs",
+		Apply: true,
+	})
+	if operation.Issue != nil {
+		t.Fatalf("CompileTerminology() issue = %+v, want nil", operation.Issue)
+	}
+	if operation.Result == nil {
+		t.Fatal("CompileTerminology() result = nil, want structured result")
+	}
+	if !operation.Result.Applied {
+		t.Fatal("CompileTerminology() result.applied = false, want true")
+	}
+	if operation.Result.AppliedFileCount < 1 {
+		t.Fatalf("applied_file_count = %d, want at least 1", operation.Result.AppliedFileCount)
+	}
+	if operation.Result.AppliedEditCount < 1 {
+		t.Fatalf("applied_edit_count = %d, want at least 1", operation.Result.AppliedEditCount)
+	}
+	if len(operation.Result.Guidance) == 0 || !strings.Contains(operation.Result.Guidance[0], "pituitary index --rebuild") {
+		t.Fatalf("guidance = %v, want rebuild guidance", operation.Result.Guidance)
+	}
+
+	// Verify the file was actually changed.
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	kernelPath := filepath.Join(cfg.Workspace.RootPath, "docs", "guides", "repo-kernel.md")
+	content, err := os.ReadFile(kernelPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	updated := string(content)
+
+	// The displaced term "repo" should be replaced by "locality".
+	if strings.Contains(updated, "each repo") {
+		t.Fatal("expected displaced term 'repo' to be replaced in the file")
+	}
+	// The preferred term should be present.
+	if !strings.Contains(updated, "locality") {
+		t.Fatal("expected preferred term 'locality' to appear in the file")
+	}
+}
+
+func TestCompileTerminologySkipsTolerated(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeCompileTerminologyWorkspace(t)
+	operation := CompileTerminology(context.Background(), configPath, CompileRequest{
+		Scope: "docs",
+	})
+	if operation.Issue != nil {
+		t.Fatalf("CompileTerminology() issue = %+v, want nil", operation.Issue)
+	}
+	if operation.Result == nil {
+		t.Fatal("CompileTerminology() result = nil, want structured result")
+	}
+
+	// The compatibility doc should NOT appear in findings (tolerated findings
+	// are separated into the tolerated slice by CheckTerminology, so they
+	// never reach the compile pipeline).
+	for _, file := range operation.Result.Files {
+		if strings.Contains(file.Ref, "repo-compatibility") {
+			t.Fatalf("tolerated doc %q should not produce compile edits", file.Ref)
+		}
+	}
+}
+
+func TestPreserveCase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		original    string
+		replacement string
+		want        string
+	}{
+		{"Repo", "locality", "Locality"},
+		{"REPO", "locality", "LOCALITY"},
+		{"repo", "locality", "locality"},
+		{"Workflow", "continuity", "Continuity"},
+		{"WORKFLOW", "continuity", "CONTINUITY"},
+		{"workflow", "continuity", "continuity"},
+		{"", "locality", "locality"},
+		{"Repo", "", ""},
+	}
+
+	for _, tc := range tests {
+		got := preserveCase(tc.original, tc.replacement)
+		if got != tc.want {
+			t.Errorf("preserveCase(%q, %q) = %q, want %q", tc.original, tc.replacement, got, tc.want)
+		}
+	}
+}
+
+func writeCompileTerminologyWorkspace(t *testing.T) string {
+	t.Helper()
+
+	repo := t.TempDir()
+	mustWriteCompileFile(t, filepath.Join(repo, "specs", "kernel-locality", "spec.toml"), `
+id = "SPEC-LOCALITY"
+title = "Kernel Locality Contract"
+status = "accepted"
+domain = "kernel"
+body = "body.md"
+`)
+	mustWriteCompileFile(t, filepath.Join(repo, "specs", "kernel-locality", "body.md"), `
+# Kernel Locality Contract
+
+## Core Model
+
+The kernel keeps continuity in clone-local state.
+The runtime is locality-centric and treats repository adapters as optional extensions.
+`)
+	mustWriteCompileFile(t, filepath.Join(repo, "docs", "guides", "repo-kernel.md"), `
+# Repo Kernel Guide
+
+The kernel keeps workflow continuity in each repo.
+Repository storage is the default operator model.
+`)
+	mustWriteCompileFile(t, filepath.Join(repo, "docs", "guides", "repo-compatibility.md"), `
+# Repo Compatibility Notes
+
+Legacy repo references remain available only as a compatibility alias during migration to locality.
+`)
+
+	configContent := `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[terminology.policies]]
+preferred = "locality"
+historical_aliases = ["repo"]
+forbidden_current = ["repository"]
+docs_severity = "error"
+specs_severity = "warning"
+
+[[terminology.policies]]
+preferred = "continuity"
+deprecated_terms = ["workflow"]
+docs_severity = "error"
+specs_severity = "warning"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`
+
+	configPath := filepath.Join(repo, "pituitary.toml")
+	if err := os.WriteFile(configPath, []byte(strings.TrimSpace(configContent)+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	return configPath
+}
+
+func mustWriteCompileFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/app/fix.go
+++ b/internal/app/fix.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -314,14 +312,6 @@ func buildFixFileResult(cfg *config.Config, record model.DocRecord, remediation 
 	return fileResult, nil
 }
 
-func resolveSourceFilePath(workspaceRoot, sourceRef string) (string, error) {
-	relative := strings.TrimSpace(strings.TrimPrefix(sourceRef, "file://"))
-	if relative == "" {
-		return "", fmt.Errorf("source_ref is empty")
-	}
-	return filepath.Join(workspaceRoot, filepath.FromSlash(relative)), nil
-}
-
 func planFixEdits(body string, remediation analysis.DocRemediationItem, driftItem analysis.DriftItem) ([]plannedFixEdit, []string) {
 	findingsByKey := make(map[string]analysis.DriftFinding, len(driftItem.Findings))
 	for _, finding := range driftItem.Findings {
@@ -477,85 +467,20 @@ func uniqueObservedToken(text, token string) (string, bool) {
 	return matched, ok
 }
 
-func uniqueMatch(text, needle string) (int, int, string, bool) {
-	needle = strings.TrimSpace(needle)
-	if needle == "" {
-		return 0, 0, "", false
-	}
-	indices := allMatchIndicesFold(text, needle)
-	if len(indices) != 1 {
-		return 0, 0, "", false
-	}
-	start := indices[0]
-	end := start + len(needle)
-	return start, end, text[start:end], true
-}
-
-func allMatchIndicesFold(text, needle string) []int {
-	lowerText := strings.ToLower(text)
-	lowerNeedle := strings.ToLower(needle)
-	var result []int
-	offset := 0
-	for {
-		index := strings.Index(lowerText[offset:], lowerNeedle)
-		if index < 0 {
-			break
-		}
-		start := offset + index
-		result = append(result, start)
-		offset = start + len(lowerNeedle)
-	}
-	return result
-}
-
 func applyFixEdits(path, expectedContent, expectedChecksum string, edits []plannedFixEdit) error {
-	// #nosec G304 -- path is the previously planned workspace file being updated in place.
-	currentBytes, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("read %s before apply: %w", path, err)
+	patchEdits := make([]plannedEdit, len(edits))
+	for i, e := range edits {
+		patchEdits[i] = plannedEdit{
+			Replace:   e.Replace,
+			With:      e.With,
+			Line:      e.Line,
+			StartByte: e.StartByte,
+			EndByte:   e.EndByte,
+			start:     e.start,
+			end:       e.end,
+		}
 	}
-	current := string(currentBytes)
-	if contentChecksum(current) != expectedChecksum || current != expectedContent {
-		return fmt.Errorf("%s changed since fix planning; rerun `pituitary fix` against a fresh index", filepath.ToSlash(path))
-	}
-
-	updated := current
-	for i := len(edits) - 1; i >= 0; i-- {
-		edit := edits[i]
-		updated = updated[:edit.start] + edit.With + updated[edit.end:]
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("stat %s before apply: %w", path, err)
-	}
-	tempFile, err := os.CreateTemp(filepath.Dir(path), ".pituitary-fix-*")
-	if err != nil {
-		return fmt.Errorf("create temp file for %s: %w", path, err)
-	}
-	tempPath := tempFile.Name()
-	defer os.Remove(tempPath)
-
-	if _, err := tempFile.WriteString(updated); err != nil {
-		_ = tempFile.Close()
-		return fmt.Errorf("write temp file for %s: %w", path, err)
-	}
-	if err := tempFile.Chmod(info.Mode()); err != nil {
-		_ = tempFile.Close()
-		return fmt.Errorf("chmod temp file for %s: %w", path, err)
-	}
-	if err := tempFile.Close(); err != nil {
-		return fmt.Errorf("close temp file for %s: %w", path, err)
-	}
-	if err := os.Rename(tempPath, path); err != nil {
-		return fmt.Errorf("replace %s: %w", path, err)
-	}
-	return nil
-}
-
-func contentChecksum(body string) string {
-	sum := sha256.Sum256([]byte(body))
-	return hex.EncodeToString(sum[:])
+	return applyEdits(path, expectedContent, expectedChecksum, patchEdits)
 }
 
 func uniqueNonEmptyStrings(values []string) []string {

--- a/internal/app/operations.go
+++ b/internal/app/operations.go
@@ -166,6 +166,15 @@ func CheckTerminology(ctx context.Context, configPath string, request analysis.T
 	})
 }
 
+// CompileTerminology loads config, runs terminology analysis, plans deterministic edits, and optionally applies them.
+func CompileTerminology(ctx context.Context, configPath string, request CompileRequest) Response[CompileRequest, CompileResult] {
+	return executeWithFreshConfig(ctx, configPath, request, operationExecutionPolicy{
+		NotFound: analysis.IsNotFound,
+	}, func(cfg *config.Config) (*CompileResult, error) {
+		return runCompileTerminology(ctx, cfg, request)
+	})
+}
+
 // CheckDocDrift loads config, executes doc drift analysis, and classifies failures.
 func CheckDocDrift(ctx context.Context, configPath string, request analysis.DocDriftRequest) Response[analysis.DocDriftRequest, analysis.DocDriftResult] {
 	return executeWithFreshConfig(ctx, configPath, request, operationExecutionPolicy{

--- a/internal/app/patch.go
+++ b/internal/app/patch.go
@@ -71,7 +71,7 @@ func applyEdits(path, expectedContent, expectedChecksum string, edits []plannedE
 	}
 	current := string(currentBytes)
 	if contentChecksum(current) != expectedChecksum || current != expectedContent {
-		return fmt.Errorf("%s changed since fix planning; rerun `pituitary fix` against a fresh index", filepath.ToSlash(path))
+		return fmt.Errorf("%s changed since edit planning; rerun the command against a fresh index", filepath.ToSlash(path))
 	}
 
 	updated := current

--- a/internal/app/patch.go
+++ b/internal/app/patch.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type plannedEdit struct {
+	Replace   string
+	With      string
+	Line      int
+	StartByte int
+	EndByte   int
+	start     int
+	end       int
+}
+
+func uniqueMatch(text, needle string) (int, int, string, bool) {
+	needle = strings.TrimSpace(needle)
+	if needle == "" {
+		return 0, 0, "", false
+	}
+	indices := allMatchIndicesFold(text, needle)
+	if len(indices) != 1 {
+		return 0, 0, "", false
+	}
+	start := indices[0]
+	end := start + len(needle)
+	return start, end, text[start:end], true
+}
+
+func allMatchIndicesFold(text, needle string) []int {
+	lowerText := strings.ToLower(text)
+	lowerNeedle := strings.ToLower(needle)
+	var result []int
+	offset := 0
+	for {
+		index := strings.Index(lowerText[offset:], lowerNeedle)
+		if index < 0 {
+			break
+		}
+		start := offset + index
+		result = append(result, start)
+		offset = start + len(lowerNeedle)
+	}
+	return result
+}
+
+func contentChecksum(body string) string {
+	sum := sha256.Sum256([]byte(body))
+	return hex.EncodeToString(sum[:])
+}
+
+func resolveSourceFilePath(workspaceRoot, sourceRef string) (string, error) {
+	relative := strings.TrimSpace(strings.TrimPrefix(sourceRef, "file://"))
+	if relative == "" {
+		return "", fmt.Errorf("source_ref is empty")
+	}
+	return filepath.Join(workspaceRoot, filepath.FromSlash(relative)), nil
+}
+
+func applyEdits(path, expectedContent, expectedChecksum string, edits []plannedEdit) error {
+	// #nosec G304 -- path is the previously planned workspace file being updated in place.
+	currentBytes, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s before apply: %w", path, err)
+	}
+	current := string(currentBytes)
+	if contentChecksum(current) != expectedChecksum || current != expectedContent {
+		return fmt.Errorf("%s changed since fix planning; rerun `pituitary fix` against a fresh index", filepath.ToSlash(path))
+	}
+
+	updated := current
+	for i := len(edits) - 1; i >= 0; i-- {
+		edit := edits[i]
+		updated = updated[:edit.start] + edit.With + updated[edit.end:]
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s before apply: %w", path, err)
+	}
+	tempFile, err := os.CreateTemp(filepath.Dir(path), ".pituitary-fix-*")
+	if err != nil {
+		return fmt.Errorf("create temp file for %s: %w", path, err)
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
+
+	if _, err := tempFile.WriteString(updated); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("write temp file for %s: %w", path, err)
+	}
+	if err := tempFile.Chmod(info.Mode()); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("chmod temp file for %s: %w", path, err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close temp file for %s: %w", path, err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes #232.

Adds `pituitary compile`, a new command that reads terminology audit findings and applies deterministic text substitutions to source files — closing the terminology lint-fix loop that previously required manual LLM agent intervention.

```
pituitary compile --scope all --dry-run          # preview edits
pituitary compile --scope all --yes              # apply edits
pituitary compile --scope all --format json      # machine-readable output
```

## What it does

1. Runs `check-terminology` internally to get all findings
2. For each non-tolerated match that has a `Replacement` string, locates every occurrence in the source file
3. Plans byte-level edits with case preservation (Title Case, ALL CAPS, lowercase)
4. Applies edits atomically (temp file + rename) or previews them in dry-run mode
5. Handles overlap resolution when shorter terms are substrings of longer governed terms

## Changes

- **`internal/app/patch.go`** (new) — Shared byte-level patch machinery extracted from `fix.go`: `uniqueMatch`, `allMatchIndicesFold`, `applyEdits`, `contentChecksum`
- **`internal/app/compile.go`** (new) — `CompileTerminology` operation with plan/apply logic
- **`cmd/compile.go`** (new) — CLI entry point with `--scope`, `--dry-run`, `--yes`, `--format`
- **`cmd/render.go`** — Text rendering for compile results
- **`cmd/root.go`** — Command registration
- **`internal/app/fix.go`** — Refactored to delegate to shared patch functions

## First real-world test

Ran against a production workspace (57 indexed artifacts, 775 chunks) with active terminology policies:

```
Scope:          all
Planned files:  13
Planned edits:  217
Skipped:        1 (source file no longer exists — handled gracefully)
```

The command correctly identified all displaced terms, planned case-preserving replacements, and handled a missing file without aborting. This v1 replaces all non-tolerated occurrences; context-aware filtering (skip historical journal entries, skip config filenames unchanged on disk) is tracked for v2.

## Test plan

- [x] `internal/app/compile_test.go` — 4 tests: dry-run plans edits, apply modifies files, tolerated findings skipped, case preservation
- [x] `cmd/compile_test.go` — 3 tests: dry-run JSON output, --yes applies and verifies on-disk changes, missing --scope returns exit 2
- [x] `make ci` passes (fmt, vet, test, race)
- [x] Smoke-tested on live workspace with real terminology policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)