### PR TITLE
chore: bump version to v1.0.0-beta.6

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/dusk-network/pituitary",
     "source": "github"
   },
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "packages": []
 }

--- a/skills/pituitary-cli/agents/openai.yaml
+++ b/skills/pituitary-cli/agents/openai.yaml
@@ -4,7 +4,7 @@ interface:
   default_prompt: "Use $pituitary-cli to inspect this repository with Pituitary and return a JSON-grounded result."
 
 metadata:
-  version: "1.0.0-beta.5"
+  version: "1.0.0-beta.6"
   source: "https://github.com/dusk-network/pituitary"
   license: "MIT"
   categories:


### PR DESCRIPTION
## Summary

- Bump version in `server.json` and `skills/pituitary-cli/agents/openai.yaml` to 1.0.0-beta.6

Tag `v1.0.0-beta.6` is already pushed. This PR lands the version references on main.

## What's new since beta.5

- Skill package expanded to Cursor, Windsurf, Cline, and OpenAI agents (#198)
- Automated prompt evaluation framework with 0.95 score (#199)
- Marketplace submission preparation (#200)
- Token optimization: spec cap, similarity threshold, section limits (#245)
- Pure-Go Wasm SQLite — no CGO, cross-compilation works (#244)
- Parallel LLM adjudication for check-doc-drift and check-compliance (#242)
- MCP server expanded from 6 to 13 tools (#241)
- check-spec-freshness command (#240)

🤖 Generated with [Claude Code](https://claude.com/claude-code)