### PR TITLE
feat(index): governance graph diff on incremental updates

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -14,11 +14,12 @@ import (
 )
 
 type indexRequest struct {
-	Rebuild bool `json:"rebuild"`
-	Update  bool `json:"update,omitempty"`
-	DryRun  bool `json:"dry_run,omitempty"`
-	Full    bool `json:"full,omitempty"`
-	Verbose bool `json:"verbose,omitempty"`
+	Rebuild   bool `json:"rebuild"`
+	Update    bool `json:"update,omitempty"`
+	DryRun    bool `json:"dry_run,omitempty"`
+	Full      bool `json:"full,omitempty"`
+	Verbose   bool `json:"verbose,omitempty"`
+	ShowDelta bool `json:"show_delta,omitempty"`
 }
 
 type indexProgressLine struct {
@@ -47,6 +48,7 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 		dryRun     bool
 		full       bool
 		verbose    bool
+		showDelta  bool
 		format     string
 		configPath string
 	)
@@ -55,6 +57,7 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 	fs.BoolVar(&dryRun, "dry-run", false, "validate config and sources without writing the index")
 	fs.BoolVar(&full, "full", false, "force a full re-embed instead of reusing compatible chunk vectors")
 	fs.BoolVar(&verbose, "verbose", false, "include per-source details for index planning and rebuild output")
+	fs.BoolVar(&showDelta, "show-delta", false, "show governance graph changes after an incremental update")
 	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
@@ -78,7 +81,7 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 			Message: err.Error(),
 		}, 2)
 	}
-	request := indexRequest{Rebuild: rebuild, Update: update, DryRun: dryRun, Full: full, Verbose: verbose}
+	request := indexRequest{Rebuild: rebuild, Update: update, DryRun: dryRun, Full: full, Verbose: verbose, ShowDelta: showDelta}
 	modeCount := 0
 	if rebuild {
 		modeCount++
@@ -99,6 +102,12 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 		return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
 			Code:    "validation_error",
 			Message: "--full is only valid with --rebuild",
+		}, 2)
+	}
+	if showDelta && !update {
+		return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
+			Code:    "validation_error",
+			Message: "--show-delta is only valid with --update",
 		}, 2)
 	}
 
@@ -192,6 +201,9 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 	}
 	if !verbose {
 		result.Sources = nil
+	}
+	if !showDelta {
+		result.Delta = nil
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "index", request, result, nil)

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -161,7 +161,7 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 
 	var result *index.RebuildResult
 	if update {
-		result, err = runIndexUpdate(ctx, cfg, records, format, stderr)
+		result, err = runIndexUpdate(ctx, cfg, records, showDelta, format, stderr)
 	} else {
 		result, err = runIndexRebuild(ctx, cfg, records, full, format, stderr)
 	}
@@ -209,8 +209,11 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 	return writeCLISuccess(stdout, stderr, format, "index", request, result, nil)
 }
 
-func runIndexUpdate(ctx context.Context, cfg *config.Config, records *source.LoadResult, format string, stderr io.Writer) (*index.RebuildResult, error) {
+func runIndexUpdate(ctx context.Context, cfg *config.Config, records *source.LoadResult, showDelta bool, format string, stderr io.Writer) (*index.RebuildResult, error) {
 	progressReporter := indexProgressReporter(format, stderr)
+	if showDelta {
+		return index.UpdateWithDeltaContextAndOptions(ctx, cfg, records, index.UpdateOptions{ComputeDelta: true}, progressReporter)
+	}
 	return index.UpdateWithProgressContextAndOptions(ctx, cfg, records, progressReporter)
 }
 

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -137,6 +137,35 @@ path = "specs"
 	}
 }
 
+func TestRunIndexShowDeltaRequiresUpdate(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild", "--show-delta"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runIndex() exit code = %d, want 2", exitCode)
+	}
+	if !strings.Contains(stderr.String(), `--show-delta is only valid with --update`) {
+		t.Fatalf("runIndex() stderr %q does not contain show-delta validation message", stderr.String())
+	}
+}
+
 func TestRunIndexRejectsUnknownAdapterInConfig(t *testing.T) {
 	repo := t.TempDir()
 	mustWriteIndexFixture(t, repo, `

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -147,6 +147,7 @@ func renderIndexResult(w io.Writer, result *index.RebuildResult) {
 		fmt.Fprintf(w, "database: %s\n", result.IndexPath)
 		renderIndexRepoCoverage(w, result.Repos)
 		renderIndexSourceSummaries(w, result.Sources)
+		renderGovernanceDelta(w, result.Delta)
 		return
 	}
 	fmt.Fprintf(w, "indexed %d artifact(s), %d chunk(s), and %d edge(s)\n", result.ArtifactCount, result.ChunkCount, result.EdgeCount)
@@ -663,6 +664,41 @@ func renderRepoCoverageLine(repo index.RepoCoverage) string {
 		line += fmt.Sprintf(" | docs: %d", repo.DocCount)
 	}
 	return line
+}
+
+func renderGovernanceDelta(w io.Writer, delta *index.GovernanceDelta) {
+	if delta == nil {
+		return
+	}
+	fmt.Fprintf(w, "\nGovernance delta since last rebuild:\n")
+	for _, s := range delta.AddedSpecs {
+		line := fmt.Sprintf("  + %s added", s.Ref)
+		if s.Status != "" {
+			line += fmt.Sprintf(" (status: %s", s.Status)
+			if s.Domain != "" {
+				line += fmt.Sprintf(", domain: %s", s.Domain)
+			}
+			line += ")"
+		}
+		fmt.Fprintln(w, line)
+	}
+	for _, s := range delta.RemovedSpecs {
+		fmt.Fprintf(w, "  - %s removed\n", s.Ref)
+	}
+	for _, s := range delta.UpdatedSpecs {
+		line := fmt.Sprintf("  ~ %s updated", s.Ref)
+		if s.Status != "" {
+			line += fmt.Sprintf(" (status: %s)", s.Status)
+		}
+		fmt.Fprintln(w, line)
+	}
+	for _, e := range delta.AddedEdges {
+		fmt.Fprintf(w, "  + %s %s %s (%s)\n", e.FromRef, e.EdgeType, e.ToRef, e.EdgeSource)
+	}
+	for _, e := range delta.RemovedEdges {
+		fmt.Fprintf(w, "  - %s %s %s (%s)\n", e.FromRef, e.EdgeType, e.ToRef, e.EdgeSource)
+	}
+	fmt.Fprintf(w, "  summary: %s\n", delta.Summary)
 }
 
 func renderOverlapResult(w io.Writer, result *analysis.OverlapResult) {

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -698,6 +698,9 @@ func renderGovernanceDelta(w io.Writer, delta *index.GovernanceDelta) {
 	for _, e := range delta.RemovedEdges {
 		fmt.Fprintf(w, "  - %s %s %s (%s)\n", e.FromRef, e.EdgeType, e.ToRef, e.EdgeSource)
 	}
+	for _, e := range delta.UpdatedEdges {
+		fmt.Fprintf(w, "  ~ %s %s %s (%s → %s)\n", e.FromRef, e.EdgeType, e.ToRef, e.EdgeSource, e.Confidence)
+	}
 	fmt.Fprintf(w, "  summary: %s\n", delta.Summary)
 }
 

--- a/internal/index/delta.go
+++ b/internal/index/delta.go
@@ -15,6 +15,7 @@ type GovernanceDelta struct {
 	UpdatedSpecs []DeltaSpec `json:"updated_specs,omitempty"`
 	AddedEdges   []DeltaEdge `json:"added_edges,omitempty"`
 	RemovedEdges []DeltaEdge `json:"removed_edges,omitempty"`
+	UpdatedEdges []DeltaEdge `json:"updated_edges,omitempty"`
 	Summary      string      `json:"summary"`
 }
 
@@ -53,10 +54,11 @@ type snapshotEdge struct {
 
 // snapshotArtifact holds one artifact's governance-relevant metadata.
 type snapshotArtifact struct {
-	ref    string
-	title  string
-	status string
-	domain string
+	ref         string
+	title       string
+	status      string
+	domain      string
+	contentHash string
 }
 
 // snapshotEdgesContext loads all edges from the current database state.
@@ -80,7 +82,7 @@ func snapshotEdgesContext(ctx context.Context, db *sql.DB) ([]snapshotEdge, erro
 
 // snapshotSpecArtifactsContext loads spec artifact metadata from the current database state.
 func snapshotSpecArtifactsContext(ctx context.Context, db *sql.DB) ([]snapshotArtifact, error) {
-	rows, err := db.QueryContext(ctx, `SELECT ref, COALESCE(title,''), COALESCE(status,''), COALESCE(domain,'') FROM artifacts WHERE kind = 'spec'`)
+	rows, err := db.QueryContext(ctx, `SELECT ref, COALESCE(title,''), COALESCE(status,''), COALESCE(domain,''), content_hash FROM artifacts WHERE kind = 'spec'`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot spec artifacts: %w", err)
 	}
@@ -89,7 +91,7 @@ func snapshotSpecArtifactsContext(ctx context.Context, db *sql.DB) ([]snapshotAr
 	var artifacts []snapshotArtifact
 	for rows.Next() {
 		var a snapshotArtifact
-		if err := rows.Scan(&a.ref, &a.title, &a.status, &a.domain); err != nil {
+		if err := rows.Scan(&a.ref, &a.title, &a.status, &a.domain, &a.contentHash); err != nil {
 			return nil, fmt.Errorf("scan snapshot artifact: %w", err)
 		}
 		artifacts = append(artifacts, a)
@@ -118,7 +120,7 @@ func snapshotEdgesTxContext(ctx context.Context, tx *sql.Tx) ([]snapshotEdge, er
 
 // snapshotSpecArtifactsTxContext loads spec artifact metadata from within a transaction.
 func snapshotSpecArtifactsTxContext(ctx context.Context, tx *sql.Tx) ([]snapshotArtifact, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT ref, COALESCE(title,''), COALESCE(status,''), COALESCE(domain,'') FROM artifacts WHERE kind = 'spec'`)
+	rows, err := tx.QueryContext(ctx, `SELECT ref, COALESCE(title,''), COALESCE(status,''), COALESCE(domain,''), content_hash FROM artifacts WHERE kind = 'spec'`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot spec artifacts (tx): %w", err)
 	}
@@ -127,7 +129,7 @@ func snapshotSpecArtifactsTxContext(ctx context.Context, tx *sql.Tx) ([]snapshot
 	var artifacts []snapshotArtifact
 	for rows.Next() {
 		var a snapshotArtifact
-		if err := rows.Scan(&a.ref, &a.title, &a.status, &a.domain); err != nil {
+		if err := rows.Scan(&a.ref, &a.title, &a.status, &a.domain, &a.contentHash); err != nil {
 			return nil, fmt.Errorf("scan snapshot artifact (tx): %w", err)
 		}
 		artifacts = append(artifacts, a)
@@ -142,7 +144,7 @@ func computeGovernanceDelta(
 ) *GovernanceDelta {
 	delta := &GovernanceDelta{}
 
-	// Diff artifacts.
+	// Diff artifacts (including content_hash for body change detection).
 	oldArtMap := make(map[string]snapshotArtifact, len(oldArtifacts))
 	for _, a := range oldArtifacts {
 		oldArtMap[a.ref] = a
@@ -158,7 +160,7 @@ func computeGovernanceDelta(
 			delta.AddedSpecs = append(delta.AddedSpecs, DeltaSpec{
 				Ref: a.ref, Title: a.title, Status: a.status, Domain: a.domain,
 			})
-		} else if old.status != a.status || old.domain != a.domain || old.title != a.title {
+		} else if old.status != a.status || old.domain != a.domain || old.title != a.title || old.contentHash != a.contentHash {
 			delta.UpdatedSpecs = append(delta.UpdatedSpecs, DeltaSpec{
 				Ref: a.ref, Title: a.title, Status: a.status, Domain: a.domain,
 			})
@@ -172,7 +174,7 @@ func computeGovernanceDelta(
 		}
 	}
 
-	// Diff edges.
+	// Diff edges (key: from_ref+to_ref+edge_type; also detect attribute changes).
 	oldEdgeSet := make(map[edgeKey]snapshotEdge, len(oldEdges))
 	for _, e := range oldEdges {
 		oldEdgeSet[edgeKey{e.fromRef, e.toRef, e.edgeType}] = e
@@ -183,8 +185,14 @@ func computeGovernanceDelta(
 	}
 
 	for k, e := range newEdgeSet {
-		if _, existed := oldEdgeSet[k]; !existed {
+		old, existed := oldEdgeSet[k]
+		if !existed {
 			delta.AddedEdges = append(delta.AddedEdges, DeltaEdge{
+				FromRef: e.fromRef, ToRef: e.toRef, EdgeType: e.edgeType,
+				EdgeSource: e.edgeSource, Confidence: e.confidence,
+			})
+		} else if old.edgeSource != e.edgeSource || old.confidence != e.confidence {
+			delta.UpdatedEdges = append(delta.UpdatedEdges, DeltaEdge{
 				FromRef: e.fromRef, ToRef: e.toRef, EdgeType: e.edgeType,
 				EdgeSource: e.edgeSource, Confidence: e.confidence,
 			})
@@ -205,6 +213,7 @@ func computeGovernanceDelta(
 	sort.Slice(delta.UpdatedSpecs, func(i, j int) bool { return delta.UpdatedSpecs[i].Ref < delta.UpdatedSpecs[j].Ref })
 	sort.Slice(delta.AddedEdges, func(i, j int) bool { return deltaEdgeLess(delta.AddedEdges[i], delta.AddedEdges[j]) })
 	sort.Slice(delta.RemovedEdges, func(i, j int) bool { return deltaEdgeLess(delta.RemovedEdges[i], delta.RemovedEdges[j]) })
+	sort.Slice(delta.UpdatedEdges, func(i, j int) bool { return deltaEdgeLess(delta.UpdatedEdges[i], delta.UpdatedEdges[j]) })
 
 	delta.Summary = formatDeltaSummary(delta)
 	return delta
@@ -221,7 +230,7 @@ func deltaEdgeLess(a, b DeltaEdge) bool {
 }
 
 func formatDeltaSummary(delta *GovernanceDelta) string {
-	parts := make([]string, 0, 6)
+	parts := make([]string, 0, 8)
 	if n := len(delta.AddedSpecs); n > 0 {
 		parts = append(parts, fmt.Sprintf("%d spec(s) added", n))
 	}
@@ -236,6 +245,9 @@ func formatDeltaSummary(delta *GovernanceDelta) string {
 	}
 	if n := len(delta.RemovedEdges); n > 0 {
 		parts = append(parts, fmt.Sprintf("%d edge(s) removed", n))
+	}
+	if n := len(delta.UpdatedEdges); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d edge(s) updated", n))
 	}
 	if len(parts) == 0 {
 		return "no governance changes"

--- a/internal/index/delta.go
+++ b/internal/index/delta.go
@@ -1,0 +1,248 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+)
+
+// GovernanceDelta reports the governance posture changes between the old and
+// new index state after an incremental update.
+type GovernanceDelta struct {
+	AddedSpecs   []DeltaSpec `json:"added_specs,omitempty"`
+	RemovedSpecs []DeltaSpec `json:"removed_specs,omitempty"`
+	UpdatedSpecs []DeltaSpec `json:"updated_specs,omitempty"`
+	AddedEdges   []DeltaEdge `json:"added_edges,omitempty"`
+	RemovedEdges []DeltaEdge `json:"removed_edges,omitempty"`
+	Summary      string      `json:"summary"`
+}
+
+// DeltaSpec reports an artifact change in the governance delta.
+type DeltaSpec struct {
+	Ref    string `json:"ref"`
+	Title  string `json:"title,omitempty"`
+	Status string `json:"status,omitempty"`
+	Domain string `json:"domain,omitempty"`
+}
+
+// DeltaEdge reports a single governance edge change.
+type DeltaEdge struct {
+	FromRef    string `json:"from_ref"`
+	ToRef      string `json:"to_ref"`
+	EdgeType   string `json:"edge_type"`
+	EdgeSource string `json:"edge_source"`
+	Confidence string `json:"confidence,omitempty"`
+}
+
+// edgeKey is the identity of an edge for diff purposes.
+type edgeKey struct {
+	fromRef  string
+	toRef    string
+	edgeType string
+}
+
+// snapshotEdge holds one edge row from the database.
+type snapshotEdge struct {
+	fromRef    string
+	toRef      string
+	edgeType   string
+	edgeSource string
+	confidence string
+}
+
+// snapshotArtifact holds one artifact's governance-relevant metadata.
+type snapshotArtifact struct {
+	ref    string
+	title  string
+	status string
+	domain string
+}
+
+// snapshotEdgesContext loads all edges from the current database state.
+func snapshotEdgesContext(ctx context.Context, db *sql.DB) ([]snapshotEdge, error) {
+	rows, err := db.QueryContext(ctx, `SELECT from_ref, to_ref, edge_type, edge_source, confidence FROM edges`)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot edges: %w", err)
+	}
+	defer rows.Close()
+
+	var edges []snapshotEdge
+	for rows.Next() {
+		var e snapshotEdge
+		if err := rows.Scan(&e.fromRef, &e.toRef, &e.edgeType, &e.edgeSource, &e.confidence); err != nil {
+			return nil, fmt.Errorf("scan snapshot edge: %w", err)
+		}
+		edges = append(edges, e)
+	}
+	return edges, rows.Err()
+}
+
+// snapshotSpecArtifactsContext loads spec artifact metadata from the current database state.
+func snapshotSpecArtifactsContext(ctx context.Context, db *sql.DB) ([]snapshotArtifact, error) {
+	rows, err := db.QueryContext(ctx, `SELECT ref, COALESCE(title,''), COALESCE(status,''), COALESCE(domain,'') FROM artifacts WHERE kind = 'spec'`)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot spec artifacts: %w", err)
+	}
+	defer rows.Close()
+
+	var artifacts []snapshotArtifact
+	for rows.Next() {
+		var a snapshotArtifact
+		if err := rows.Scan(&a.ref, &a.title, &a.status, &a.domain); err != nil {
+			return nil, fmt.Errorf("scan snapshot artifact: %w", err)
+		}
+		artifacts = append(artifacts, a)
+	}
+	return artifacts, rows.Err()
+}
+
+// snapshotEdgesTxContext loads all edges from within a transaction.
+func snapshotEdgesTxContext(ctx context.Context, tx *sql.Tx) ([]snapshotEdge, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT from_ref, to_ref, edge_type, edge_source, confidence FROM edges`)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot edges (tx): %w", err)
+	}
+	defer rows.Close()
+
+	var edges []snapshotEdge
+	for rows.Next() {
+		var e snapshotEdge
+		if err := rows.Scan(&e.fromRef, &e.toRef, &e.edgeType, &e.edgeSource, &e.confidence); err != nil {
+			return nil, fmt.Errorf("scan snapshot edge (tx): %w", err)
+		}
+		edges = append(edges, e)
+	}
+	return edges, rows.Err()
+}
+
+// snapshotSpecArtifactsTxContext loads spec artifact metadata from within a transaction.
+func snapshotSpecArtifactsTxContext(ctx context.Context, tx *sql.Tx) ([]snapshotArtifact, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT ref, COALESCE(title,''), COALESCE(status,''), COALESCE(domain,'') FROM artifacts WHERE kind = 'spec'`)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot spec artifacts (tx): %w", err)
+	}
+	defer rows.Close()
+
+	var artifacts []snapshotArtifact
+	for rows.Next() {
+		var a snapshotArtifact
+		if err := rows.Scan(&a.ref, &a.title, &a.status, &a.domain); err != nil {
+			return nil, fmt.Errorf("scan snapshot artifact (tx): %w", err)
+		}
+		artifacts = append(artifacts, a)
+	}
+	return artifacts, rows.Err()
+}
+
+// computeGovernanceDelta computes the governance changes between old and new states.
+func computeGovernanceDelta(
+	oldArtifacts []snapshotArtifact, newArtifacts []snapshotArtifact,
+	oldEdges []snapshotEdge, newEdges []snapshotEdge,
+) *GovernanceDelta {
+	delta := &GovernanceDelta{}
+
+	// Diff artifacts.
+	oldArtMap := make(map[string]snapshotArtifact, len(oldArtifacts))
+	for _, a := range oldArtifacts {
+		oldArtMap[a.ref] = a
+	}
+	newArtMap := make(map[string]snapshotArtifact, len(newArtifacts))
+	for _, a := range newArtifacts {
+		newArtMap[a.ref] = a
+	}
+
+	for _, a := range newArtifacts {
+		old, existed := oldArtMap[a.ref]
+		if !existed {
+			delta.AddedSpecs = append(delta.AddedSpecs, DeltaSpec{
+				Ref: a.ref, Title: a.title, Status: a.status, Domain: a.domain,
+			})
+		} else if old.status != a.status || old.domain != a.domain || old.title != a.title {
+			delta.UpdatedSpecs = append(delta.UpdatedSpecs, DeltaSpec{
+				Ref: a.ref, Title: a.title, Status: a.status, Domain: a.domain,
+			})
+		}
+	}
+	for _, a := range oldArtifacts {
+		if _, exists := newArtMap[a.ref]; !exists {
+			delta.RemovedSpecs = append(delta.RemovedSpecs, DeltaSpec{
+				Ref: a.ref, Title: a.title, Status: a.status, Domain: a.domain,
+			})
+		}
+	}
+
+	// Diff edges.
+	oldEdgeSet := make(map[edgeKey]snapshotEdge, len(oldEdges))
+	for _, e := range oldEdges {
+		oldEdgeSet[edgeKey{e.fromRef, e.toRef, e.edgeType}] = e
+	}
+	newEdgeSet := make(map[edgeKey]snapshotEdge, len(newEdges))
+	for _, e := range newEdges {
+		newEdgeSet[edgeKey{e.fromRef, e.toRef, e.edgeType}] = e
+	}
+
+	for k, e := range newEdgeSet {
+		if _, existed := oldEdgeSet[k]; !existed {
+			delta.AddedEdges = append(delta.AddedEdges, DeltaEdge{
+				FromRef: e.fromRef, ToRef: e.toRef, EdgeType: e.edgeType,
+				EdgeSource: e.edgeSource, Confidence: e.confidence,
+			})
+		}
+	}
+	for k, e := range oldEdgeSet {
+		if _, exists := newEdgeSet[k]; !exists {
+			delta.RemovedEdges = append(delta.RemovedEdges, DeltaEdge{
+				FromRef: e.fromRef, ToRef: e.toRef, EdgeType: e.edgeType,
+				EdgeSource: e.edgeSource, Confidence: e.confidence,
+			})
+		}
+	}
+
+	// Sort for deterministic output.
+	sort.Slice(delta.AddedSpecs, func(i, j int) bool { return delta.AddedSpecs[i].Ref < delta.AddedSpecs[j].Ref })
+	sort.Slice(delta.RemovedSpecs, func(i, j int) bool { return delta.RemovedSpecs[i].Ref < delta.RemovedSpecs[j].Ref })
+	sort.Slice(delta.UpdatedSpecs, func(i, j int) bool { return delta.UpdatedSpecs[i].Ref < delta.UpdatedSpecs[j].Ref })
+	sort.Slice(delta.AddedEdges, func(i, j int) bool { return deltaEdgeLess(delta.AddedEdges[i], delta.AddedEdges[j]) })
+	sort.Slice(delta.RemovedEdges, func(i, j int) bool { return deltaEdgeLess(delta.RemovedEdges[i], delta.RemovedEdges[j]) })
+
+	delta.Summary = formatDeltaSummary(delta)
+	return delta
+}
+
+func deltaEdgeLess(a, b DeltaEdge) bool {
+	if a.FromRef != b.FromRef {
+		return a.FromRef < b.FromRef
+	}
+	if a.ToRef != b.ToRef {
+		return a.ToRef < b.ToRef
+	}
+	return a.EdgeType < b.EdgeType
+}
+
+func formatDeltaSummary(delta *GovernanceDelta) string {
+	parts := make([]string, 0, 6)
+	if n := len(delta.AddedSpecs); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d spec(s) added", n))
+	}
+	if n := len(delta.RemovedSpecs); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d spec(s) removed", n))
+	}
+	if n := len(delta.UpdatedSpecs); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d spec(s) updated", n))
+	}
+	if n := len(delta.AddedEdges); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d edge(s) added", n))
+	}
+	if n := len(delta.RemovedEdges); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d edge(s) removed", n))
+	}
+	if len(parts) == 0 {
+		return "no governance changes"
+	}
+	result := parts[0]
+	for i := 1; i < len(parts); i++ {
+		result += ", " + parts[i]
+	}
+	return result
+}

--- a/internal/index/delta_test.go
+++ b/internal/index/delta_test.go
@@ -1,0 +1,122 @@
+package index
+
+import (
+	"testing"
+)
+
+func TestComputeGovernanceDelta_NoChanges(t *testing.T) {
+	t.Parallel()
+	arts := []snapshotArtifact{{ref: "SPEC-001", title: "Auth", status: "accepted", domain: "auth"}}
+	edges := []snapshotEdge{{fromRef: "SPEC-001", toRef: "code://a.go", edgeType: "applies_to", edgeSource: "manual", confidence: "extracted"}}
+
+	delta := computeGovernanceDelta(arts, arts, edges, edges)
+	if len(delta.AddedSpecs) != 0 || len(delta.RemovedSpecs) != 0 || len(delta.UpdatedSpecs) != 0 {
+		t.Fatalf("expected no spec changes, got added=%d removed=%d updated=%d", len(delta.AddedSpecs), len(delta.RemovedSpecs), len(delta.UpdatedSpecs))
+	}
+	if len(delta.AddedEdges) != 0 || len(delta.RemovedEdges) != 0 {
+		t.Fatalf("expected no edge changes, got added=%d removed=%d", len(delta.AddedEdges), len(delta.RemovedEdges))
+	}
+	if delta.Summary != "no governance changes" {
+		t.Fatalf("unexpected summary: %s", delta.Summary)
+	}
+}
+
+func TestComputeGovernanceDelta_AddedSpec(t *testing.T) {
+	t.Parallel()
+	oldArts := []snapshotArtifact{{ref: "SPEC-001", title: "Auth", status: "accepted", domain: "auth"}}
+	newArts := []snapshotArtifact{
+		{ref: "SPEC-001", title: "Auth", status: "accepted", domain: "auth"},
+		{ref: "SPEC-002", title: "Rate Limiting", status: "draft", domain: "api"},
+	}
+	oldEdges := []snapshotEdge{{fromRef: "SPEC-001", toRef: "code://a.go", edgeType: "applies_to", edgeSource: "manual", confidence: "extracted"}}
+	newEdges := []snapshotEdge{
+		{fromRef: "SPEC-001", toRef: "code://a.go", edgeType: "applies_to", edgeSource: "manual", confidence: "extracted"},
+		{fromRef: "SPEC-002", toRef: "code://b.go", edgeType: "applies_to", edgeSource: "inferred", confidence: "inferred"},
+	}
+
+	delta := computeGovernanceDelta(oldArts, newArts, oldEdges, newEdges)
+	if len(delta.AddedSpecs) != 1 {
+		t.Fatalf("expected 1 added spec, got %d", len(delta.AddedSpecs))
+	}
+	if delta.AddedSpecs[0].Ref != "SPEC-002" {
+		t.Fatalf("expected added spec SPEC-002, got %s", delta.AddedSpecs[0].Ref)
+	}
+	if len(delta.AddedEdges) != 1 {
+		t.Fatalf("expected 1 added edge, got %d", len(delta.AddedEdges))
+	}
+	if delta.AddedEdges[0].FromRef != "SPEC-002" || delta.AddedEdges[0].ToRef != "code://b.go" {
+		t.Fatalf("unexpected added edge: %+v", delta.AddedEdges[0])
+	}
+}
+
+func TestComputeGovernanceDelta_RemovedSpec(t *testing.T) {
+	t.Parallel()
+	oldArts := []snapshotArtifact{
+		{ref: "SPEC-001", title: "Auth", status: "accepted", domain: "auth"},
+		{ref: "SPEC-002", title: "Rate Limiting", status: "accepted", domain: "api"},
+	}
+	newArts := []snapshotArtifact{
+		{ref: "SPEC-001", title: "Auth", status: "accepted", domain: "auth"},
+	}
+	oldEdges := []snapshotEdge{
+		{fromRef: "SPEC-001", toRef: "code://a.go", edgeType: "applies_to", edgeSource: "manual", confidence: "extracted"},
+		{fromRef: "SPEC-002", toRef: "code://b.go", edgeType: "applies_to", edgeSource: "manual", confidence: "extracted"},
+	}
+	newEdges := []snapshotEdge{
+		{fromRef: "SPEC-001", toRef: "code://a.go", edgeType: "applies_to", edgeSource: "manual", confidence: "extracted"},
+	}
+
+	delta := computeGovernanceDelta(oldArts, newArts, oldEdges, newEdges)
+	if len(delta.RemovedSpecs) != 1 || delta.RemovedSpecs[0].Ref != "SPEC-002" {
+		t.Fatalf("expected 1 removed spec SPEC-002, got %+v", delta.RemovedSpecs)
+	}
+	if len(delta.RemovedEdges) != 1 || delta.RemovedEdges[0].FromRef != "SPEC-002" {
+		t.Fatalf("expected 1 removed edge from SPEC-002, got %+v", delta.RemovedEdges)
+	}
+}
+
+func TestComputeGovernanceDelta_UpdatedSpec(t *testing.T) {
+	t.Parallel()
+	oldArts := []snapshotArtifact{{ref: "SPEC-001", title: "Auth", status: "draft", domain: "auth"}}
+	newArts := []snapshotArtifact{{ref: "SPEC-001", title: "Auth", status: "accepted", domain: "auth"}}
+
+	delta := computeGovernanceDelta(oldArts, newArts, nil, nil)
+	if len(delta.UpdatedSpecs) != 1 || delta.UpdatedSpecs[0].Status != "accepted" {
+		t.Fatalf("expected 1 updated spec with status accepted, got %+v", delta.UpdatedSpecs)
+	}
+}
+
+func TestComputeGovernanceDelta_SummaryFormat(t *testing.T) {
+	t.Parallel()
+	oldArts := []snapshotArtifact{}
+	newArts := []snapshotArtifact{
+		{ref: "SPEC-001", title: "A", status: "draft"},
+		{ref: "SPEC-002", title: "B", status: "draft"},
+	}
+	oldEdges := []snapshotEdge{}
+	newEdges := []snapshotEdge{
+		{fromRef: "SPEC-001", toRef: "code://a.go", edgeType: "applies_to", edgeSource: "manual", confidence: "extracted"},
+	}
+
+	delta := computeGovernanceDelta(oldArts, newArts, oldEdges, newEdges)
+	if delta.Summary != "2 spec(s) added, 1 edge(s) added" {
+		t.Fatalf("unexpected summary: %q", delta.Summary)
+	}
+}
+
+func TestComputeGovernanceDelta_SortOrder(t *testing.T) {
+	t.Parallel()
+	oldArts := []snapshotArtifact{}
+	newArts := []snapshotArtifact{
+		{ref: "SPEC-003"},
+		{ref: "SPEC-001"},
+		{ref: "SPEC-002"},
+	}
+
+	delta := computeGovernanceDelta(oldArts, newArts, nil, nil)
+	for i := 1; i < len(delta.AddedSpecs); i++ {
+		if delta.AddedSpecs[i].Ref < delta.AddedSpecs[i-1].Ref {
+			t.Fatalf("added specs not sorted: %v", delta.AddedSpecs)
+		}
+	}
+}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -47,6 +47,7 @@ type RebuildResult struct {
 	ContentFingerprint  string                     `json:"content_fingerprint"`
 	Repos               []RepoCoverage             `json:"repo_coverage,omitempty"`
 	Sources             []source.LoadSourceSummary `json:"sources,omitempty"`
+	Delta               *GovernanceDelta           `json:"delta,omitempty"`
 }
 
 // RebuildOptions controls optional rebuild behavior.

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -257,6 +257,16 @@ func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Confi
 	}
 	result.ChunkCount += unchangedChunkCount
 
+	// Snapshot edges and spec artifacts before edge rebuild for delta computation.
+	oldEdges, err := snapshotEdgesContext(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot old edges: %w", err)
+	}
+	oldArtifacts, err := snapshotSpecArtifactsContext(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot old artifacts: %w", err)
+	}
+
 	// Step 10e: Full edge rebuild.
 	if _, err := tx.ExecContext(ctx, `DELETE FROM edges`); err != nil {
 		return nil, fmt.Errorf("delete edges: %w", err)
@@ -297,6 +307,17 @@ func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Confi
 	}
 	result.EdgeCount += inferredCount
 	result.InferredEdgeCount = inferredCount
+
+	// Compute governance delta from edge and artifact snapshots.
+	newEdges, err := snapshotEdgesTxContext(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot new edges: %w", err)
+	}
+	newArtifacts, err := snapshotSpecArtifactsTxContext(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot new artifacts: %w", err)
+	}
+	result.Delta = computeGovernanceDelta(oldArtifacts, newArtifacts, oldEdges, newEdges)
 
 	// Step 10f: Upsert metadata.
 	if err := upsertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -36,19 +36,30 @@ func IsUpdatePrecondition(err error) bool {
 	return errors.As(err, &target)
 }
 
+// UpdateOptions controls optional update behavior.
+type UpdateOptions struct {
+	ComputeDelta bool
+}
+
 // UpdateContextWithOptions performs an incremental index update, writing only
 // changed artifacts to the existing database.
 func UpdateContextWithOptions(ctx context.Context, cfg *config.Config, records *source.LoadResult) (*RebuildResult, error) {
-	return updateContext(ctx, cfg, records, nil)
+	return updateContext(ctx, cfg, records, UpdateOptions{}, nil)
 }
 
 // UpdateWithProgressContextAndOptions performs an incremental index update with
 // progress reporting.
 func UpdateWithProgressContextAndOptions(ctx context.Context, cfg *config.Config, records *source.LoadResult, reporter RebuildProgressReporter) (*RebuildResult, error) {
-	return updateContext(ctx, cfg, records, reporter)
+	return updateContext(ctx, cfg, records, UpdateOptions{}, reporter)
 }
 
-func updateContext(ctx context.Context, cfg *config.Config, records *source.LoadResult, reporter RebuildProgressReporter) (*RebuildResult, error) {
+// UpdateWithDeltaContextAndOptions performs an incremental index update with
+// progress reporting and governance delta computation.
+func UpdateWithDeltaContextAndOptions(ctx context.Context, cfg *config.Config, records *source.LoadResult, options UpdateOptions, reporter RebuildProgressReporter) (*RebuildResult, error) {
+	return updateContext(ctx, cfg, records, options, reporter)
+}
+
+func updateContext(ctx context.Context, cfg *config.Config, records *source.LoadResult, options UpdateOptions, reporter RebuildProgressReporter) (*RebuildResult, error) {
 	embedder, err := prepareRebuildContext(ctx, cfg, records)
 	if err != nil {
 		return nil, err
@@ -77,7 +88,7 @@ func updateContext(ctx context.Context, cfg *config.Config, records *source.Load
 		return nil, fmt.Errorf("create index backup: %w", err)
 	}
 
-	result, err := applyUpdateContext(ctx, indexPath, cfg, dimension, embedder, records, reporter)
+	result, err := applyUpdateContext(ctx, indexPath, cfg, dimension, embedder, records, options, reporter)
 	if err != nil {
 		// Restore from backup on any failure. Keep the backup in place
 		// if restoration itself fails so the user has a recovery path.
@@ -92,7 +103,7 @@ func updateContext(ctx context.Context, cfg *config.Config, records *source.Load
 	return result, nil
 }
 
-func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Config, dimension int, embedder Embedder, records *source.LoadResult, reporter RebuildProgressReporter) (*RebuildResult, error) {
+func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Config, dimension int, embedder Embedder, records *source.LoadResult, options UpdateOptions, reporter RebuildProgressReporter) (*RebuildResult, error) {
 	db, err := openReadWriteContext(ctx, indexPath)
 	if err != nil {
 		return nil, fmt.Errorf("open index for update: %w", err)
@@ -258,13 +269,17 @@ func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Confi
 	result.ChunkCount += unchangedChunkCount
 
 	// Snapshot edges and spec artifacts before edge rebuild for delta computation.
-	oldEdges, err := snapshotEdgesContext(ctx, db)
-	if err != nil {
-		return nil, fmt.Errorf("snapshot old edges: %w", err)
-	}
-	oldArtifacts, err := snapshotSpecArtifactsContext(ctx, db)
-	if err != nil {
-		return nil, fmt.Errorf("snapshot old artifacts: %w", err)
+	var oldEdges []snapshotEdge
+	var oldArtifacts []snapshotArtifact
+	if options.ComputeDelta {
+		oldEdges, err = snapshotEdgesContext(ctx, db)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot old edges: %w", err)
+		}
+		oldArtifacts, err = snapshotSpecArtifactsContext(ctx, db)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot old artifacts: %w", err)
+		}
 	}
 
 	// Step 10e: Full edge rebuild.
@@ -309,15 +324,17 @@ func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Confi
 	result.InferredEdgeCount = inferredCount
 
 	// Compute governance delta from edge and artifact snapshots.
-	newEdges, err := snapshotEdgesTxContext(ctx, tx)
-	if err != nil {
-		return nil, fmt.Errorf("snapshot new edges: %w", err)
+	if options.ComputeDelta {
+		newEdges, deltaErr := snapshotEdgesTxContext(ctx, tx)
+		if deltaErr != nil {
+			return nil, fmt.Errorf("snapshot new edges: %w", deltaErr)
+		}
+		newArtifacts, deltaErr := snapshotSpecArtifactsTxContext(ctx, tx)
+		if deltaErr != nil {
+			return nil, fmt.Errorf("snapshot new artifacts: %w", deltaErr)
+		}
+		result.Delta = computeGovernanceDelta(oldArtifacts, newArtifacts, oldEdges, newEdges)
 	}
-	newArtifacts, err := snapshotSpecArtifactsTxContext(ctx, tx)
-	if err != nil {
-		return nil, fmt.Errorf("snapshot new artifacts: %w", err)
-	}
-	result.Delta = computeGovernanceDelta(oldArtifacts, newArtifacts, oldEdges, newEdges)
 
 	// Step 10f: Upsert metadata.
 	if err := upsertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {

--- a/internal/index/update_test.go
+++ b/internal/index/update_test.go
@@ -485,6 +485,101 @@ func TestUpdatePreservesDBOnFailure(t *testing.T) {
 	}
 }
 
+func TestUpdateDeltaReportsAddedSpec(t *testing.T) {
+	t.Parallel()
+
+	indexPath := filepath.Join(t.TempDir(), "pituitary.db")
+	repoDir := t.TempDir()
+
+	// Set up a spec workspace with one spec.
+	mustWriteFile(t, filepath.Join(repoDir, "specs", "auth", "spec.toml"), `id = "SPEC-001"
+title = "Authentication"
+status = "accepted"
+domain = "auth"
+body = "body.md"
+`)
+	mustWriteFile(t, filepath.Join(repoDir, "specs", "auth", "body.md"), "# Authentication\n\nAuth spec body.\n")
+
+	configPath := filepath.Join(t.TempDir(), "pituitary.toml")
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repoDir)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	cfg, err := loadAndRebuild(t, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a second spec.
+	mustWriteFile(t, filepath.Join(repoDir, "specs", "rate-limit", "spec.toml"), `id = "SPEC-002"
+title = "Rate Limiting"
+status = "draft"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(t, filepath.Join(repoDir, "specs", "rate-limit", "body.md"), "# Rate Limiting\n\nRate limit spec body.\n")
+
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+
+	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	if err != nil {
+		t.Fatalf("UpdateContextWithOptions() error = %v", err)
+	}
+
+	if result.Delta == nil {
+		t.Fatal("expected non-nil delta")
+	}
+	if len(result.Delta.AddedSpecs) != 1 {
+		t.Fatalf("expected 1 added spec, got %d", len(result.Delta.AddedSpecs))
+	}
+	if result.Delta.AddedSpecs[0].Ref != "SPEC-002" {
+		t.Fatalf("expected added spec SPEC-002, got %s", result.Delta.AddedSpecs[0].Ref)
+	}
+	if !strings.Contains(result.Delta.Summary, "1 spec(s) added") {
+		t.Fatalf("expected summary to mention added spec, got %q", result.Delta.Summary)
+	}
+}
+
+func TestUpdateDeltaNoOpHasNoChanges(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	if err != nil {
+		t.Fatalf("UpdateContextWithOptions() error = %v", err)
+	}
+
+	if result.Delta == nil {
+		t.Fatal("expected non-nil delta")
+	}
+	if result.Delta.Summary != "no governance changes" {
+		t.Fatalf("expected no governance changes, got %q", result.Delta.Summary)
+	}
+}
+
 // loadAndRebuild loads config and performs an initial rebuild.
 func loadAndRebuild(t *testing.T, configPath string) (*config.Config, error) {
 	t.Helper()

--- a/internal/index/update_test.go
+++ b/internal/index/update_test.go
@@ -536,9 +536,9 @@ body = "body.md"
 		t.Fatalf("source.LoadFromConfig() error = %v", err)
 	}
 
-	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	result, err := UpdateWithDeltaContextAndOptions(context.Background(), cfg, records, UpdateOptions{ComputeDelta: true}, nil)
 	if err != nil {
-		t.Fatalf("UpdateContextWithOptions() error = %v", err)
+		t.Fatalf("UpdateWithDeltaContextAndOptions() error = %v", err)
 	}
 
 	if result.Delta == nil {
@@ -567,9 +567,9 @@ func TestUpdateDeltaNoOpHasNoChanges(t *testing.T) {
 		t.Fatalf("Rebuild() error = %v", err)
 	}
 
-	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	result, err := UpdateWithDeltaContextAndOptions(context.Background(), cfg, records, UpdateOptions{ComputeDelta: true}, nil)
 	if err != nil {
-		t.Fatalf("UpdateContextWithOptions() error = %v", err)
+		t.Fatalf("UpdateWithDeltaContextAndOptions() error = %v", err)
 	}
 
 	if result.Delta == nil {


### PR DESCRIPTION
## Summary
- Adds `GovernanceDelta` computation to the incremental update path, snapshotting edges and spec artifacts before/after the edge rebuild to produce a structured changelog
- New `--show-delta` flag on `index --update` surfaces added/removed/updated specs and edges in both text and JSON output
- Comprehensive unit and integration tests for delta computation and CLI flag validation

Closes #265

## Test plan
- [x] Unit tests for `computeGovernanceDelta` (no-change, add, remove, update, sorting)
- [x] Integration tests through `UpdateContextWithOptions` (added spec delta, no-op delta)
- [x] CLI test for `--show-delta` flag validation (rejects without `--update`)
- [x] Full `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)