### PR TITLE
feat(index): spec family discovery via dependency graph clustering

### DIFF
--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/analysis"
 	"github.com/dusk-network/pituitary/internal/app"
 	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
 )
 
 func runAnalyzeImpact(args []string, stdout, stderr io.Writer) int {
@@ -128,5 +129,38 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 		return writeCLIError(stdout, stderr, format, "analyze-impact", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
+	// Annotate cross-family impact.
+	annotateCrossFamilyImpact(ctx, resolvedConfigPath, request.SpecRef, operation.Result)
+
 	return writeCLISuccess(stdout, stderr, format, "analyze-impact", operation.Request, operation.Result, nil)
+}
+
+func annotateCrossFamilyImpact(ctx context.Context, configPath string, sourceRef string, result *analysis.AnalyzeImpactResult) {
+	if result == nil || len(result.AffectedSpecs) == 0 || sourceRef == "" {
+		return
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return
+	}
+	familyResult, err := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
+	if err != nil || len(familyResult.Assignments) == 0 {
+		return
+	}
+
+	assignmentMap := make(map[string]int)
+	for _, a := range familyResult.Assignments {
+		assignmentMap[a.Ref] = a.FamilyID
+	}
+
+	sourceFamily, ok := assignmentMap[sourceRef]
+	if !ok {
+		return
+	}
+
+	for i := range result.AffectedSpecs {
+		if targetFamily, exists := assignmentMap[result.AffectedSpecs[i].Ref]; exists && targetFamily != sourceFamily {
+			result.AffectedSpecs[i].CrossFamily = true
+		}
+	}
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -439,8 +439,36 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 			}
 		}
 	}
+	renderSpecFamilies(w, result.Families)
 	for _, guidance := range result.Guidance {
 		fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
+	}
+}
+
+func renderSpecFamilies(w io.Writer, families *index.FamilyResult) {
+	if families == nil || len(families.Families) == 0 {
+		return
+	}
+	p := presentationForWriter(w)
+	fmt.Fprintf(w, "  %s\n", p.white("SPEC FAMILIES"))
+	for i, family := range families.Families {
+		memberList := strings.Join(family.Members, ", ")
+		fmt.Fprintf(w, "  %s family %d (%d member(s), cohesion: %.2f): %s\n",
+			p.treeItem(i == len(families.Families)-1 && len(families.Ungoverned) == 0),
+			family.ID, family.Size, family.Cohesion, memberList)
+	}
+	if len(families.Ungoverned) > 0 {
+		fmt.Fprintf(w, "  %s ungoverned files: %d\n", p.dim("coverage gap:"), len(families.Ungoverned))
+		limit := 5
+		if len(families.Ungoverned) < limit {
+			limit = len(families.Ungoverned)
+		}
+		for _, path := range families.Ungoverned[:limit] {
+			fmt.Fprintf(w, "    %s %s\n", p.cross(), path)
+		}
+		if len(families.Ungoverned) > 5 {
+			fmt.Fprintf(w, "    %s ... and %d more\n", p.dim(""), len(families.Ungoverned)-5)
+		}
 	}
 }
 

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -140,24 +140,32 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 	// Post-filter by family if --family was specified.
 	if familyID >= 0 && operation.Result != nil {
 		cfg, cfgErr := config.Load(resolvedConfigPath)
-		if cfgErr == nil {
-			familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
-			if famErr == nil {
-				familyMembers := make(map[string]bool)
-				for _, a := range familyResult.Assignments {
-					if a.FamilyID == familyID {
-						familyMembers[a.Ref] = true
-					}
-				}
-				var filtered []index.SearchSpecMatch
-				for _, m := range operation.Result.Matches {
-					if familyMembers[m.Ref] {
-						filtered = append(filtered, m)
-					}
-				}
-				operation.Result.Matches = filtered
+		if cfgErr != nil {
+			return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssue{
+				Code:    "config_error",
+				Message: fmt.Sprintf("failed to load config for --family filtering: %v", cfgErr),
+			}, 2)
+		}
+		familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
+		if famErr != nil {
+			return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssue{
+				Code:    "internal_error",
+				Message: fmt.Sprintf("failed to compute families for --family filtering: %v", famErr),
+			}, 2)
+		}
+		familyMembers := make(map[string]bool)
+		for _, a := range familyResult.Assignments {
+			if a.FamilyID == familyID {
+				familyMembers[a.Ref] = true
 			}
 		}
+		var filtered []index.SearchSpecMatch
+		for _, m := range operation.Result.Matches {
+			if familyMembers[m.Ref] {
+				filtered = append(filtered, m)
+			}
+		}
+		operation.Result.Matches = filtered
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "search-specs", operation.Request, operation.Result, nil)

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -40,6 +40,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 		configPath  string
 		statuses    searchSpecsFlagList
 		limit       int
+		familyID    int
 	)
 	fs.StringVar(&query, "query", "", "semantic query")
 	fs.StringVar(&requestFile, "request-file", "", "path to search request JSON, or - for stdin")
@@ -48,6 +49,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 	fs.StringVar(&domain, "domain", "", "filter by domain")
 	fs.Var(&statuses, "status", "filter by status; repeat to set multiple statuses")
 	fs.IntVar(&limit, "limit", 10, "maximum matches to return")
+	fs.IntVar(&familyID, "family", -1, "filter results to specs in the given family ID")
 
 	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
 		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
@@ -133,6 +135,29 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 	operation := app.SearchSpecs(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
 		return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
+	}
+
+	// Post-filter by family if --family was specified.
+	if familyID >= 0 && operation.Result != nil {
+		cfg, cfgErr := config.Load(resolvedConfigPath)
+		if cfgErr == nil {
+			familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
+			if famErr == nil {
+				familyMembers := make(map[string]bool)
+				for _, a := range familyResult.Assignments {
+					if a.FamilyID == familyID {
+						familyMembers[a.Ref] = true
+					}
+				}
+				var filtered []index.SearchSpecMatch
+				for _, m := range operation.Result.Matches {
+					if familyMembers[m.Ref] {
+						filtered = append(filtered, m)
+					}
+				}
+				operation.Result.Matches = filtered
+			}
+		}
 	}
 
 	return writeCLISuccess(stdout, stderr, format, "search-specs", operation.Request, operation.Result, nil)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -133,7 +133,11 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 	statusOut := newStatusResult(result, resolution)
 	if showFamilies && statusOut != nil && statusOut.IndexExists {
 		familyResult, err := index.DiscoverFamiliesContext(ctx, result.Index.IndexPath)
-		if err == nil {
+		if err != nil {
+			statusOut.Guidance = append(statusOut.Guidance,
+				fmt.Sprintf("unable to discover families: %v", err),
+			)
+		} else {
 			statusOut.Families = familyResult
 		}
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -34,6 +34,7 @@ type statusResult struct {
 	Repos             []index.RepoCoverage       `json:"repo_coverage,omitempty"`
 	ArtifactLocations *statusArtifactLocation    `json:"artifact_locations,omitempty"`
 	RelationGraph     *index.RelationGraphStatus `json:"relation_graph,omitempty"`
+	Families          *index.FamilyResult        `json:"families,omitempty"`
 	Runtime           *runtimeprobe.Result       `json:"runtime,omitempty"`
 	Guidance          []string                   `json:"guidance,omitempty"`
 }
@@ -74,10 +75,12 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 		format       string
 		configPath   string
 		checkRuntime string
+		showFamilies bool
 	)
 	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 	fs.StringVar(&configPath, "config", "", "path to workspace config")
 	fs.StringVar(&checkRuntime, "check-runtime", string(runtimeprobe.ScopeNone), "runtime probe scope: none, embedder, analysis, or all")
+	fs.BoolVar(&showFamilies, "show-families", false, "discover and display spec families via dependency graph clustering")
 
 	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
 		return writeCLIError(stdout, stderr, format, "status", nil, cliIssue{
@@ -127,7 +130,15 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 	}
 	result := response.Result
 
-	return writeCLISuccess(stdout, stderr, format, "status", request, newStatusResult(result, resolution), nil)
+	statusOut := newStatusResult(result, resolution)
+	if showFamilies && statusOut != nil && statusOut.IndexExists {
+		familyResult, err := index.DiscoverFamiliesContext(ctx, result.Index.IndexPath)
+		if err == nil {
+			statusOut.Families = familyResult
+		}
+	}
+
+	return writeCLISuccess(stdout, stderr, format, "status", request, statusOut, nil)
 }
 
 func newStatusResult(result *app.StatusResult, resolution *configResolution) *statusResult {

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -36,6 +36,7 @@ type ImpactedSpec struct {
 	Severity           string                     `json:"severity,omitempty"`
 	SeverityConfidence float64                    `json:"severity_confidence,omitempty"`
 	SeverityReason     string                     `json:"severity_reason,omitempty"`
+	CrossFamily        bool                       `json:"cross_family,omitempty"`
 }
 
 // ImpactedRef reports one affected code or config reference.

--- a/internal/index/family.go
+++ b/internal/index/family.go
@@ -63,7 +63,10 @@ func discoverFamiliesDBContext(ctx context.Context, db *sql.DB) (*FamilyResult, 
 	result := buildFamilyResult(specRefs, communities, adj)
 
 	// Find ungoverned code files: files in ast_cache not covered by any applies_to edge.
-	result.Ungoverned, _ = findUngovernedFilesContext(ctx, db)
+	result.Ungoverned, err = findUngovernedFilesContext(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("find ungoverned files: %w", err)
+	}
 
 	return result, nil
 }
@@ -185,9 +188,10 @@ func louvain(nodes []string, adj map[string]map[string]float64) map[string]int {
 		}
 	}
 
-	// Iterative optimization.
+	// Iterative optimization with a max iteration limit.
+	const maxIterations = 100
 	improved := true
-	for improved {
+	for iter := 0; improved && iter < maxIterations; iter++ {
 		improved = false
 		for _, node := range nodes {
 			currentComm := community[node]
@@ -201,15 +205,19 @@ func louvain(nodes []string, adj map[string]map[string]float64) map[string]int {
 			}
 
 			// Try moving to each neighboring community.
+			// Gain threshold to avoid oscillation on symmetric graphs.
+			const minGain = 1e-6
 			ki := degree[node]
+			edgesToCurrent := neighborComms[currentComm]
 			for comm, edgesIn := range neighborComms {
 				if comm == currentComm {
 					continue
 				}
-				// Modularity gain: edgesIn/m - ki*sumTot/(2*m^2)
-				sumTot := communityDegreeSum(community, degree, comm, node)
-				gain := edgesIn/totalWeight - ki*sumTot/(totalWeight*totalWeight)
-				if gain > bestGain {
+				sumTotNew := communityDegreeSum(community, degree, comm, node)
+				sumTotOld := communityDegreeSum(community, degree, currentComm, node)
+				// Net gain: benefit of joining new - cost of leaving current.
+				gain := (edgesIn-edgesToCurrent)/totalWeight - ki*(sumTotNew-sumTotOld)/(totalWeight*totalWeight)
+				if gain > bestGain+minGain {
 					bestGain = gain
 					bestComm = comm
 				}
@@ -237,14 +245,22 @@ func communityDegreeSum(community map[string]int, degree map[string]float64, com
 }
 
 func renumberCommunities(community map[string]int) map[string]int {
-	remap := make(map[int]int)
-	next := 0
+	unique := make(map[int]struct{})
 	for _, c := range community {
-		if _, exists := remap[c]; !exists {
-			remap[c] = next
-			next++
-		}
+		unique[c] = struct{}{}
 	}
+
+	originalIDs := make([]int, 0, len(unique))
+	for c := range unique {
+		originalIDs = append(originalIDs, c)
+	}
+	sort.Ints(originalIDs)
+
+	remap := make(map[int]int, len(originalIDs))
+	for next, c := range originalIDs {
+		remap[c] = next
+	}
+
 	result := make(map[string]int, len(community))
 	for node, c := range community {
 		result[node] = remap[c]
@@ -289,26 +305,29 @@ func buildFamilyResult(specRefs []string, community map[string]int, adj map[stri
 	}
 }
 
-// computeCohesion calculates intra-community edge density.
-// cohesion = actual_edges / possible_edges
+// computeCohesion calculates intra-community edge density (unweighted).
+// cohesion = actual_connected_pairs / possible_pairs, always in [0, 1].
 func computeCohesion(members []string, adj map[string]map[string]float64) float64 {
 	if len(members) < 2 {
 		return 1.0
 	}
-	memberSet := make(map[string]bool, len(members))
-	for _, m := range members {
-		memberSet[m] = true
-	}
 
 	intraEdges := 0.0
-	for _, m := range members {
-		for neighbor, w := range adj[m] {
-			if memberSet[neighbor] {
-				intraEdges += w
+	for i := 0; i < len(members); i++ {
+		for j := i + 1; j < len(members); j++ {
+			if neighbors, ok := adj[members[i]]; ok {
+				if _, connected := neighbors[members[j]]; connected {
+					intraEdges++
+					continue
+				}
+			}
+			if neighbors, ok := adj[members[j]]; ok {
+				if _, connected := neighbors[members[i]]; connected {
+					intraEdges++
+				}
 			}
 		}
 	}
-	intraEdges /= 2 // undirected, counted twice
 
 	possibleEdges := float64(len(members)) * float64(len(members)-1) / 2
 	return intraEdges / possibleEdges
@@ -317,7 +336,10 @@ func computeCohesion(members []string, adj map[string]map[string]float64) float6
 func findUngovernedFilesContext(ctx context.Context, db *sql.DB) ([]string, error) {
 	// Check if ast_cache table exists.
 	var tableCount int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ast_cache'`).Scan(&tableCount); err != nil || tableCount == 0 {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ast_cache'`).Scan(&tableCount); err != nil {
+		return nil, fmt.Errorf("check ast_cache table existence: %w", err)
+	}
+	if tableCount == 0 {
 		return nil, nil
 	}
 

--- a/internal/index/family.go
+++ b/internal/index/family.go
@@ -1,0 +1,347 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+)
+
+// SpecFamily represents a discovered governance community.
+type SpecFamily struct {
+	ID       int      `json:"id"`
+	Members  []string `json:"members"`
+	Size     int      `json:"size"`
+	Cohesion float64  `json:"cohesion"`
+	Label    string   `json:"label,omitempty"`
+}
+
+// FamilyAssignment stores the community assignment for one artifact.
+type FamilyAssignment struct {
+	Ref      string `json:"ref"`
+	FamilyID int    `json:"family_id"`
+}
+
+// FamilyResult holds the full output of spec family discovery.
+type FamilyResult struct {
+	Families    []SpecFamily       `json:"families"`
+	Assignments []FamilyAssignment `json:"assignments,omitempty"`
+	Ungoverned  []string           `json:"ungoverned,omitempty"`
+}
+
+// DiscoverFamiliesContext runs community detection on the spec dependency graph.
+func DiscoverFamiliesContext(ctx context.Context, dbPath string) (*FamilyResult, error) {
+	db, err := OpenReadOnlyContext(ctx, dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open index for family discovery: %w", err)
+	}
+	defer db.Close()
+
+	return discoverFamiliesDBContext(ctx, db)
+}
+
+func discoverFamiliesDBContext(ctx context.Context, db *sql.DB) (*FamilyResult, error) {
+	// Load all spec refs.
+	specRefs, err := loadAllSpecRefsContext(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if len(specRefs) == 0 {
+		return &FamilyResult{}, nil
+	}
+
+	// Build undirected adjacency from edges.
+	adj, err := buildSpecAdjacencyContext(ctx, db, specRefs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Run Louvain community detection.
+	communities := louvain(specRefs, adj)
+
+	// Build result.
+	result := buildFamilyResult(specRefs, communities, adj)
+
+	// Find ungoverned code files: files in ast_cache not covered by any applies_to edge.
+	result.Ungoverned, _ = findUngovernedFilesContext(ctx, db)
+
+	return result, nil
+}
+
+func loadAllSpecRefsContext(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `SELECT ref FROM artifacts WHERE kind = 'spec' ORDER BY ref`)
+	if err != nil {
+		return nil, fmt.Errorf("query spec refs: %w", err)
+	}
+	defer rows.Close()
+
+	var refs []string
+	for rows.Next() {
+		var ref string
+		if err := rows.Scan(&ref); err != nil {
+			return nil, err
+		}
+		refs = append(refs, ref)
+	}
+	return refs, rows.Err()
+}
+
+// buildSpecAdjacencyContext builds an undirected adjacency list from spec edges.
+// Connections come from: depends_on, supersedes, relates_to (direct), and
+// shared applies_to targets (specs that govern the same code file).
+func buildSpecAdjacencyContext(ctx context.Context, db *sql.DB, specRefs []string) (map[string]map[string]float64, error) {
+	adj := make(map[string]map[string]float64)
+	for _, ref := range specRefs {
+		adj[ref] = make(map[string]float64)
+	}
+
+	// Direct edges: depends_on, supersedes, relates_to between specs.
+	rows, err := db.QueryContext(ctx, `
+		SELECT e.from_ref, e.to_ref
+		FROM edges e
+		JOIN artifacts a1 ON a1.ref = e.from_ref AND a1.kind = 'spec'
+		JOIN artifacts a2 ON a2.ref = e.to_ref AND a2.kind = 'spec'
+		WHERE e.edge_type IN ('depends_on', 'supersedes', 'relates_to')
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query spec-spec edges: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var from, to string
+		if err := rows.Scan(&from, &to); err != nil {
+			return nil, err
+		}
+		if _, ok := adj[from]; ok {
+			adj[from][to] += 1.0
+		}
+		if _, ok := adj[to]; ok {
+			adj[to][from] += 1.0
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Shared applies_to: specs governing the same code/config target.
+	targetRows, err := db.QueryContext(ctx, `
+		SELECT e1.from_ref, e2.from_ref
+		FROM edges e1
+		JOIN edges e2 ON e1.to_ref = e2.to_ref AND e1.from_ref < e2.from_ref
+		JOIN artifacts a1 ON a1.ref = e1.from_ref AND a1.kind = 'spec'
+		JOIN artifacts a2 ON a2.ref = e2.from_ref AND a2.kind = 'spec'
+		WHERE e1.edge_type = 'applies_to' AND e2.edge_type = 'applies_to'
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query shared applies_to: %w", err)
+	}
+	defer targetRows.Close()
+
+	for targetRows.Next() {
+		var from, to string
+		if err := targetRows.Scan(&from, &to); err != nil {
+			return nil, err
+		}
+		if _, ok := adj[from]; ok {
+			adj[from][to] += 0.5 // shared target is a weaker signal
+		}
+		if _, ok := adj[to]; ok {
+			adj[to][from] += 0.5
+		}
+	}
+	if err := targetRows.Err(); err != nil {
+		return nil, err
+	}
+
+	return adj, nil
+}
+
+// louvain runs a simplified Louvain community detection algorithm.
+// Returns a map from node → community ID.
+func louvain(nodes []string, adj map[string]map[string]float64) map[string]int {
+	// Initialize each node in its own community.
+	community := make(map[string]int, len(nodes))
+	for i, node := range nodes {
+		community[node] = i
+	}
+
+	// Compute total edge weight (2m in modularity formula).
+	totalWeight := 0.0
+	for _, neighbors := range adj {
+		for _, w := range neighbors {
+			totalWeight += w
+		}
+	}
+	if totalWeight == 0 {
+		return community
+	}
+
+	// Node degree (sum of weights).
+	degree := make(map[string]float64, len(nodes))
+	for node, neighbors := range adj {
+		for _, w := range neighbors {
+			degree[node] += w
+		}
+	}
+
+	// Iterative optimization.
+	improved := true
+	for improved {
+		improved = false
+		for _, node := range nodes {
+			currentComm := community[node]
+			bestComm := currentComm
+			bestGain := 0.0
+
+			// Compute community-level aggregates for neighbors.
+			neighborComms := make(map[int]float64)
+			for neighbor, w := range adj[node] {
+				neighborComms[community[neighbor]] += w
+			}
+
+			// Try moving to each neighboring community.
+			ki := degree[node]
+			for comm, edgesIn := range neighborComms {
+				if comm == currentComm {
+					continue
+				}
+				// Modularity gain: edgesIn/m - ki*sumTot/(2*m^2)
+				sumTot := communityDegreeSum(community, degree, comm, node)
+				gain := edgesIn/totalWeight - ki*sumTot/(totalWeight*totalWeight)
+				if gain > bestGain {
+					bestGain = gain
+					bestComm = comm
+				}
+			}
+
+			if bestComm != currentComm {
+				community[node] = bestComm
+				improved = true
+			}
+		}
+	}
+
+	// Renumber communities sequentially.
+	return renumberCommunities(community)
+}
+
+func communityDegreeSum(community map[string]int, degree map[string]float64, commID int, excludeNode string) float64 {
+	sum := 0.0
+	for node, c := range community {
+		if c == commID && node != excludeNode {
+			sum += degree[node]
+		}
+	}
+	return sum
+}
+
+func renumberCommunities(community map[string]int) map[string]int {
+	remap := make(map[int]int)
+	next := 0
+	for _, c := range community {
+		if _, exists := remap[c]; !exists {
+			remap[c] = next
+			next++
+		}
+	}
+	result := make(map[string]int, len(community))
+	for node, c := range community {
+		result[node] = remap[c]
+	}
+	return result
+}
+
+func buildFamilyResult(specRefs []string, community map[string]int, adj map[string]map[string]float64) *FamilyResult {
+	// Group specs by community.
+	familyMembers := make(map[int][]string)
+	for _, ref := range specRefs {
+		cid := community[ref]
+		familyMembers[cid] = append(familyMembers[cid], ref)
+	}
+
+	// Build families with cohesion scores.
+	var families []SpecFamily
+	for cid, members := range familyMembers {
+		sort.Strings(members)
+		cohesion := computeCohesion(members, adj)
+		families = append(families, SpecFamily{
+			ID:       cid,
+			Members:  members,
+			Size:     len(members),
+			Cohesion: cohesion,
+		})
+	}
+	sort.Slice(families, func(i, j int) bool { return families[i].ID < families[j].ID })
+
+	// Build assignments.
+	assignments := make([]FamilyAssignment, 0, len(specRefs))
+	for _, ref := range specRefs {
+		assignments = append(assignments, FamilyAssignment{
+			Ref:      ref,
+			FamilyID: community[ref],
+		})
+	}
+
+	return &FamilyResult{
+		Families:    families,
+		Assignments: assignments,
+	}
+}
+
+// computeCohesion calculates intra-community edge density.
+// cohesion = actual_edges / possible_edges
+func computeCohesion(members []string, adj map[string]map[string]float64) float64 {
+	if len(members) < 2 {
+		return 1.0
+	}
+	memberSet := make(map[string]bool, len(members))
+	for _, m := range members {
+		memberSet[m] = true
+	}
+
+	intraEdges := 0.0
+	for _, m := range members {
+		for neighbor, w := range adj[m] {
+			if memberSet[neighbor] {
+				intraEdges += w
+			}
+		}
+	}
+	intraEdges /= 2 // undirected, counted twice
+
+	possibleEdges := float64(len(members)) * float64(len(members)-1) / 2
+	return intraEdges / possibleEdges
+}
+
+func findUngovernedFilesContext(ctx context.Context, db *sql.DB) ([]string, error) {
+	// Check if ast_cache table exists.
+	var tableCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ast_cache'`).Scan(&tableCount); err != nil || tableCount == 0 {
+		return nil, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT ac.path FROM ast_cache ac
+		WHERE NOT EXISTS (
+			SELECT 1 FROM edges e
+			WHERE e.edge_type = 'applies_to'
+			AND (e.to_ref = 'code://' || ac.path OR e.to_ref = 'config://' || ac.path)
+		)
+		ORDER BY ac.path
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query ungoverned files: %w", err)
+	}
+	defer rows.Close()
+
+	var paths []string
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return nil, err
+		}
+		paths = append(paths, path)
+	}
+	return paths, rows.Err()
+}

--- a/internal/index/family_test.go
+++ b/internal/index/family_test.go
@@ -1,0 +1,173 @@
+package index
+
+import (
+	"testing"
+)
+
+func TestLouvain_SingleNode(t *testing.T) {
+	t.Parallel()
+	nodes := []string{"SPEC-001"}
+	adj := map[string]map[string]float64{
+		"SPEC-001": {},
+	}
+
+	community := louvain(nodes, adj)
+	if len(community) != 1 {
+		t.Fatalf("expected 1 community assignment, got %d", len(community))
+	}
+}
+
+func TestLouvain_TwoClusters(t *testing.T) {
+	t.Parallel()
+	nodes := []string{"A", "B", "C", "D"}
+	adj := map[string]map[string]float64{
+		"A": {"B": 1.0},
+		"B": {"A": 1.0},
+		"C": {"D": 1.0},
+		"D": {"C": 1.0},
+	}
+
+	community := louvain(nodes, adj)
+
+	// A and B should be in same community, C and D should be in same community.
+	if community["A"] != community["B"] {
+		t.Errorf("A and B should be in same community: A=%d B=%d", community["A"], community["B"])
+	}
+	if community["C"] != community["D"] {
+		t.Errorf("C and D should be in same community: C=%d D=%d", community["C"], community["D"])
+	}
+	if community["A"] == community["C"] {
+		t.Error("A and C should be in different communities")
+	}
+}
+
+func TestLouvain_FullyConnected(t *testing.T) {
+	t.Parallel()
+	nodes := []string{"A", "B", "C"}
+	adj := map[string]map[string]float64{
+		"A": {"B": 1.0, "C": 1.0},
+		"B": {"A": 1.0, "C": 1.0},
+		"C": {"A": 1.0, "B": 1.0},
+	}
+
+	community := louvain(nodes, adj)
+
+	// All should be in the same community.
+	if community["A"] != community["B"] || community["B"] != community["C"] {
+		t.Errorf("fully connected graph should have one community: A=%d B=%d C=%d",
+			community["A"], community["B"], community["C"])
+	}
+}
+
+func TestLouvain_Disconnected(t *testing.T) {
+	t.Parallel()
+	nodes := []string{"A", "B", "C"}
+	adj := map[string]map[string]float64{
+		"A": {},
+		"B": {},
+		"C": {},
+	}
+
+	community := louvain(nodes, adj)
+	// Disconnected nodes stay in their own communities.
+	if community["A"] == community["B"] || community["B"] == community["C"] || community["A"] == community["C"] {
+		t.Errorf("disconnected nodes should be in different communities: A=%d B=%d C=%d",
+			community["A"], community["B"], community["C"])
+	}
+}
+
+func TestComputeCohesion_FullyConnected(t *testing.T) {
+	t.Parallel()
+	adj := map[string]map[string]float64{
+		"A": {"B": 1.0, "C": 1.0},
+		"B": {"A": 1.0, "C": 1.0},
+		"C": {"A": 1.0, "B": 1.0},
+	}
+
+	cohesion := computeCohesion([]string{"A", "B", "C"}, adj)
+	if cohesion != 1.0 {
+		t.Errorf("cohesion = %f, want 1.0", cohesion)
+	}
+}
+
+func TestComputeCohesion_HalfConnected(t *testing.T) {
+	t.Parallel()
+	adj := map[string]map[string]float64{
+		"A": {"B": 1.0},
+		"B": {"A": 1.0},
+		"C": {},
+	}
+
+	// 1 edge out of 3 possible = 0.333...
+	cohesion := computeCohesion([]string{"A", "B", "C"}, adj)
+	expected := 1.0 / 3.0
+	if cohesion < expected-0.01 || cohesion > expected+0.01 {
+		t.Errorf("cohesion = %f, want ~%f", cohesion, expected)
+	}
+}
+
+func TestComputeCohesion_SingleMember(t *testing.T) {
+	t.Parallel()
+	adj := map[string]map[string]float64{"A": {}}
+	cohesion := computeCohesion([]string{"A"}, adj)
+	if cohesion != 1.0 {
+		t.Errorf("single member cohesion = %f, want 1.0", cohesion)
+	}
+}
+
+func TestBuildFamilyResult(t *testing.T) {
+	t.Parallel()
+	specRefs := []string{"SPEC-001", "SPEC-002", "SPEC-003"}
+	community := map[string]int{
+		"SPEC-001": 0,
+		"SPEC-002": 0,
+		"SPEC-003": 1,
+	}
+	adj := map[string]map[string]float64{
+		"SPEC-001": {"SPEC-002": 1.0},
+		"SPEC-002": {"SPEC-001": 1.0},
+		"SPEC-003": {},
+	}
+
+	result := buildFamilyResult(specRefs, community, adj)
+
+	if len(result.Families) != 2 {
+		t.Fatalf("expected 2 families, got %d", len(result.Families))
+	}
+	if len(result.Assignments) != 3 {
+		t.Fatalf("expected 3 assignments, got %d", len(result.Assignments))
+	}
+
+	// Family 0 should have 2 members, family 1 should have 1.
+	familySizes := map[int]int{}
+	for _, f := range result.Families {
+		familySizes[f.ID] = f.Size
+	}
+	if familySizes[0] != 2 {
+		t.Errorf("family 0 size = %d, want 2", familySizes[0])
+	}
+	if familySizes[1] != 1 {
+		t.Errorf("family 1 size = %d, want 1", familySizes[1])
+	}
+}
+
+func TestRenumberCommunities(t *testing.T) {
+	t.Parallel()
+	input := map[string]int{"A": 5, "B": 5, "C": 12}
+	result := renumberCommunities(input)
+
+	if result["A"] != result["B"] {
+		t.Error("A and B should be in the same community")
+	}
+	if result["A"] == result["C"] {
+		t.Error("A and C should be in different communities")
+	}
+	// IDs should be 0 and 1 (sequential).
+	ids := map[int]bool{}
+	for _, c := range result {
+		ids[c] = true
+	}
+	if !ids[0] || !ids[1] || len(ids) != 2 {
+		t.Errorf("communities not sequential: %v", result)
+	}
+}


### PR DESCRIPTION
## Summary
- Implements Louvain community detection on the spec dependency graph (depends_on, supersedes, relates_to + shared applies_to targets) to discover natural governance families
- New `status --show-families` flag displays families with member counts, cohesion scores, and ungoverned file coverage gaps
- New `search-specs --family N` flag filters search results to specs in family N
- `analyze-impact` annotates impacted specs crossing family boundaries with `cross_family: true`
- Ungoverned files (in ast_cache but not covered by any applies_to edge) are surfaced as coverage gaps
- Full JSON output available for CI integration

Closes #267

## Test plan
- [x] Unit tests for Louvain algorithm (single node, two clusters, fully connected, disconnected)
- [x] Unit tests for cohesion computation (full, half, single member)
- [x] Unit tests for community renumbering and family result building
- [x] Full `make test` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)