### PR TITLE
Add relates_to soft edge type for non-dependency relationships

### DIFF
--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -363,7 +363,7 @@ func TestRunIndexVerboseTextReportsSourceCountsAndProgress(t *testing.T) {
 		t.Fatalf("runIndex(--verbose) exit code = %d, want 0", exitCode)
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "indexed 5 artifact(s), 17 chunk(s), and 8 edge(s)") {
+	if !strings.Contains(out, "indexed 5 artifact(s), 17 chunk(s), and 9 edge(s)") {
 		t.Fatalf("runIndex(--verbose) output %q does not contain rebuild summary", out)
 	}
 	if !strings.Contains(out, "source: specs | spec_bundle | root: specs | items: 3 | specs: 3") {
@@ -463,7 +463,7 @@ func TestRunIndexDryRunTextDoesNotCreateDatabase(t *testing.T) {
 		t.Fatalf("runIndex(--dry-run) wrote unexpected stderr: %q", stderr.String())
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "dry run validated 5 artifact(s), 17 chunk(s), and 8 edge(s)") {
+	if !strings.Contains(out, "dry run validated 5 artifact(s), 17 chunk(s), and 9 edge(s)") {
 		t.Fatalf("runIndex(--dry-run) output %q does not contain dry-run summary", out)
 	}
 	if !strings.Contains(out, "database write: skipped") {
@@ -519,8 +519,8 @@ func TestRunIndexDryRunJSONDoesNotCreateDatabase(t *testing.T) {
 	if payload.Result.ArtifactCount != 5 || payload.Result.SpecCount != 3 || payload.Result.DocCount != 2 {
 		t.Fatalf("result = %+v, want 5 artifacts / 3 specs / 2 docs", payload.Result)
 	}
-	if payload.Result.ChunkCount != 17 || payload.Result.EdgeCount != 8 {
-		t.Fatalf("result = %+v, want 17 chunks / 8 edges", payload.Result)
+	if payload.Result.ChunkCount != 17 || payload.Result.EdgeCount != 9 {
+		t.Fatalf("result = %+v, want 17 chunks / 9 edges", payload.Result)
 	}
 	if payload.Result.IndexPath == "" {
 		t.Fatalf("result = %+v, want non-empty index path", payload.Result)

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -222,7 +222,7 @@ func TestRenderInitResultSummarizesOnboarding(t *testing.T) {
 		Index: &index.RebuildResult{
 			ArtifactCount: 5,
 			ChunkCount:    17,
-			EdgeCount:     8,
+			EdgeCount:     9,
 		},
 		Status: &statusResult{
 			EmbedderProvider: "fixture",

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -230,6 +230,17 @@ func impactedSpecs(candidate model.SpecRecord, specs map[string]specDocument) []
 				Historical:   true,
 				Inference:    spec.Record.Inference,
 			})
+		case relationExists(candidate.Relations, model.RelationRelatesTo, spec.Record.Ref) ||
+			relationExists(spec.Record.Relations, model.RelationRelatesTo, candidate.Ref):
+			result = append(result, ImpactedSpec{
+				Ref:          spec.Record.Ref,
+				Title:        spec.Record.Title,
+				Repo:         artifactRepoID(spec.Record.Metadata),
+				Status:       spec.Record.Status,
+				Relationship: string(model.RelationRelatesTo),
+				Historical:   false,
+				Inference:    spec.Record.Inference,
+			})
 		}
 	}
 
@@ -325,7 +336,10 @@ func buildImpactSummary(specs []ImpactedSpec, docs []ImpactedDoc, limit int) []I
 	for _, item := range specs {
 		why := "depends on this spec"
 		priority := 0
-		if item.Historical {
+		if item.Relationship == string(model.RelationRelatesTo) {
+			why = "related spec (soft reference)"
+			priority = 2
+		} else if item.Historical {
 			why = "historical spec superseded by this spec"
 			priority = 3
 		}

--- a/internal/analysis/repository_similarity.go
+++ b/internal/analysis/repository_similarity.go
@@ -74,6 +74,16 @@ func (r *analysisRepository) impactedSpecRefs(candidate model.SpecRecord) ([]str
 		return nil, err
 	}
 	refs = append(refs, dependentRefs...)
+
+	// Traverse relates_to edges in both directions: outgoing from the
+	// candidate and incoming from other specs.
+	refs = append(refs, relationRefs(candidate.Relations, model.RelationRelatesTo)...)
+	incomingRelatesTo, err := r.specRefsWithIncomingEdge(model.RelationRelatesTo, candidate.Ref, nil)
+	if err != nil {
+		return nil, err
+	}
+	refs = append(refs, incomingRelatesTo...)
+
 	return uniqueStrings(refs), nil
 }
 

--- a/internal/index/graph_validation_test.go
+++ b/internal/index/graph_validation_test.go
@@ -75,6 +75,57 @@ func TestValidateRelationGraphReturnsStructuredError(t *testing.T) {
 	}
 }
 
+func TestInspectRelationGraphAllowsMutualRelatesToWithoutCycle(t *testing.T) {
+	t.Parallel()
+
+	status := InspectRelationGraph([]model.SpecRecord{
+		specWithRelations("SPEC-400",
+			model.Relation{Type: model.RelationRelatesTo, Ref: "SPEC-401"},
+		),
+		specWithRelations("SPEC-401",
+			model.Relation{Type: model.RelationRelatesTo, Ref: "SPEC-400"},
+		),
+	})
+
+	if got, want := status.State, "valid"; got != want {
+		t.Fatalf("state = %q, want %q; mutual relates_to should not trigger cycle detection", got, want)
+	}
+}
+
+func TestInspectRelationGraphAllowsRelatesToAlongsideDependsOn(t *testing.T) {
+	t.Parallel()
+
+	status := InspectRelationGraph([]model.SpecRecord{
+		specWithRelations("SPEC-500",
+			model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-501"},
+			model.Relation{Type: model.RelationRelatesTo, Ref: "SPEC-502"},
+		),
+		specWithRelations("SPEC-501"),
+		specWithRelations("SPEC-502"),
+	})
+
+	if got, want := status.State, "valid"; got != want {
+		t.Fatalf("state = %q, want %q; relates_to should not conflict with depends_on", got, want)
+	}
+}
+
+func TestInspectRelationGraphDetectsRelatesToSelfReference(t *testing.T) {
+	t.Parallel()
+
+	status := InspectRelationGraph([]model.SpecRecord{
+		specWithRelations("SPEC-600",
+			model.Relation{Type: model.RelationRelatesTo, Ref: "SPEC-600"},
+		),
+	})
+
+	if got, want := status.State, "invalid"; got != want {
+		t.Fatalf("state = %q, want %q; self-referencing relates_to should be invalid", got, want)
+	}
+	if len(status.Findings) != 1 || status.Findings[0].Code != "self_reference" {
+		t.Fatalf("findings = %+v, want one self_reference finding", status.Findings)
+	}
+}
+
 func specWithRelations(ref string, relations ...model.Relation) model.SpecRecord {
 	return model.SpecRecord{
 		Ref:       ref,

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -33,8 +33,8 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 	if result.ChunkCount != 17 {
 		t.Fatalf("chunk count = %d, want 17", result.ChunkCount)
 	}
-	if result.EdgeCount != 8 {
-		t.Fatalf("edge count = %d, want 8", result.EdgeCount)
+	if result.EdgeCount != 9 {
+		t.Fatalf("edge count = %d, want 9", result.EdgeCount)
 	}
 	if result.EmbedderDimension != 8 {
 		t.Fatalf("embedder dimension = %d, want 8", result.EmbedderDimension)
@@ -51,7 +51,7 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 
 	assertCount(t, db, `SELECT COUNT(*) FROM artifacts`, 5)
 	assertCount(t, db, `SELECT COUNT(*) FROM chunks`, 17)
-	assertCount(t, db, `SELECT COUNT(*) FROM edges`, 8)
+	assertCount(t, db, `SELECT COUNT(*) FROM edges`, 9)
 	assertCount(t, db, `SELECT COUNT(*) FROM chunks_vec`, 17)
 	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 5)
 	assertMetadataValue(t, db, "embedder_fingerprint", "fixture|fixture-8d|plain_v1")
@@ -139,8 +139,8 @@ func TestPrepareRebuildSummarizesFixturesWithoutWritingDatabase(t *testing.T) {
 	if result.ChunkCount != 17 {
 		t.Fatalf("chunk count = %d, want 17", result.ChunkCount)
 	}
-	if result.EdgeCount != 8 {
-		t.Fatalf("edge count = %d, want 8", result.EdgeCount)
+	if result.EdgeCount != 9 {
+		t.Fatalf("edge count = %d, want 9", result.EdgeCount)
 	}
 	if result.EmbedderDimension != 8 {
 		t.Fatalf("embedder dimension = %d, want 8", result.EmbedderDimension)

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -20,6 +20,7 @@ type RelationType = sdk.RelationType
 const (
 	RelationDependsOn  = sdk.RelationDependsOn
 	RelationSupersedes = sdk.RelationSupersedes
+	RelationRelatesTo  = sdk.RelationRelatesTo
 )
 
 type Relation = sdk.Relation

--- a/internal/source/canonicalize.go
+++ b/internal/source/canonicalize.go
@@ -231,6 +231,7 @@ func renderCanonicalizedSpecToml(workspaceRoot, sourcePath string, spec model.Sp
 	writeSpecBundleArray(&builder, "tags", spec.Tags)
 	writeSpecBundleArray(&builder, "depends_on", collectRelationRefs(spec.Relations, model.RelationDependsOn))
 	writeSpecBundleArray(&builder, "supersedes", collectRelationRefs(spec.Relations, model.RelationSupersedes))
+	writeSpecBundleArray(&builder, "relates_to", collectRelationRefs(spec.Relations, model.RelationRelatesTo))
 	writeSpecBundleArray(&builder, "applies_to", spec.AppliesTo)
 	return builder.String(), nil
 }

--- a/internal/source/explain.go
+++ b/internal/source/explain.go
@@ -68,6 +68,7 @@ type ExplainedInferredSpec struct {
 	Domain     string                     `json:"domain,omitempty"`
 	DependsOn  []string                   `json:"depends_on,omitempty"`
 	Supersedes []string                   `json:"supersedes,omitempty"`
+	RelatesTo  []string                   `json:"relates_to,omitempty"`
 	AppliesTo  []string                   `json:"applies_to,omitempty"`
 	Inference  *model.InferenceConfidence `json:"inference,omitempty"`
 }
@@ -240,6 +241,7 @@ func explainMarkdownContractSource(workspaceRoot string, explanation SourceFileE
 		Domain:     record.Domain,
 		DependsOn:  relationRefs(record.Relations, model.RelationDependsOn),
 		Supersedes: relationRefs(record.Relations, model.RelationSupersedes),
+		RelatesTo:  relationRefs(record.Relations, model.RelationRelatesTo),
 		AppliesTo:  append([]string(nil), record.AppliesTo...),
 		Inference:  record.Inference,
 	}

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -237,6 +237,7 @@ type rawSpecBundle struct {
 	Body       string
 	DependsOn  []string
 	Supersedes []string
+	RelatesTo  []string
 	AppliesTo  []string
 }
 
@@ -282,7 +283,7 @@ func loadSpecBundle(workspaceRoot string, source config.Source, bundleDir string
 		Domain:      raw.Domain,
 		Authors:     append([]string(nil), raw.Authors...),
 		Tags:        append([]string(nil), raw.Tags...),
-		Relations:   buildRelations(raw.DependsOn, raw.Supersedes),
+		Relations:   buildRelations(raw.DependsOn, raw.Supersedes, raw.RelatesTo),
 		AppliesTo:   append([]string(nil), raw.AppliesTo...),
 		SourceRef:   fileSourceRef(workspaceRoot, specPath),
 		BodyFormat:  model.BodyFormatMarkdown,
@@ -321,13 +322,16 @@ func validateRawSpec(workspaceRoot, sourceName, bundleDir string, raw rawSpecBun
 	return nil
 }
 
-func buildRelations(dependsOn, supersedes []string) []model.Relation {
-	relations := make([]model.Relation, 0, len(dependsOn)+len(supersedes))
+func buildRelations(dependsOn, supersedes, relatesTo []string) []model.Relation {
+	relations := make([]model.Relation, 0, len(dependsOn)+len(supersedes)+len(relatesTo))
 	for _, ref := range dependsOn {
 		relations = append(relations, model.Relation{Type: model.RelationDependsOn, Ref: ref})
 	}
 	for _, ref := range supersedes {
 		relations = append(relations, model.Relation{Type: model.RelationSupersedes, Ref: ref})
+	}
+	for _, ref := range relatesTo {
+		relations = append(relations, model.Relation{Type: model.RelationRelatesTo, Ref: ref})
 	}
 	return relations
 }
@@ -479,6 +483,7 @@ type markdownContractFields struct {
 	Domain     string
 	DependsOn  []string
 	Supersedes []string
+	RelatesTo  []string
 	AppliesTo  []string
 }
 
@@ -525,7 +530,7 @@ func inferMarkdownContract(workspaceRoot string, source config.Source, path stri
 		Title:       title,
 		Status:      status,
 		Domain:      domain,
-		Relations:   buildRelations(fields.DependsOn, fields.Supersedes),
+		Relations:   buildRelations(fields.DependsOn, fields.Supersedes, fields.RelatesTo),
 		AppliesTo:   uniqueStringValues(fields.AppliesTo),
 		SourceRef:   fileSourceRef(workspaceRoot, path),
 		BodyFormat:  model.BodyFormatMarkdown,
@@ -739,6 +744,8 @@ func assignMarkdownContractListField(fields *markdownContractFields, key string,
 		fields.DependsOn = append(fields.DependsOn, values...)
 	case "supersedes":
 		fields.Supersedes = append(fields.Supersedes, values...)
+	case "relates_to":
+		fields.RelatesTo = append(fields.RelatesTo, values...)
 	case "applies_to":
 		fields.AppliesTo = append(fields.AppliesTo, values...)
 	}
@@ -930,7 +937,7 @@ func assignSpecScalarField(spec *rawSpecBundle, key, value string) error {
 
 func isSpecArrayField(key string) bool {
 	switch key {
-	case "authors", "tags", "depends_on", "supersedes", "applies_to":
+	case "authors", "tags", "depends_on", "supersedes", "relates_to", "applies_to":
 		return true
 	default:
 		return false
@@ -947,6 +954,8 @@ func assignSpecArrayField(spec *rawSpecBundle, key string, values []string) erro
 		spec.DependsOn = append(spec.DependsOn, values...)
 	case "supersedes":
 		spec.Supersedes = append(spec.Supersedes, values...)
+	case "relates_to":
+		spec.RelatesTo = append(spec.RelatesTo, values...)
 	case "applies_to":
 		spec.AppliesTo = append(spec.AppliesTo, values...)
 	default:

--- a/sdk/model.go
+++ b/sdk/model.go
@@ -26,6 +26,7 @@ type RelationType string
 const (
 	RelationDependsOn  RelationType = "depends_on"
 	RelationSupersedes RelationType = "supersedes"
+	RelationRelatesTo  RelationType = "relates_to"
 )
 
 // Relation represents one explicit edge emitted by a normalized spec record.

--- a/specs/burst-handling/spec.toml
+++ b/specs/burst-handling/spec.toml
@@ -7,6 +7,7 @@ tags = ["rate-limiting", "api", "burst"]
 body = "body.md"
 
 depends_on = ["SPEC-042"]
+relates_to = ["SPEC-008"]
 applies_to = [
   "code://src/api/middleware/ratelimiter.go",
   "config://src/api/config/limits.yaml",


### PR DESCRIPTION
## Summary

- Adds `RelationRelatesTo` (`"relates_to"`) to the `RelationType` enum in `sdk/model.go` and re-exports in `internal/model`
- Parses `relates_to` from spec.toml frontmatter and markdown contract metadata
- Emits `relates_to` in canonicalize output and explain-file JSON
- `analyze-impact` traverses `relates_to` edges bidirectionally, surfacing them as "related spec (soft reference)" with lower priority than `depends_on` dependents
- Graph validation: mutual `relates_to` is valid (no cycle detection), coexistence with `depends_on`/`supersedes` is valid, self-reference is still caught
- Adds fixture: SPEC-055 (burst-handling) now `relates_to` SPEC-008 (rate-limit-legacy)

Closes #252

## Test plan

- [x] 3 new graph validation tests: mutual relates_to, coexistence with depends_on, self-reference
- [x] Fixture edge count updated from 8 to 9 across rebuild, index, and render tests
- [x] Full `make test` and `make vet` green
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)