### PR TITLE
chore: bump version to v1.0.0-beta.7

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/dusk-network/pituitary",
     "source": "github"
   },
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "packages": [],
   "tools": [
     {"name": "search_specs", "description": "Semantic search across indexed spec sections. Filter by domain and status."},

--- a/skills/pituitary-cli/agents/openai.yaml
+++ b/skills/pituitary-cli/agents/openai.yaml
@@ -4,7 +4,7 @@ interface:
   default_prompt: "Use $pituitary-cli to inspect this repository with Pituitary and return a JSON-grounded result."
 
 metadata:
-  version: "1.0.0-beta.6"
+  version: "1.0.0-beta.7"
   source: "https://github.com/dusk-network/pituitary"
   license: "MIT"
   categories:


### PR DESCRIPTION
## Summary

- Bump `server.json` and `skills/pituitary-cli/agents/openai.yaml` to `1.0.0-beta.7`

### Changes since beta.6

- **feat**: `explain-file` multirepo support — `repo_id`, scoped `workspace_path`, CWD-relative paths (#223)
- **feat**: Config shadowing detection for multirepo setups (#224)
- **fix**: Lightweight TOML parse for shadow detection — no filesystem validation required (#224)
- **feat**: Incremental index updates without full rebuild (#253/#258)
- **feat**: `source_adapter` metadata injection in loader (#254/#257)
- **feat**: `relates_to` soft edge type for non-dependency relationships (#252/#256)
- **fix**: Hardcoded adapter column in `rebuild.go` (#255)
- **fix**: Tool definitions in `server.json` for Smithery discovery

## Test plan

- [x] Version strings updated in both files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)