### PR TITLE
feat: add new overlap pre-check and analyze-impact severity classification

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/source"
 )
 
@@ -26,6 +27,7 @@ type newCommandDefaults struct {
 	ConfigPath    string
 	SourceName    string
 	SourceHasFile bool
+	Config        *config.Config
 	Warnings      []source.NewSpecBundleWarning
 }
 
@@ -110,6 +112,11 @@ func runNewContext(ctx context.Context, args []string, stdout, stderr io.Writer)
 	if defaults.ConfigPath != "" {
 		result.ConfigPath = filepath.ToSlash(defaults.ConfigPath)
 	}
+	// Run semantic overlap pre-check if index is available.
+	if defaults.Config != nil {
+		overlapWarnings := checkNewSpecOverlap(ctx, defaults.Config, request.Title)
+		result.Warnings = append(result.Warnings, overlapWarnings...)
+	}
 	result.Warnings = append(result.Warnings, defaults.Warnings...)
 	appendNewConfigWarnings(result, defaults)
 
@@ -151,6 +158,7 @@ func resolveNewCommandDefaults(ctx context.Context) (newCommandDefaults, error) 
 	}
 
 	defaults.WorkspaceRoot = cfg.Workspace.RootPath
+	defaults.Config = cfg
 	defaults.ConfigPath = resolvedConfigPath
 	selectedSource := firstFilesystemSpecSource(cfg)
 	if selectedSource == nil {
@@ -224,4 +232,28 @@ func pathWithinRootNew(root, path string) bool {
 		return false
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func checkNewSpecOverlap(ctx context.Context, cfg *config.Config, title string) []source.NewSpecBundleWarning {
+	searchResult, err := index.SearchSpecsContext(ctx, cfg, index.SearchSpecQuery{
+		Query:    title,
+		Kind:     "spec",
+		Statuses: []string{"draft", "review", "accepted"},
+		Limit:    3,
+	})
+	if err != nil || searchResult == nil {
+		return nil
+	}
+
+	const overlapThreshold = 0.50
+	var warnings []source.NewSpecBundleWarning
+	for _, match := range searchResult.Matches {
+		if match.Score >= overlapThreshold {
+			warnings = append(warnings, source.NewSpecBundleWarning{
+				Code:    "similar_spec_exists",
+				Message: fmt.Sprintf("existing spec %s %q has %.0f%% similarity to the proposed title; review before proceeding", match.Ref, match.Title, match.Score*100),
+			})
+		}
+	}
+	return warnings
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -251,7 +251,7 @@ func checkNewSpecOverlap(ctx context.Context, cfg *config.Config, title string) 
 		if match.Score >= overlapThreshold {
 			warnings = append(warnings, source.NewSpecBundleWarning{
 				Code:    "similar_spec_exists",
-				Message: fmt.Sprintf("existing spec %s %q has %.0f%% similarity to the proposed title; review before proceeding", match.Ref, match.Title, match.Score*100),
+				Message: fmt.Sprintf("existing spec %s %q has %.0f%% semantic similarity; review before proceeding", match.Ref, match.Title, match.Score*100),
 			})
 		}
 	}

--- a/internal/analysis/classify_impact.go
+++ b/internal/analysis/classify_impact.go
@@ -1,0 +1,179 @@
+package analysis
+
+import (
+	"context"
+	"strings"
+)
+
+// impactSeverityClassifier is an optional capability for analysis providers
+// that support classifying the severity of spec change impact.
+type impactSeverityClassifier interface {
+	ClassifyImpactSeverity(ctx context.Context, request impactSeverityRequest) (*impactSeverityResponse, error)
+}
+
+type impactSeverityRequest struct {
+	Spec       analysisSpecPrompt   `json:"spec"`
+	ChangeType string               `json:"change_type"`
+	Items      []impactSeverityItem `json:"items"`
+}
+
+type impactSeverityItem struct {
+	Ref          string `json:"ref"`
+	Kind         string `json:"kind"`
+	Title        string `json:"title"`
+	Relationship string `json:"relationship,omitempty"`
+	Excerpt      string `json:"excerpt,omitempty"`
+}
+
+type impactSeverityResponse struct {
+	Classifications []impactSeverityClassification `json:"classifications"`
+}
+
+type impactSeverityClassification struct {
+	Ref        string  `json:"ref"`
+	Severity   string  `json:"severity"`
+	Confidence float64 `json:"confidence"`
+	Reason     string  `json:"reason"`
+}
+
+const (
+	ImpactSeverityBreaking   = "breaking"
+	ImpactSeverityBehavioral = "behavioral"
+	ImpactSeverityCosmetic   = "cosmetic"
+	ImpactSeverityUnknown    = "unknown"
+
+	openAICompatibleImpactSeveritySystemPrompt = "You are Pituitary's impact severity classifier. Given a spec and its change type, classify the severity of impact on each affected item. Return only one JSON object with key classifications containing an array. Each classification must have: ref (the affected item ref), severity (breaking, behavioral, cosmetic, or unknown), confidence (0.0 to 1.0), and reason (brief justification). Breaking means the change invalidates assumptions or contracts in the affected item. Behavioral means the change alters behavior but doesn't break contracts. Cosmetic means the change only affects naming, formatting, or documentation without functional impact."
+	impactSeverityMaxItems                     = 12
+)
+
+// ClassifyImpactSeverity implements impactSeverityClassifier for the
+// OpenAI-compatible analysis provider.
+func (p *openAICompatibleAnalysisProvider) ClassifyImpactSeverity(ctx context.Context, request impactSeverityRequest) (*impactSeverityResponse, error) {
+	if len(request.Items) == 0 {
+		return &impactSeverityResponse{}, nil
+	}
+
+	payload := impactSeverityPrompt{
+		Command:    "analyze-impact-severity",
+		Spec:       request.Spec,
+		ChangeType: request.ChangeType,
+		Items:      truncateImpactItems(request.Items),
+	}
+
+	var response impactSeverityResponse
+	if err := p.completeJSON(ctx, openAICompatibleImpactSeveritySystemPrompt, payload, &response); err != nil {
+		return nil, err
+	}
+	response.Classifications = normalizeImpactClassifications(response.Classifications, request.Items)
+	return &response, nil
+}
+
+type impactSeverityPrompt struct {
+	Command    string               `json:"command"`
+	Spec       analysisSpecPrompt   `json:"spec"`
+	ChangeType string               `json:"change_type"`
+	Items      []impactSeverityItem `json:"items"`
+}
+
+func truncateImpactItems(items []impactSeverityItem) []impactSeverityItem {
+	if len(items) <= impactSeverityMaxItems {
+		return items
+	}
+	return items[:impactSeverityMaxItems]
+}
+
+func normalizeImpactClassifications(classifications []impactSeverityClassification, items []impactSeverityItem) []impactSeverityClassification {
+	validRefs := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		validRefs[item.Ref] = struct{}{}
+	}
+
+	result := make([]impactSeverityClassification, 0, len(classifications))
+	for _, c := range classifications {
+		ref := strings.TrimSpace(c.Ref)
+		if ref == "" {
+			continue
+		}
+		if _, ok := validRefs[ref]; !ok {
+			continue
+		}
+		severity := strings.TrimSpace(c.Severity)
+		switch severity {
+		case ImpactSeverityBreaking, ImpactSeverityBehavioral, ImpactSeverityCosmetic:
+		default:
+			severity = ImpactSeverityUnknown
+		}
+		c.Ref = ref
+		c.Severity = severity
+		c.Reason = strings.TrimSpace(c.Reason)
+		if c.Confidence < 0 {
+			c.Confidence = 0
+		}
+		if c.Confidence > 1 {
+			c.Confidence = 1
+		}
+		result = append(result, c)
+	}
+	return result
+}
+
+// classifyImpactSeverities enriches the impact result with model-backed
+// severity classifications. Errors are silently ignored — severity is
+// non-fatal enrichment.
+func classifyImpactSeverities(ctx context.Context, classifier impactSeverityClassifier, candidate *specDocument, result *AnalyzeImpactResult) {
+	specPrompt := analysisSpecFromDocument(*candidate)
+
+	items := make([]impactSeverityItem, 0, len(result.AffectedSpecs)+len(result.AffectedDocs))
+	for _, spec := range result.AffectedSpecs {
+		items = append(items, impactSeverityItem{
+			Ref:          spec.Ref,
+			Kind:         "spec",
+			Title:        spec.Title,
+			Relationship: spec.Relationship,
+		})
+	}
+	for _, doc := range result.AffectedDocs {
+		excerpt := ""
+		if doc.Evidence != nil {
+			excerpt = doc.Evidence.DocExcerpt
+		}
+		items = append(items, impactSeverityItem{
+			Ref:     doc.Ref,
+			Kind:    "doc",
+			Title:   doc.Title,
+			Excerpt: excerpt,
+		})
+	}
+	if len(items) == 0 {
+		return
+	}
+
+	response, err := classifier.ClassifyImpactSeverity(ctx, impactSeverityRequest{
+		Spec:       specPrompt,
+		ChangeType: result.ChangeType,
+		Items:      items,
+	})
+	if err != nil || response == nil {
+		return
+	}
+
+	classificationByRef := make(map[string]impactSeverityClassification, len(response.Classifications))
+	for _, c := range response.Classifications {
+		classificationByRef[c.Ref] = c
+	}
+
+	for i := range result.AffectedSpecs {
+		if c, ok := classificationByRef[result.AffectedSpecs[i].Ref]; ok {
+			result.AffectedSpecs[i].Severity = c.Severity
+			result.AffectedSpecs[i].SeverityConfidence = c.Confidence
+			result.AffectedSpecs[i].SeverityReason = c.Reason
+		}
+	}
+	for i := range result.AffectedDocs {
+		if c, ok := classificationByRef[result.AffectedDocs[i].Ref]; ok {
+			result.AffectedDocs[i].Severity = c.Severity
+			result.AffectedDocs[i].SeverityConfidence = c.Confidence
+			result.AffectedDocs[i].SeverityReason = c.Reason
+		}
+	}
+}

--- a/internal/analysis/classify_impact.go
+++ b/internal/analysis/classify_impact.go
@@ -99,7 +99,7 @@ func normalizeImpactClassifications(classifications []impactSeverityClassificati
 		}
 		severity := strings.TrimSpace(c.Severity)
 		switch severity {
-		case ImpactSeverityBreaking, ImpactSeverityBehavioral, ImpactSeverityCosmetic:
+		case ImpactSeverityBreaking, ImpactSeverityBehavioral, ImpactSeverityCosmetic, ImpactSeverityUnknown:
 		default:
 			severity = ImpactSeverityUnknown
 		}

--- a/internal/analysis/classify_impact_test.go
+++ b/internal/analysis/classify_impact_test.go
@@ -1,0 +1,168 @@
+package analysis
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeImpactClassificationsFiltersInvalidRefs(t *testing.T) {
+	t.Parallel()
+
+	items := []impactSeverityItem{
+		{Ref: "SPEC-001", Kind: "spec", Title: "Auth"},
+		{Ref: "doc://guides/auth", Kind: "doc", Title: "Auth Guide"},
+	}
+	classifications := []impactSeverityClassification{
+		{Ref: "SPEC-001", Severity: "breaking", Confidence: 0.9, Reason: "invalidates auth contract"},
+		{Ref: "SPEC-999", Severity: "behavioral", Confidence: 0.8, Reason: "unknown ref"},
+		{Ref: "", Severity: "cosmetic", Confidence: 0.5, Reason: "empty ref"},
+		{Ref: "doc://guides/auth", Severity: "cosmetic", Confidence: 0.7, Reason: "naming only"},
+	}
+
+	result := normalizeImpactClassifications(classifications, items)
+
+	if len(result) != 2 {
+		t.Fatalf("got %d classifications, want 2", len(result))
+	}
+	if result[0].Ref != "SPEC-001" || result[0].Severity != "breaking" {
+		t.Errorf("result[0] = %+v, want SPEC-001 breaking", result[0])
+	}
+	if result[1].Ref != "doc://guides/auth" || result[1].Severity != "cosmetic" {
+		t.Errorf("result[1] = %+v, want doc://guides/auth cosmetic", result[1])
+	}
+}
+
+func TestNormalizeImpactClassificationsNormalizesUnknownSeverity(t *testing.T) {
+	t.Parallel()
+
+	items := []impactSeverityItem{
+		{Ref: "SPEC-001", Kind: "spec", Title: "Auth"},
+	}
+	classifications := []impactSeverityClassification{
+		{Ref: "SPEC-001", Severity: "critical", Confidence: 0.8, Reason: "invalid severity value"},
+	}
+
+	result := normalizeImpactClassifications(classifications, items)
+
+	if len(result) != 1 {
+		t.Fatalf("got %d classifications, want 1", len(result))
+	}
+	if result[0].Severity != ImpactSeverityUnknown {
+		t.Errorf("severity = %q, want %q", result[0].Severity, ImpactSeverityUnknown)
+	}
+}
+
+func TestNormalizeImpactClassificationsClampsConfidence(t *testing.T) {
+	t.Parallel()
+
+	items := []impactSeverityItem{
+		{Ref: "SPEC-001", Kind: "spec"},
+		{Ref: "SPEC-002", Kind: "spec"},
+	}
+	classifications := []impactSeverityClassification{
+		{Ref: "SPEC-001", Severity: "breaking", Confidence: 1.5, Reason: "over"},
+		{Ref: "SPEC-002", Severity: "behavioral", Confidence: -0.3, Reason: "under"},
+	}
+
+	result := normalizeImpactClassifications(classifications, items)
+
+	if len(result) != 2 {
+		t.Fatalf("got %d classifications, want 2", len(result))
+	}
+	if result[0].Confidence != 1.0 {
+		t.Errorf("confidence = %f, want 1.0", result[0].Confidence)
+	}
+	if result[1].Confidence != 0.0 {
+		t.Errorf("confidence = %f, want 0.0", result[1].Confidence)
+	}
+}
+
+func TestTruncateImpactItemsRespectsLimit(t *testing.T) {
+	t.Parallel()
+
+	items := make([]impactSeverityItem, 20)
+	for i := range items {
+		items[i] = impactSeverityItem{Ref: "SPEC-" + string(rune('A'+i)), Kind: "spec"}
+	}
+
+	result := truncateImpactItems(items)
+	if len(result) != impactSeverityMaxItems {
+		t.Errorf("got %d items, want %d", len(result), impactSeverityMaxItems)
+	}
+}
+
+func TestTruncateImpactItemsPassthroughWhenUnderLimit(t *testing.T) {
+	t.Parallel()
+
+	items := []impactSeverityItem{
+		{Ref: "SPEC-001", Kind: "spec"},
+		{Ref: "SPEC-002", Kind: "spec"},
+	}
+
+	result := truncateImpactItems(items)
+	if len(result) != 2 {
+		t.Errorf("got %d items, want 2", len(result))
+	}
+}
+
+func TestImpactSeverityPromptMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	prompt := impactSeverityPrompt{
+		Command: "analyze-impact-severity",
+		Spec: analysisSpecPrompt{
+			Ref:   "SPEC-042",
+			Title: "Rate Limiting",
+		},
+		ChangeType: "accepted",
+		Items: []impactSeverityItem{
+			{Ref: "SPEC-055", Kind: "spec", Title: "Throttle Policy", Relationship: "depends_on"},
+		},
+	}
+	data, err := json.Marshal(prompt)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("empty JSON")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed["command"] != "analyze-impact-severity" {
+		t.Errorf("command = %v, want analyze-impact-severity", parsed["command"])
+	}
+}
+
+func TestBuildImpactSummarySeverityOverridesPriority(t *testing.T) {
+	t.Parallel()
+
+	specs := []ImpactedSpec{
+		{Ref: "SPEC-A", Title: "Alpha", Relationship: "depends_on", Severity: ImpactSeverityCosmetic},
+		{Ref: "SPEC-B", Title: "Beta", Relationship: "depends_on", Severity: ImpactSeverityBreaking},
+	}
+	docs := []ImpactedDoc{
+		{Ref: "doc://x", Title: "Doc X", SourceRef: "x.md", Score: 0.9, Classification: impactDocClassificationSemanticNeighbor, Severity: ImpactSeverityBehavioral},
+	}
+
+	result := buildImpactSummary(specs, docs, 5)
+	if len(result) != 3 {
+		t.Fatalf("got %d summary items, want 3", len(result))
+	}
+	// Breaking should come first.
+	if result[0].Ref != "SPEC-B" {
+		t.Errorf("rank 1 ref = %q, want SPEC-B (breaking)", result[0].Ref)
+	}
+	if result[0].Severity != ImpactSeverityBreaking {
+		t.Errorf("rank 1 severity = %q, want breaking", result[0].Severity)
+	}
+	// Behavioral second.
+	if result[1].Ref != "doc://x" {
+		t.Errorf("rank 2 ref = %q, want doc://x (behavioral)", result[1].Ref)
+	}
+	// Cosmetic last.
+	if result[2].Ref != "SPEC-A" {
+		t.Errorf("rank 3 ref = %q, want SPEC-A (cosmetic)", result[2].Ref)
+	}
+}

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -168,12 +168,14 @@ func AnalyzeImpactContext(ctx context.Context, cfg *config.Config, request Analy
 
 	// Severity classification: if the analysis runtime is configured, use
 	// the model to classify impact severity for each affected item.
-	analyzer, err := newQualitativeAnalyzer(cfg.Runtime.Analysis)
-	if err != nil {
-		return nil, err
-	}
+	// This is non-fatal enrichment — errors are swallowed so the
+	// deterministic result is always returned.
+	analyzer, _ := newQualitativeAnalyzer(cfg.Runtime.Analysis)
 	if classifier, ok := analyzer.(impactSeverityClassifier); ok {
 		classifyImpactSeverities(ctx, classifier, candidate, result)
+		// Rebuild summary after severity is populated so severity-based
+		// priority overrides take effect.
+		result.RankedSummary = buildImpactSummary(result.AffectedSpecs, result.AffectedDocs, 5)
 	}
 
 	return result, nil

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -25,13 +25,16 @@ type AnalyzeImpactRequest struct {
 
 // ImpactedSpec reports one affected spec.
 type ImpactedSpec struct {
-	Ref          string                     `json:"ref"`
-	Title        string                     `json:"title"`
-	Repo         string                     `json:"repo,omitempty"`
-	Status       string                     `json:"status,omitempty"`
-	Relationship string                     `json:"relationship"`
-	Historical   bool                       `json:"historical"`
-	Inference    *model.InferenceConfidence `json:"inference,omitempty"`
+	Ref                string                     `json:"ref"`
+	Title              string                     `json:"title"`
+	Repo               string                     `json:"repo,omitempty"`
+	Status             string                     `json:"status,omitempty"`
+	Relationship       string                     `json:"relationship"`
+	Historical         bool                       `json:"historical"`
+	Inference          *model.InferenceConfidence `json:"inference,omitempty"`
+	Severity           string                     `json:"severity,omitempty"`
+	SeverityConfidence float64                    `json:"severity_confidence,omitempty"`
+	SeverityReason     string                     `json:"severity_reason,omitempty"`
 }
 
 // ImpactedRef reports one affected code or config reference.
@@ -66,15 +69,18 @@ type ImpactEditTarget struct {
 
 // ImpactedDoc reports one semantically related document.
 type ImpactedDoc struct {
-	Ref              string             `json:"ref"`
-	Title            string             `json:"title"`
-	Repo             string             `json:"repo,omitempty"`
-	SourceRef        string             `json:"source_ref"`
-	Score            float64            `json:"score"`
-	Classification   string             `json:"classification,omitempty"`
-	Reasons          []string           `json:"reasons,omitempty"`
-	Evidence         *ImpactEvidence    `json:"evidence,omitempty"`
-	SuggestedTargets []ImpactEditTarget `json:"suggested_targets,omitempty"`
+	Ref                string             `json:"ref"`
+	Title              string             `json:"title"`
+	Repo               string             `json:"repo,omitempty"`
+	SourceRef          string             `json:"source_ref"`
+	Score              float64            `json:"score"`
+	Classification     string             `json:"classification,omitempty"`
+	Reasons            []string           `json:"reasons,omitempty"`
+	Evidence           *ImpactEvidence    `json:"evidence,omitempty"`
+	SuggestedTargets   []ImpactEditTarget `json:"suggested_targets,omitempty"`
+	Severity           string             `json:"severity,omitempty"`
+	SeverityConfidence float64            `json:"severity_confidence,omitempty"`
+	SeverityReason     string             `json:"severity_reason,omitempty"`
 }
 
 // ImpactSummaryItem captures one high-priority follow-up target.
@@ -88,6 +94,7 @@ type ImpactSummaryItem struct {
 	Score       float64 `json:"score,omitempty"`
 	Why         string  `json:"why,omitempty"`
 	ReviewFirst string  `json:"review_first,omitempty"`
+	Severity    string  `json:"severity,omitempty"`
 }
 
 // AnalyzeImpactResult is the structured impact-analysis response.
@@ -157,7 +164,19 @@ func AnalyzeImpactContext(ctx context.Context, cfg *config.Config, request Analy
 		return nil, err
 	}
 
-	return buildAnalyzeImpactResult(candidate, request.ChangeType, request.Summary, specs, docs), nil
+	result := buildAnalyzeImpactResult(candidate, request.ChangeType, request.Summary, specs, docs)
+
+	// Severity classification: if the analysis runtime is configured, use
+	// the model to classify impact severity for each affected item.
+	analyzer, err := newQualitativeAnalyzer(cfg.Runtime.Analysis)
+	if err != nil {
+		return nil, err
+	}
+	if classifier, ok := analyzer.(impactSeverityClassifier); ok {
+		classifyImpactSeverities(ctx, classifier, candidate, result)
+	}
+
+	return result, nil
 }
 
 func buildAnalyzeImpactResult(candidate *specDocument, changeType string, summaryOnly bool, specs map[string]specDocument, docs map[string]docDocument) *AnalyzeImpactResult {
@@ -296,6 +315,7 @@ func buildImpactSummary(specs []ImpactedSpec, docs []ImpactedDoc, limit int) []I
 	type scoredSummary struct {
 		item     ImpactSummaryItem
 		priority int
+		severity string
 		score    float64
 	}
 
@@ -315,8 +335,10 @@ func buildImpactSummary(specs []ImpactedSpec, docs []ImpactedDoc, limit int) []I
 				Repo:        item.Repo,
 				Why:         why,
 				ReviewFirst: impactSummarySpecTarget(item),
+				Severity:    item.Severity,
 			},
 			priority: priority,
+			severity: item.Severity,
 		})
 	}
 	for _, item := range docs {
@@ -334,10 +356,26 @@ func buildImpactSummary(specs []ImpactedSpec, docs []ImpactedDoc, limit int) []I
 				Score:       item.Score,
 				Why:         impactSummaryDocReason(item),
 				ReviewFirst: impactSummaryDocTarget(item),
+				Severity:    item.Severity,
 			},
 			priority: priority,
+			severity: item.Severity,
 			score:    item.Score,
 		})
+	}
+
+	// Severity-based priority override: when the model has classified
+	// severity, use it to promote or demote items regardless of the
+	// default heuristic priority.
+	for i := range scored {
+		switch scored[i].severity {
+		case ImpactSeverityBreaking:
+			scored[i].priority = 0
+		case ImpactSeverityBehavioral:
+			scored[i].priority = 1
+		case ImpactSeverityCosmetic:
+			scored[i].priority = 3
+		}
 	}
 
 	sort.Slice(scored, func(i, j int) bool {


### PR DESCRIPTION
## Summary

Implements the two secondary opportunities from #233:

- **`new` with semantic overlap pre-check**: Before scaffolding, searches the index for specs with >50% title similarity and emits `similar_spec_exists` warnings. Non-blocking — the bundle is always created. Only activates when `pituitary.toml` and an index are available.

- **`analyze-impact` with severity classification**: When `runtime.analysis` is configured, classifies each affected spec/doc as `breaking`, `behavioral`, `cosmetic`, or `unknown`. Severity flows into `ImpactedSpec`, `ImpactedDoc`, and `ImpactSummaryItem`. Breaking items sort first in the ranked summary. Non-fatal — if the model fails, results are returned without severity fields.

### Design

Both features follow the established patterns:
- Runtime config is the sole opt-in (no new CLI flags)
- Type assertions for optional provider capabilities (`impactSeverityClassifier`)
- Graceful degradation — errors are swallowed, deterministic baseline is never broken

### Files changed

| File | Change |
|------|--------|
| `cmd/new.go` | Add `Config` to defaults, call `checkNewSpecOverlap` after scaffolding |
| `internal/analysis/impact.go` | Add `Severity`/`SeverityConfidence`/`SeverityReason` to `ImpactedSpec`, `ImpactedDoc`, `ImpactSummaryItem`; integrate classifier; severity-based priority in summary |
| `internal/analysis/classify_impact.go` | New: `impactSeverityClassifier` interface, OpenAI impl, normalization |
| `internal/analysis/classify_impact_test.go` | New: tests for normalization, clamping, truncation, priority |

## Test plan

- [x] `make ci` passes
- [x] All existing tests pass without modification
- [x] New unit tests cover normalization, confidence clamping, truncation, severity priority
- [ ] Manual: run `pituitary new --title "Rate Limiting"` in a repo with indexed rate-limiting specs
- [ ] Manual: run `pituitary analyze-impact --spec-ref X --summary` with `runtime.analysis` configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)