### PR TITLE
Fix hardcoded adapter column in rebuild.go

### DIFF
--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -613,9 +613,9 @@ func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocReco
 }
 
 // adapterFromMetadata returns the source adapter recorded in metadata, falling
-// back to the filesystem adapter when the key is absent or empty.
+// back to the filesystem adapter when the key is absent or blank.
 func adapterFromMetadata(metadata map[string]string) string {
-	if v := metadata["source_adapter"]; v != "" {
+	if v := strings.TrimSpace(metadata["source_adapter"]); v != "" {
 		return v
 	}
 	return config.AdapterFilesystem

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -528,6 +528,11 @@ func TestAdapterFromMetadata(t *testing.T) {
 			metadata: map[string]string{"source_adapter": ""},
 			want:     config.AdapterFilesystem,
 		},
+		{
+			name:     "source_adapter whitespace-only falls back",
+			metadata: map[string]string{"source_adapter": "  "},
+			want:     config.AdapterFilesystem,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reads `source_adapter` from record metadata instead of hardcoding `config.AdapterFilesystem` in both `insertSpecArtifactContext` and `insertDocArtifactContext`
- Falls back to `"filesystem"` when the metadata key is absent or empty (backward compatible)
- Adds table-driven unit tests for the new `adapterFromMetadata` helper

Closes #251

## Test plan

- [x] `TestAdapterFromMetadata` covers nil, empty, present, and empty-string metadata cases
- [x] Full `internal/index` test suite passes
- [x] `make test` and `make vet` green
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)