### PR TITLE
Add JSON source adapter

### DIFF
--- a/cmd/explain_file_test.go
+++ b/cmd/explain_file_test.go
@@ -45,7 +45,7 @@ func TestRunExplainFileJSON(t *testing.T) {
 	if got, want := payload.Request.Path, "docs/development/testing-guide.md"; got != want {
 		t.Fatalf("request path = %q, want %q", got, want)
 	}
-	if got, want := payload.Result.Summary.Status, "not_indexed"; got != want {
+	if got, want := payload.Result.Summary.Status, "excluded"; got != want {
 		t.Fatalf("summary status = %q, want %q", got, want)
 	}
 	if got, want := payload.Result.WorkspacePath, "docs/development/testing-guide.md"; got != want {

--- a/cmd/explain_file_test.go
+++ b/cmd/explain_file_test.go
@@ -124,6 +124,77 @@ func TestRunExplainFileContractJSON(t *testing.T) {
 	}
 }
 
+func TestRunExplainFileJSONSource(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "json-specs"
+adapter = "json"
+kind = "json_spec"
+path = "schemas"
+files = ["rate-limit.json"]
+
+[sources.options]
+title_pointer = "/info/title"
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "schemas", "rate-limit.json"), `{
+  "info": {
+    "title": "Rate Limit Schema"
+  }
+}`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runExplainFile([]string{"schemas/rate-limit.json", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runExplainFile() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runExplainFile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Summary struct {
+				Status string `json:"status"`
+			} `json:"summary"`
+			Sources []explainFileSourceJSON `json:"sources"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal explain payload: %v", err)
+	}
+	if got, want := payload.Result.Summary.Status, "indexed"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	source, ok := findExplainFileSource(payload.Result.Sources, func(src explainFileSourceJSON) bool {
+		return src.Name == "json-specs"
+	})
+	if !ok {
+		t.Fatal("did not find json-specs source in payload result")
+	}
+	if got, want := source.Reason, "indexed_json_spec"; got != want {
+		t.Fatalf("reason = %q, want %q", got, want)
+	}
+	if got, want := source.ArtifactKind, "spec"; got != want {
+		t.Fatalf("artifact kind = %q, want %q", got, want)
+	}
+	if !source.Selected {
+		t.Fatalf("source explanation = %+v, want selected source", source)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
 func TestRunExplainFileRejectsMissingPath(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/cmd/explain_file_test.go
+++ b/cmd/explain_file_test.go
@@ -45,7 +45,7 @@ func TestRunExplainFileJSON(t *testing.T) {
 	if got, want := payload.Request.Path, "docs/development/testing-guide.md"; got != want {
 		t.Fatalf("request path = %q, want %q", got, want)
 	}
-	if got, want := payload.Result.Summary.Status, "excluded"; got != want {
+	if got, want := payload.Result.Summary.Status, "not_indexed"; got != want {
 		t.Fatalf("summary status = %q, want %q", got, want)
 	}
 	if got, want := payload.Result.WorkspacePath, "docs/development/testing-guide.md"; got != want {
@@ -189,6 +189,136 @@ title_pointer = "/info/title"
 	}
 	if !source.Selected {
 		t.Fatalf("source explanation = %+v, want selected source", source)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
+func TestRunExplainFileJSONDocSource(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "json-docs"
+adapter = "json"
+kind = "json_doc"
+path = "artifacts"
+files = ["events.json"]
+
+[sources.options]
+title_pointer = "/title"
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "artifacts", "events.json"), `{
+  "title": "Event Schema"
+}`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runExplainFile([]string{"artifacts/events.json", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runExplainFile() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runExplainFile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Summary struct {
+				Status string `json:"status"`
+			} `json:"summary"`
+			Sources []explainFileSourceJSON `json:"sources"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal explain payload: %v", err)
+	}
+	if got, want := payload.Result.Summary.Status, "indexed"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	source, ok := findExplainFileSource(payload.Result.Sources, func(src explainFileSourceJSON) bool {
+		return src.Name == "json-docs"
+	})
+	if !ok {
+		t.Fatal("did not find json-docs source in payload result")
+	}
+	if got, want := source.Reason, "indexed_json_doc"; got != want {
+		t.Fatalf("reason = %q, want %q", got, want)
+	}
+	if got, want := source.ArtifactKind, "doc"; got != want {
+		t.Fatalf("artifact kind = %q, want %q", got, want)
+	}
+	if !source.Selected {
+		t.Fatalf("source explanation = %+v, want selected source", source)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
+func TestRunExplainFileJSONSourceRejectsNonJSONFile(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "json-specs"
+adapter = "json"
+kind = "json_spec"
+path = "schemas"
+include = ["*"]
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "schemas", "notes.md"), "# Notes\n")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runExplainFile([]string{"schemas/notes.md", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runExplainFile() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runExplainFile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Summary struct {
+				Status string `json:"status"`
+			} `json:"summary"`
+			Sources []explainFileSourceJSON `json:"sources"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal explain payload: %v", err)
+	}
+	if got, want := payload.Result.Summary.Status, "not_indexed"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	source, ok := findExplainFileSource(payload.Result.Sources, func(src explainFileSourceJSON) bool {
+		return src.Name == "json-specs"
+	})
+	if !ok {
+		t.Fatal("did not find json-specs source in payload result")
+	}
+	if got, want := source.Reason, "not_json_file"; got != want {
+		t.Fatalf("reason = %q, want %q", got, want)
+	}
+	if source.Selected {
+		t.Fatalf("source explanation = %+v, want unselected source", source)
 	}
 	if len(payload.Errors) != 0 {
 		t.Fatalf("errors = %+v, want none", payload.Errors)

--- a/cmd/extensions.go
+++ b/cmd/extensions.go
@@ -1,3 +1,6 @@
 package cmd
 
-import _ "github.com/dusk-network/pituitary/extensions/github"
+import (
+	_ "github.com/dusk-network/pituitary/extensions/github"
+	_ "github.com/dusk-network/pituitary/extensions/json"
+)

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -46,6 +46,67 @@ path = "specs"
 	}
 }
 
+func TestRunIndexWithJSONAdapter(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "json-specs"
+adapter = "json"
+kind = "json_spec"
+path = "schemas"
+
+[sources.options]
+title_pointer = "/info/title"
+status_pointer = "/meta/status"
+domain_pointer = "/meta/domain"
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "schemas", "rate-limit.json"), `{
+  "meta": {
+    "status": "accepted",
+    "domain": "api"
+  },
+  "info": {
+    "title": "JSON Rate Limits"
+  },
+  "limits": {
+    "requests_per_minute": 120
+  }
+}`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	progress := stderr.String()
+	if !strings.Contains(progress, "pituitary index: chunking") {
+		t.Fatalf("runIndex() stderr %q does not contain chunking progress", progress)
+	}
+	if !strings.Contains(progress, "pituitary index: embedding") {
+		t.Fatalf("runIndex() stderr %q does not contain embedding progress", progress)
+	}
+	if !strings.Contains(stdout.String(), "indexed 1 artifact(s)") {
+		t.Fatalf("runIndex() output %q does not contain JSON adapter counts", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".pituitary", "pituitary.db")); err != nil {
+		t.Fatalf("runIndex() did not create database: %v", err)
+	}
+}
+
 func TestRunIndexReportsRepoCoverage(t *testing.T) {
 	repo := writeMultiRepoSearchWorkspace(t)
 

--- a/cmd/preview_sources_test.go
+++ b/cmd/preview_sources_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"path/filepath"
 	"testing"
 )
 
@@ -53,5 +54,83 @@ func TestRunPreviewSourcesJSON(t *testing.T) {
 	}
 	if payload.Result.Sources[1].Items[0].ArtifactKind != "doc" {
 		t.Fatalf("first doc item = %+v, want artifact_kind=doc", payload.Result.Sources[1].Items[0])
+	}
+}
+
+func TestRunPreviewSourcesJSONAdapter(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "json-specs"
+adapter = "json"
+kind = "json_spec"
+path = "schemas"
+files = ["rate-limit.json"]
+
+[sources.options]
+title_pointer = "/info/title"
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "schemas", "rate-limit.json"), `{
+  "info": {
+    "title": "Rate Limit Schema"
+  }
+}`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runPreviewSources([]string{"--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runPreviewSources() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runPreviewSources() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Sources []struct {
+				Name      string `json:"name"`
+				Adapter   string `json:"adapter"`
+				Kind      string `json:"kind"`
+				ItemCount int    `json:"item_count"`
+				Items     []struct {
+					ArtifactKind string `json:"artifact_kind"`
+					Path         string `json:"path"`
+				} `json:"items"`
+			} `json:"sources"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal preview payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if got, want := len(payload.Result.Sources), 1; got != want {
+		t.Fatalf("source count = %d, want %d", got, want)
+	}
+	source := payload.Result.Sources[0]
+	if got, want := source.Adapter, "json"; got != want {
+		t.Fatalf("source adapter = %q, want %q", got, want)
+	}
+	if got, want := source.Kind, "json_spec"; got != want {
+		t.Fatalf("source kind = %q, want %q", got, want)
+	}
+	if got, want := source.ItemCount, 1; got != want {
+		t.Fatalf("item count = %d, want %d", got, want)
+	}
+	if got, want := source.Items[0].ArtifactKind, "spec"; got != want {
+		t.Fatalf("artifact kind = %q, want %q", got, want)
+	}
+	if got, want := source.Items[0].Path, "schemas/rate-limit.json"; got != want {
+		t.Fatalf("item path = %q, want %q", got, want)
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,6 +198,30 @@ files = ["CLAUDE.md", "AGENTS.md", "ARCHITECTURE.md"]
 
 This indexes them alongside your specs so drift detection and search cover them. Note: `markdown_docs` sources participate in drift checks and semantic search, not overlap or review — for that, use `markdown_contract` or promote to a spec bundle with `pituitary canonicalize`.
 
+### Example: Indexing structured JSON intent artifacts
+
+If your repo keeps intent in JSON files such as API schemas or machine-generated policy/config records, add a JSON adapter source:
+
+```toml
+[[sources]]
+name = "api-json"
+adapter = "json"
+kind = "json_spec"
+path = "schemas"
+include = ["*.json"]
+
+[sources.options]
+ref_pointer = "/x-pituitary/ref"
+title_pointer = "/info/title"
+status_pointer = "/x-pituitary/status"
+domain_pointer = "/x-pituitary/domain"
+body_pointer = ""
+tags_pointer = "/x-pituitary/tags"
+applies_to_pointer = "/x-pituitary/applies_to"
+```
+
+`kind = "json_spec"` normalizes each matched JSON file into a `SpecRecord`; `kind = "json_doc"` emits `DocRecord`s instead. Pointer options use JSON Pointer syntax (`/a/b/0`). When a pointer is omitted, Pituitary falls back to a stable path-based ref, the filename as title, `draft` status for specs, the source name as the default spec domain, and the whole JSON document as the body rendered into markdown.
+
 ## Source Kinds
 
 **`spec_bundle`**: `spec.toml` + `body.md` pairs. The structured, high-rigor format.
@@ -207,6 +231,8 @@ This indexes them alongside your specs so drift detection and search cover them.
 **`markdown_contract`**: Markdown files treated as inferred specs. Pituitary extracts metadata from `Ref:`, `Status:`, `Domain:`, `Depends On:`, `Supersedes:`, and `Applies To:` lines when present, or falls back to stable workspace-derived refs like `contract://rfcs/auth/session-policy` with status `draft`.
 
 **`issue`**: Optional adapter-defined kind used by the built-in GitHub source adapter. GitHub issues labeled like specs/RFCs are normalized as specs; other issues are normalized as docs.
+
+**`json_spec` / `json_doc`**: Optional adapter-defined kinds used by the built-in JSON source adapter. Each matched `.json` file is normalized into a spec or doc using JSON Pointer mappings from `sources.options`.
 
 ## Selectors
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,12 +215,11 @@ ref_pointer = "/x-pituitary/ref"
 title_pointer = "/info/title"
 status_pointer = "/x-pituitary/status"
 domain_pointer = "/x-pituitary/domain"
-body_pointer = ""
 tags_pointer = "/x-pituitary/tags"
 applies_to_pointer = "/x-pituitary/applies_to"
 ```
 
-`kind = "json_spec"` normalizes each matched JSON file into a `SpecRecord`; `kind = "json_doc"` emits `DocRecord`s instead. Pointer options use JSON Pointer syntax (`/a/b/0`). When a pointer is omitted, Pituitary falls back to a stable path-based ref, the filename as title, `draft` status for specs, the source name as the default spec domain, and the whole JSON document as the body rendered into markdown.
+`kind = "json_spec"` normalizes each matched JSON file into a `SpecRecord`; `kind = "json_doc"` emits `DocRecord`s instead. Pointer options use JSON Pointer syntax (`/a/b/0`). When a pointer is omitted, Pituitary falls back to a stable path-based ref, the filename as title, `draft` status for specs, the source name as the default spec domain, and the whole JSON document as the body rendered into markdown. Configured pointer values must resolve to non-empty strings or arrays; omit the pointer to use the built-in fallback instead.
 
 ## Source Kinds
 

--- a/extensions/json/adapter.go
+++ b/extensions/json/adapter.go
@@ -1,0 +1,834 @@
+package jsonadapter
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	stdjson "encoding/json"
+	"fmt"
+	"io"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dusk-network/pituitary/sdk"
+)
+
+const (
+	adapterName = "json"
+	kindSpec    = "json_spec"
+	kindDoc     = "json_doc"
+)
+
+func init() {
+	sdk.Register(adapterName, func() sdk.Adapter {
+		return &adapter{}
+	})
+}
+
+type adapter struct{}
+
+func (a *adapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sdk.AdapterResult, error) {
+	files, kind, err := enumerateSelectedJSONFiles(cfg)
+	if err != nil {
+		return nil, err
+	}
+	options, err := parseSourceOptions(kind, cfg.Options)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &sdk.AdapterResult{}
+	for _, file := range files {
+		record, err := loadJSONArtifact(ctx, cfg, options, kind, file)
+		if err != nil {
+			return nil, err
+		}
+		switch kind {
+		case kindSpec:
+			result.Specs = append(result.Specs, record.spec)
+		case kindDoc:
+			result.Docs = append(result.Docs, record.doc)
+		default:
+			return nil, fmt.Errorf("unsupported kind %q", kind)
+		}
+	}
+	return result, nil
+}
+
+func (a *adapter) Preview(ctx context.Context, cfg sdk.SourceConfig) ([]sdk.PreviewItem, error) {
+	_ = ctx
+
+	files, kind, err := enumerateSelectedJSONFiles(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	artifactKind := sdk.ArtifactKindDoc
+	if kind == kindSpec {
+		artifactKind = sdk.ArtifactKindSpec
+	}
+
+	items := make([]sdk.PreviewItem, 0, len(files))
+	for _, file := range files {
+		items = append(items, sdk.PreviewItem{
+			ArtifactKind: artifactKind,
+			Path:         workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath),
+		})
+	}
+	return items, nil
+}
+
+type sourceOptions struct {
+	refPointer        string
+	titlePointer      string
+	bodyPointer       string
+	statusPointer     string
+	domainPointer     string
+	authorsPointer    string
+	tagsPointer       string
+	dependsOnPointer  string
+	supersedesPointer string
+	relatesToPointer  string
+	appliesToPointer  string
+}
+
+func parseSourceOptions(kind string, options map[string]any) (sourceOptions, error) {
+	parsed := sourceOptions{}
+	if len(options) == 0 {
+		return parsed, nil
+	}
+
+	allowed := map[string]*string{
+		"applies_to_pointer": &parsed.appliesToPointer,
+		"authors_pointer":    &parsed.authorsPointer,
+		"body_pointer":       &parsed.bodyPointer,
+		"depends_on_pointer": &parsed.dependsOnPointer,
+		"domain_pointer":     &parsed.domainPointer,
+		"ref_pointer":        &parsed.refPointer,
+		"relates_to_pointer": &parsed.relatesToPointer,
+		"status_pointer":     &parsed.statusPointer,
+		"supersedes_pointer": &parsed.supersedesPointer,
+		"tags_pointer":       &parsed.tagsPointer,
+		"title_pointer":      &parsed.titlePointer,
+	}
+	for key, value := range options {
+		target, ok := allowed[key]
+		if !ok {
+			return sourceOptions{}, fmt.Errorf("unsupported option %q", key)
+		}
+		pointer, err := optionPointer(value)
+		if err != nil {
+			return sourceOptions{}, fmt.Errorf("options.%s: %w", key, err)
+		}
+		*target = pointer
+	}
+
+	if kind == kindDoc {
+		specOnly := map[string]string{
+			"applies_to_pointer": parsed.appliesToPointer,
+			"authors_pointer":    parsed.authorsPointer,
+			"depends_on_pointer": parsed.dependsOnPointer,
+			"domain_pointer":     parsed.domainPointer,
+			"relates_to_pointer": parsed.relatesToPointer,
+			"status_pointer":     parsed.statusPointer,
+			"supersedes_pointer": parsed.supersedesPointer,
+			"tags_pointer":       parsed.tagsPointer,
+		}
+		for key, pointer := range specOnly {
+			if pointer != "" {
+				return sourceOptions{}, fmt.Errorf("options.%s is only supported for kind %q", key, kindSpec)
+			}
+		}
+	}
+
+	return parsed, nil
+}
+
+func optionPointer(value any) (string, error) {
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("expected string, got %T", value)
+	}
+	if err := validateJSONPointer(text); err != nil {
+		return "", err
+	}
+	return text, nil
+}
+
+type selectedJSONFile struct {
+	AbsolutePath string
+	RelativePath string
+}
+
+func enumerateSelectedJSONFiles(cfg sdk.SourceConfig) ([]selectedJSONFile, string, error) {
+	kind := normalizeKind(cfg.Kind)
+	if kind == "" {
+		return nil, "", fmt.Errorf("unsupported kind %q", cfg.Kind)
+	}
+
+	resolvedPath, err := resolveSourceRoot(cfg.WorkspaceRoot, cfg.Path)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := validateExplicitJSONFiles(resolvedPath, cfg.Files); err != nil {
+		return nil, "", err
+	}
+
+	matches := make([]selectedJSONFile, 0)
+	err = filepath.WalkDir(resolvedPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		relPath, err := filepath.Rel(resolvedPath, path)
+		if err != nil {
+			return fmt.Errorf("json %q: resolve relative path: %w", workspaceRelative(cfg.WorkspaceRoot, path), err)
+		}
+		relPath = filepath.ToSlash(relPath)
+		allowed, err := sourcePathAllowed(cfg, relPath)
+		if err != nil {
+			return fmt.Errorf("json %q: %w", workspaceRelative(cfg.WorkspaceRoot, path), err)
+		}
+		if !allowed {
+			return nil
+		}
+		matches = append(matches, selectedJSONFile{
+			AbsolutePath: path,
+			RelativePath: relPath,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].RelativePath < matches[j].RelativePath
+	})
+	return matches, kind, nil
+}
+
+func resolveSourceRoot(workspaceRoot, sourcePath string) (string, error) {
+	sourcePath = strings.TrimSpace(sourcePath)
+	if sourcePath == "" {
+		return "", fmt.Errorf("path is required for adapter %q", adapterName)
+	}
+
+	resolvedPath := sourcePath
+	if !filepath.IsAbs(resolvedPath) {
+		resolvedPath = filepath.Join(workspaceRoot, sourcePath)
+	}
+	resolvedPath = filepath.Clean(resolvedPath)
+
+	info, err := os.Stat(resolvedPath)
+	switch {
+	case err == nil && !info.IsDir():
+		return "", fmt.Errorf("path %q is not a directory", sourcePath)
+	case err != nil:
+		return "", fmt.Errorf("path %q does not exist", sourcePath)
+	}
+	return resolvedPath, nil
+}
+
+func validateExplicitJSONFiles(sourceRoot string, files []string) error {
+	for i, relFile := range files {
+		normalized := filepath.ToSlash(strings.TrimSpace(relFile))
+		if pathpkg.Ext(normalized) != ".json" {
+			return fmt.Errorf("files[%d]: %q must point to a JSON file", i, relFile)
+		}
+		resolvedFile := filepath.Join(sourceRoot, filepath.FromSlash(normalized))
+		info, err := os.Stat(resolvedFile)
+		switch {
+		case err == nil && info.IsDir():
+			return fmt.Errorf("files[%d]: %q is a directory", i, relFile)
+		case err != nil:
+			return fmt.Errorf("files[%d]: %q does not exist", i, relFile)
+		}
+	}
+	return nil
+}
+
+func normalizeKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case kindSpec, sdk.ArtifactKindSpec:
+		return kindSpec
+	case kindDoc, sdk.ArtifactKindDoc:
+		return kindDoc
+	default:
+		return ""
+	}
+}
+
+func sourcePathAllowed(cfg sdk.SourceConfig, relPath string) (bool, error) {
+	relPath = filepath.ToSlash(relPath)
+
+	if len(cfg.Files) > 0 {
+		matched := false
+		for _, file := range cfg.Files {
+			if filepath.ToSlash(strings.TrimSpace(file)) == relPath {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+
+	if len(cfg.Include) > 0 {
+		matched := false
+		for _, pattern := range cfg.Include {
+			ok, err := pathpkg.Match(pattern, relPath)
+			if err != nil {
+				return false, fmt.Errorf("include pattern %q is invalid: %w", pattern, err)
+			}
+			if ok {
+				matched = true
+			}
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+
+	for _, pattern := range cfg.Exclude {
+		ok, err := pathpkg.Match(pattern, relPath)
+		if err != nil {
+			return false, fmt.Errorf("exclude pattern %q is invalid: %w", pattern, err)
+		}
+		if ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+type loadedArtifact struct {
+	spec sdk.SpecRecord
+	doc  sdk.DocRecord
+}
+
+func loadJSONArtifact(ctx context.Context, cfg sdk.SourceConfig, options sourceOptions, kind string, file selectedJSONFile) (loadedArtifact, error) {
+	_ = ctx
+
+	raw, err := os.ReadFile(file.AbsolutePath)
+	if err != nil {
+		return loadedArtifact{}, fmt.Errorf("source %q json %q: read file: %w", cfg.Name, workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath), err)
+	}
+
+	decoder := stdjson.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var document any
+	if err := decoder.Decode(&document); err != nil {
+		return loadedArtifact{}, fmt.Errorf("source %q json %q: parse JSON: %w", cfg.Name, workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath), err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return loadedArtifact{}, fmt.Errorf("source %q json %q: parse JSON: unexpected trailing content", cfg.Name, workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath))
+		}
+		return loadedArtifact{}, fmt.Errorf("source %q json %q: parse JSON: %w", cfg.Name, workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath), err)
+	}
+
+	switch kind {
+	case kindSpec:
+		spec, err := buildSpecRecord(cfg, options, file, raw, document)
+		if err != nil {
+			return loadedArtifact{}, err
+		}
+		return loadedArtifact{spec: spec}, nil
+	case kindDoc:
+		doc, err := buildDocRecord(cfg, options, file, raw, document)
+		if err != nil {
+			return loadedArtifact{}, err
+		}
+		return loadedArtifact{doc: doc}, nil
+	default:
+		return loadedArtifact{}, fmt.Errorf("unsupported kind %q", kind)
+	}
+}
+
+func buildSpecRecord(cfg sdk.SourceConfig, options sourceOptions, file selectedJSONFile, raw []byte, document any) (sdk.SpecRecord, error) {
+	title, titleSource, err := selectStringField(document, options.titlePointer, strings.TrimSuffix(filepath.Base(file.AbsolutePath), filepath.Ext(file.AbsolutePath)), "filename")
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "title_pointer", err)
+	}
+	refFallback := pathBasedRef("json-spec://", file.RelativePath, cfg.Repo, cfg.PrimaryRepoID)
+	ref, refSource, err := selectStringField(document, options.refPointer, refFallback, "path")
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "ref_pointer", err)
+	}
+	status, statusSource, err := selectStatus(document, options.statusPointer)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "status_pointer", err)
+	}
+	domain, domainSource, err := selectDomain(document, options.domainPointer, cfg.Name)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "domain_pointer", err)
+	}
+	authors, err := selectStringListField(document, options.authorsPointer)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "authors_pointer", err)
+	}
+	tags, err := selectStringListField(document, options.tagsPointer)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "tags_pointer", err)
+	}
+	dependsOn, err := selectStringListField(document, options.dependsOnPointer)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "depends_on_pointer", err)
+	}
+	supersedes, err := selectStringListField(document, options.supersedesPointer)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "supersedes_pointer", err)
+	}
+	relatesTo, err := selectStringListField(document, options.relatesToPointer)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "relates_to_pointer", err)
+	}
+	appliesTo, err := selectStringListField(document, options.appliesToPointer)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "applies_to_pointer", err)
+	}
+	bodyValue, err := selectBodyValue(document, options.bodyPointer)
+	if err != nil {
+		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "body_pointer", err)
+	}
+	bodyText, err := renderSpecBody(title, ref, status, domain, authors, tags, dependsOn, supersedes, relatesTo, appliesTo, bodyValue)
+	if err != nil {
+		return sdk.SpecRecord{}, fmt.Errorf("source %q json %q: render body: %w", cfg.Name, workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath), err)
+	}
+
+	return sdk.SpecRecord{
+		Ref:         ref,
+		Kind:        sdk.ArtifactKindSpec,
+		Title:       title,
+		Status:      status,
+		Domain:      domain,
+		Authors:     authors,
+		Tags:        tags,
+		Relations:   buildRelations(dependsOn, supersedes, relatesTo),
+		AppliesTo:   appliesTo,
+		SourceRef:   fileSourceRef(cfg.WorkspaceRoot, file.AbsolutePath),
+		BodyFormat:  sdk.BodyFormatMarkdown,
+		BodyText:    bodyText,
+		ContentHash: contentHash(raw),
+		Metadata: map[string]string{
+			"path":          workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath),
+			"source_name":   cfg.Name,
+			"source_kind":   kindSpec,
+			"path_ref":      refFallback,
+			"ref_source":    refSource,
+			"title_source":  titleSource,
+			"status_source": statusSource,
+			"domain_source": domainSource,
+		},
+	}, nil
+}
+
+func buildDocRecord(cfg sdk.SourceConfig, options sourceOptions, file selectedJSONFile, raw []byte, document any) (sdk.DocRecord, error) {
+	title, titleSource, err := selectStringField(document, options.titlePointer, strings.TrimSuffix(filepath.Base(file.AbsolutePath), filepath.Ext(file.AbsolutePath)), "filename")
+	if err != nil {
+		return sdk.DocRecord{}, fieldError(cfg.Name, file.AbsolutePath, "title_pointer", err)
+	}
+	refFallback := pathBasedRef("json-doc://", file.RelativePath, cfg.Repo, cfg.PrimaryRepoID)
+	ref, refSource, err := selectStringField(document, options.refPointer, refFallback, "path")
+	if err != nil {
+		return sdk.DocRecord{}, fieldError(cfg.Name, file.AbsolutePath, "ref_pointer", err)
+	}
+	bodyValue, err := selectBodyValue(document, options.bodyPointer)
+	if err != nil {
+		return sdk.DocRecord{}, fieldError(cfg.Name, file.AbsolutePath, "body_pointer", err)
+	}
+	bodyText, err := renderDocBody(title, bodyValue)
+	if err != nil {
+		return sdk.DocRecord{}, fmt.Errorf("source %q json %q: render body: %w", cfg.Name, workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath), err)
+	}
+
+	return sdk.DocRecord{
+		Ref:         ref,
+		Kind:        sdk.ArtifactKindDoc,
+		Title:       title,
+		SourceRef:   fileSourceRef(cfg.WorkspaceRoot, file.AbsolutePath),
+		BodyFormat:  sdk.BodyFormatMarkdown,
+		BodyText:    bodyText,
+		ContentHash: contentHash(raw),
+		Metadata: map[string]string{
+			"path":         workspaceRelative(cfg.WorkspaceRoot, file.AbsolutePath),
+			"source_name":  cfg.Name,
+			"source_kind":  kindDoc,
+			"path_ref":     refFallback,
+			"ref_source":   refSource,
+			"title_source": titleSource,
+		},
+	}, nil
+}
+
+func fieldError(sourceName, path, option string, err error) error {
+	return fmt.Errorf("source %q json %q %s: %w", sourceName, filepath.ToSlash(path), option, err)
+}
+
+func selectStringField(document any, pointer, fallback, fallbackSource string) (string, string, error) {
+	if pointer == "" {
+		return fallback, fallbackSource, nil
+	}
+	value, err := lookupPointer(document, pointer)
+	if err != nil {
+		return "", "", err
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", "", fmt.Errorf("expected string, got %T", value)
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", "", fmt.Errorf("value must not be empty")
+	}
+	return text, "json_pointer", nil
+}
+
+func selectStatus(document any, pointer string) (string, string, error) {
+	if pointer == "" {
+		return sdk.StatusDraft, "default", nil
+	}
+	value, err := lookupPointer(document, pointer)
+	if err != nil {
+		return "", "", err
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", "", fmt.Errorf("expected string, got %T", value)
+	}
+	status := strings.ToLower(strings.TrimSpace(text))
+	switch status {
+	case sdk.StatusDraft, sdk.StatusReview, sdk.StatusAccepted, sdk.StatusSuperseded, sdk.StatusDeprecated:
+		return status, "json_pointer", nil
+	default:
+		return "", "", fmt.Errorf("unsupported status %q", text)
+	}
+}
+
+func selectDomain(document any, pointer, sourceName string) (string, string, error) {
+	if pointer == "" {
+		return defaultDomain(sourceName), "source_name", nil
+	}
+	value, err := lookupPointer(document, pointer)
+	if err != nil {
+		return "", "", err
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", "", fmt.Errorf("expected string, got %T", value)
+	}
+	text = normalizeDomain(text)
+	if text == "" {
+		return "", "", fmt.Errorf("value must not be empty")
+	}
+	return text, "json_pointer", nil
+}
+
+func selectStringListField(document any, pointer string) ([]string, error) {
+	if pointer == "" {
+		return nil, nil
+	}
+	value, err := lookupPointer(document, pointer)
+	if err != nil {
+		return nil, err
+	}
+	return toStringSlice(value)
+}
+
+func selectBodyValue(document any, pointer string) (any, error) {
+	if pointer == "" {
+		return document, nil
+	}
+	return lookupPointer(document, pointer)
+}
+
+func renderSpecBody(title, ref, status, domain string, authors, tags, dependsOn, supersedes, relatesTo, appliesTo []string, bodyValue any) (string, error) {
+	var builder strings.Builder
+	builder.WriteString("# " + title + "\n\n")
+	builder.WriteString("Ref: " + ref + "\n")
+	builder.WriteString("Status: " + status + "\n")
+	if domain != "" {
+		builder.WriteString("Domain: " + domain + "\n")
+	}
+	if len(authors) > 0 {
+		builder.WriteString("Authors: " + strings.Join(authors, ", ") + "\n")
+	}
+	if len(tags) > 0 {
+		builder.WriteString("Tags: " + strings.Join(tags, ", ") + "\n")
+	}
+	if len(dependsOn) > 0 {
+		builder.WriteString("Depends On: " + strings.Join(dependsOn, ", ") + "\n")
+	}
+	if len(supersedes) > 0 {
+		builder.WriteString("Supersedes: " + strings.Join(supersedes, ", ") + "\n")
+	}
+	if len(relatesTo) > 0 {
+		builder.WriteString("Relates To: " + strings.Join(relatesTo, ", ") + "\n")
+	}
+	if len(appliesTo) > 0 {
+		builder.WriteString("Applies To: " + strings.Join(appliesTo, ", ") + "\n")
+	}
+	builder.WriteString("\n")
+
+	body, err := renderBodyValue(bodyValue)
+	if err != nil {
+		return "", err
+	}
+	builder.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		builder.WriteString("\n")
+	}
+	return builder.String(), nil
+}
+
+func renderDocBody(title string, bodyValue any) (string, error) {
+	var builder strings.Builder
+	builder.WriteString("# " + title + "\n\n")
+	body, err := renderBodyValue(bodyValue)
+	if err != nil {
+		return "", err
+	}
+	builder.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		builder.WriteString("\n")
+	}
+	return builder.String(), nil
+}
+
+func renderBodyValue(bodyValue any) (string, error) {
+	switch typed := bodyValue.(type) {
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return "```json\n\"\"\n```\n", nil
+		}
+		return trimmed + "\n", nil
+	default:
+		rendered, err := stdjson.MarshalIndent(bodyValue, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return "```json\n" + string(rendered) + "\n```\n", nil
+	}
+}
+
+func buildRelations(dependsOn, supersedes, relatesTo []string) []sdk.Relation {
+	relations := make([]sdk.Relation, 0, len(dependsOn)+len(supersedes)+len(relatesTo))
+	for _, ref := range dependsOn {
+		relations = append(relations, sdk.Relation{Type: sdk.RelationDependsOn, Ref: ref})
+	}
+	for _, ref := range supersedes {
+		relations = append(relations, sdk.Relation{Type: sdk.RelationSupersedes, Ref: ref})
+	}
+	for _, ref := range relatesTo {
+		relations = append(relations, sdk.Relation{Type: sdk.RelationRelatesTo, Ref: ref})
+	}
+	return relations
+}
+
+func toStringSlice(value any) ([]string, error) {
+	switch typed := value.(type) {
+	case string:
+		text := strings.TrimSpace(typed)
+		if text == "" {
+			return nil, fmt.Errorf("value must not be empty")
+		}
+		return []string{text}, nil
+	case []any:
+		result := make([]string, 0, len(typed))
+		for i, item := range typed {
+			text, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("item %d: expected string, got %T", i, item)
+			}
+			text = strings.TrimSpace(text)
+			if text == "" {
+				return nil, fmt.Errorf("item %d: value must not be empty", i)
+			}
+			result = append(result, text)
+		}
+		return uniqueStrings(result), nil
+	default:
+		return nil, fmt.Errorf("expected string or string array, got %T", value)
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func lookupPointer(document any, pointer string) (any, error) {
+	if pointer == "" {
+		return document, nil
+	}
+	parts, err := parseJSONPointer(pointer)
+	if err != nil {
+		return nil, err
+	}
+
+	current := document
+	for _, part := range parts {
+		switch typed := current.(type) {
+		case map[string]any:
+			next, ok := typed[part]
+			if !ok {
+				return nil, fmt.Errorf("pointer %q does not exist", pointer)
+			}
+			current = next
+		case []any:
+			index, err := parsePointerIndex(part, len(typed))
+			if err != nil {
+				return nil, fmt.Errorf("pointer %q: %w", pointer, err)
+			}
+			current = typed[index]
+		default:
+			return nil, fmt.Errorf("pointer %q cannot descend into %T", pointer, current)
+		}
+	}
+	return current, nil
+}
+
+func validateJSONPointer(pointer string) error {
+	_, err := parseJSONPointer(pointer)
+	return err
+}
+
+func parseJSONPointer(pointer string) ([]string, error) {
+	if pointer == "" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(pointer, "/") {
+		return nil, fmt.Errorf("must be empty or start with '/'")
+	}
+
+	rawParts := strings.Split(pointer[1:], "/")
+	parts := make([]string, 0, len(rawParts))
+	for _, part := range rawParts {
+		decoded, err := decodePointerToken(part)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, decoded)
+	}
+	return parts, nil
+}
+
+func decodePointerToken(token string) (string, error) {
+	var builder strings.Builder
+	for i := 0; i < len(token); i++ {
+		if token[i] != '~' {
+			builder.WriteByte(token[i])
+			continue
+		}
+		if i+1 >= len(token) {
+			return "", fmt.Errorf("invalid escape in JSON pointer token %q", token)
+		}
+		i++
+		switch token[i] {
+		case '0':
+			builder.WriteByte('~')
+		case '1':
+			builder.WriteByte('/')
+		default:
+			return "", fmt.Errorf("invalid escape in JSON pointer token %q", token)
+		}
+	}
+	return builder.String(), nil
+}
+
+func parsePointerIndex(raw string, length int) (int, error) {
+	if raw == "" {
+		return 0, fmt.Errorf("array index must not be empty")
+	}
+	index := 0
+	for i := 0; i < len(raw); i++ {
+		if raw[i] < '0' || raw[i] > '9' {
+			return 0, fmt.Errorf("array index %q is not numeric", raw)
+		}
+		index = index*10 + int(raw[i]-'0')
+	}
+	if index < 0 || index >= length {
+		return 0, fmt.Errorf("array index %q is out of range", raw)
+	}
+	return index, nil
+}
+
+func pathBasedRef(prefix, relativePath, repoID, primaryRepoID string) string {
+	relativePath = strings.TrimSuffix(filepath.ToSlash(relativePath), ".json")
+	relativePath = strings.TrimPrefix(strings.TrimSpace(relativePath), "/")
+	repoID = strings.TrimSpace(repoID)
+	primaryRepoID = strings.TrimSpace(primaryRepoID)
+	if repoID == "" || repoID == primaryRepoID {
+		return prefix + relativePath
+	}
+	return prefix + repoID + "/" + relativePath
+}
+
+func fileSourceRef(workspaceRoot, path string) string {
+	return "file://" + workspaceRelative(workspaceRoot, path)
+}
+
+func workspaceRelative(workspaceRoot, path string) string {
+	rel, err := filepath.Rel(workspaceRoot, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func defaultDomain(sourceName string) string {
+	normalized := normalizeDomain(sourceName)
+	if normalized == "" {
+		return "json"
+	}
+	return normalized
+}
+
+func normalizeDomain(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range value {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			builder.WriteRune(r)
+			lastDash = false
+		case r == '-' || r == '_' || r == ' ' || r == '/':
+			if !lastDash && builder.Len() > 0 {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func contentHash(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}

--- a/extensions/json/adapter.go
+++ b/extensions/json/adapter.go
@@ -12,6 +12,7 @@ import (
 	pathpkg "path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/dusk-network/pituitary/sdk"
@@ -230,35 +231,61 @@ func resolveSourceRoot(workspaceRoot, sourcePath string) (string, error) {
 	switch {
 	case err == nil && !info.IsDir():
 		return "", fmt.Errorf("path %q is not a directory", sourcePath)
-	case err != nil:
+	case os.IsNotExist(err):
 		return "", fmt.Errorf("path %q does not exist", sourcePath)
+	case err != nil:
+		return "", fmt.Errorf("stat path %q: %w", sourcePath, err)
 	}
 	return resolvedPath, nil
 }
 
 func validateExplicitJSONFiles(sourceRoot string, files []string) error {
 	for i, relFile := range files {
-		normalized := filepath.ToSlash(strings.TrimSpace(relFile))
-		if pathpkg.Ext(normalized) != ".json" {
-			return fmt.Errorf("files[%d]: %q must point to a JSON file", i, relFile)
+		normalized, err := normalizeExplicitJSONFilePath(relFile)
+		if err != nil {
+			return fmt.Errorf("files[%d]: %q %v", i, relFile, err)
 		}
 		resolvedFile := filepath.Join(sourceRoot, filepath.FromSlash(normalized))
 		info, err := os.Stat(resolvedFile)
 		switch {
 		case err == nil && info.IsDir():
 			return fmt.Errorf("files[%d]: %q is a directory", i, relFile)
-		case err != nil:
+		case os.IsNotExist(err):
 			return fmt.Errorf("files[%d]: %q does not exist", i, relFile)
+		case err != nil:
+			return fmt.Errorf("files[%d]: stat %q: %w", i, relFile, err)
 		}
 	}
 	return nil
 }
 
+func normalizeExplicitJSONFilePath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("must point to a JSON file")
+	}
+	if filepath.IsAbs(value) {
+		return "", fmt.Errorf("must be relative to the source root")
+	}
+
+	normalized := pathpkg.Clean(filepath.ToSlash(value))
+	if normalized == "." {
+		return "", fmt.Errorf("must point to a JSON file")
+	}
+	if normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return "", fmt.Errorf("escapes the source root")
+	}
+	if pathpkg.Ext(normalized) != ".json" {
+		return "", fmt.Errorf("must point to a JSON file")
+	}
+	return normalized, nil
+}
+
 func normalizeKind(kind string) string {
 	switch strings.TrimSpace(kind) {
-	case kindSpec, sdk.ArtifactKindSpec:
+	case kindSpec:
 		return kindSpec
-	case kindDoc, sdk.ArtifactKindDoc:
+	case kindDoc:
 		return kindDoc
 	default:
 		return ""
@@ -358,48 +385,48 @@ func loadJSONArtifact(ctx context.Context, cfg sdk.SourceConfig, options sourceO
 func buildSpecRecord(cfg sdk.SourceConfig, options sourceOptions, file selectedJSONFile, raw []byte, document any) (sdk.SpecRecord, error) {
 	title, titleSource, err := selectStringField(document, options.titlePointer, strings.TrimSuffix(filepath.Base(file.AbsolutePath), filepath.Ext(file.AbsolutePath)), "filename")
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "title_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "title_pointer", err)
 	}
 	refFallback := pathBasedRef("json-spec://", file.RelativePath, cfg.Repo, cfg.PrimaryRepoID)
 	ref, refSource, err := selectStringField(document, options.refPointer, refFallback, "path")
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "ref_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "ref_pointer", err)
 	}
 	status, statusSource, err := selectStatus(document, options.statusPointer)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "status_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "status_pointer", err)
 	}
 	domain, domainSource, err := selectDomain(document, options.domainPointer, cfg.Name)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "domain_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "domain_pointer", err)
 	}
 	authors, err := selectStringListField(document, options.authorsPointer)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "authors_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "authors_pointer", err)
 	}
 	tags, err := selectStringListField(document, options.tagsPointer)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "tags_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "tags_pointer", err)
 	}
 	dependsOn, err := selectStringListField(document, options.dependsOnPointer)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "depends_on_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "depends_on_pointer", err)
 	}
 	supersedes, err := selectStringListField(document, options.supersedesPointer)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "supersedes_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "supersedes_pointer", err)
 	}
 	relatesTo, err := selectStringListField(document, options.relatesToPointer)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "relates_to_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "relates_to_pointer", err)
 	}
 	appliesTo, err := selectStringListField(document, options.appliesToPointer)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "applies_to_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "applies_to_pointer", err)
 	}
 	bodyValue, err := selectBodyValue(document, options.bodyPointer)
 	if err != nil {
-		return sdk.SpecRecord{}, fieldError(cfg.Name, file.AbsolutePath, "body_pointer", err)
+		return sdk.SpecRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "body_pointer", err)
 	}
 	bodyText, err := renderSpecBody(title, ref, status, domain, authors, tags, dependsOn, supersedes, relatesTo, appliesTo, bodyValue)
 	if err != nil {
@@ -436,16 +463,16 @@ func buildSpecRecord(cfg sdk.SourceConfig, options sourceOptions, file selectedJ
 func buildDocRecord(cfg sdk.SourceConfig, options sourceOptions, file selectedJSONFile, raw []byte, document any) (sdk.DocRecord, error) {
 	title, titleSource, err := selectStringField(document, options.titlePointer, strings.TrimSuffix(filepath.Base(file.AbsolutePath), filepath.Ext(file.AbsolutePath)), "filename")
 	if err != nil {
-		return sdk.DocRecord{}, fieldError(cfg.Name, file.AbsolutePath, "title_pointer", err)
+		return sdk.DocRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "title_pointer", err)
 	}
 	refFallback := pathBasedRef("json-doc://", file.RelativePath, cfg.Repo, cfg.PrimaryRepoID)
 	ref, refSource, err := selectStringField(document, options.refPointer, refFallback, "path")
 	if err != nil {
-		return sdk.DocRecord{}, fieldError(cfg.Name, file.AbsolutePath, "ref_pointer", err)
+		return sdk.DocRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "ref_pointer", err)
 	}
 	bodyValue, err := selectBodyValue(document, options.bodyPointer)
 	if err != nil {
-		return sdk.DocRecord{}, fieldError(cfg.Name, file.AbsolutePath, "body_pointer", err)
+		return sdk.DocRecord{}, fieldError(cfg.Name, cfg.WorkspaceRoot, file.AbsolutePath, "body_pointer", err)
 	}
 	bodyText, err := renderDocBody(title, bodyValue)
 	if err != nil {
@@ -471,8 +498,8 @@ func buildDocRecord(cfg sdk.SourceConfig, options sourceOptions, file selectedJS
 	}, nil
 }
 
-func fieldError(sourceName, path, option string, err error) error {
-	return fmt.Errorf("source %q json %q %s: %w", sourceName, filepath.ToSlash(path), option, err)
+func fieldError(sourceName, workspaceRoot, path, option string, err error) error {
+	return fmt.Errorf("source %q json %q %s: %w", sourceName, workspaceRelative(workspaceRoot, path), option, err)
 }
 
 func selectStringField(document any, pointer, fallback, fallbackSource string) (string, string, error) {
@@ -762,12 +789,12 @@ func parsePointerIndex(raw string, length int) (int, error) {
 	if raw == "" {
 		return 0, fmt.Errorf("array index must not be empty")
 	}
-	index := 0
-	for i := 0; i < len(raw); i++ {
-		if raw[i] < '0' || raw[i] > '9' {
-			return 0, fmt.Errorf("array index %q is not numeric", raw)
-		}
-		index = index*10 + int(raw[i]-'0')
+	if len(raw) > 1 && raw[0] == '0' {
+		return 0, fmt.Errorf("array index %q has invalid leading zero", raw)
+	}
+	index, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("array index %q is not numeric", raw)
 	}
 	if index < 0 || index >= length {
 		return 0, fmt.Errorf("array index %q is out of range", raw)

--- a/extensions/json/adapter_test.go
+++ b/extensions/json/adapter_test.go
@@ -1,0 +1,208 @@
+package jsonadapter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/sdk"
+)
+
+func TestAdapterLoadsJSONSpecWithMappedFields(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "schemas", "rate-limit.json"), `{
+  "meta": {
+    "ref": "SPEC-JSON-001",
+    "status": "accepted",
+    "domain": "api",
+    "authors": ["alice", "bob"],
+    "tags": ["rate-limit", "api"],
+    "depends_on": ["SPEC-BASE-001"],
+    "applies_to": ["config://api/rate-limit.json"]
+  },
+  "info": {
+    "title": "JSON Rate Limits"
+  },
+  "description": "JSON-backed rate limiting policy."
+}`)
+
+	adapter := &adapter{}
+	result, err := adapter.Load(context.Background(), sdk.SourceConfig{
+		Name:          "api-json",
+		Adapter:       adapterName,
+		Kind:          kindSpec,
+		Path:          "schemas",
+		WorkspaceRoot: root,
+		Options: map[string]any{
+			"ref_pointer":        "/meta/ref",
+			"title_pointer":      "/info/title",
+			"body_pointer":       "/description",
+			"status_pointer":     "/meta/status",
+			"domain_pointer":     "/meta/domain",
+			"authors_pointer":    "/meta/authors",
+			"tags_pointer":       "/meta/tags",
+			"depends_on_pointer": "/meta/depends_on",
+			"applies_to_pointer": "/meta/applies_to",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got, want := len(result.Specs), 1; got != want {
+		t.Fatalf("spec count = %d, want %d", got, want)
+	}
+	spec := result.Specs[0]
+	if got, want := spec.Ref, "SPEC-JSON-001"; got != want {
+		t.Fatalf("spec ref = %q, want %q", got, want)
+	}
+	if got, want := spec.Status, sdk.StatusAccepted; got != want {
+		t.Fatalf("spec status = %q, want %q", got, want)
+	}
+	if got, want := spec.Domain, "api"; got != want {
+		t.Fatalf("spec domain = %q, want %q", got, want)
+	}
+	if got, want := spec.Metadata["path"], "schemas/rate-limit.json"; got != want {
+		t.Fatalf("spec metadata path = %q, want %q", got, want)
+	}
+	if !strings.Contains(spec.BodyText, "JSON-backed rate limiting policy.") {
+		t.Fatalf("spec body = %q, want mapped body text", spec.BodyText)
+	}
+	if got, want := len(spec.Relations), 1; got != want {
+		t.Fatalf("relation count = %d, want %d", got, want)
+	}
+}
+
+func TestAdapterLoadsJSONDocWithPathFallbacks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "artifacts", "schema.json"), `{
+  "title": "Event Schema",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"}
+  }
+}`)
+
+	adapter := &adapter{}
+	result, err := adapter.Load(context.Background(), sdk.SourceConfig{
+		Name:          "json-docs",
+		Adapter:       adapterName,
+		Kind:          kindDoc,
+		Path:          "artifacts",
+		WorkspaceRoot: root,
+		Options: map[string]any{
+			"title_pointer": "/title",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got, want := len(result.Docs), 1; got != want {
+		t.Fatalf("doc count = %d, want %d", got, want)
+	}
+	doc := result.Docs[0]
+	if got, want := doc.Ref, "json-doc://schema"; got != want {
+		t.Fatalf("doc ref = %q, want %q", got, want)
+	}
+	if got, want := doc.Title, "Event Schema"; got != want {
+		t.Fatalf("doc title = %q, want %q", got, want)
+	}
+	if !strings.Contains(doc.BodyText, "properties") {
+		t.Fatalf("doc body = %q, want rendered JSON body", doc.BodyText)
+	}
+}
+
+func TestAdapterPreviewListsSelectedJSONFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "schemas", "keep.json"), `{"title":"Keep"}`)
+	writeFile(t, filepath.Join(root, "schemas", "skip.json"), `{"title":"Skip"}`)
+
+	adapter := &adapter{}
+	items, err := adapter.Preview(context.Background(), sdk.SourceConfig{
+		Name:          "json-docs",
+		Adapter:       adapterName,
+		Kind:          kindDoc,
+		Path:          "schemas",
+		WorkspaceRoot: root,
+		Files:         []string{"keep.json"},
+	})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("preview item count = %d, want %d", got, want)
+	}
+	if got, want := items[0].Path, "schemas/keep.json"; got != want {
+		t.Fatalf("preview path = %q, want %q", got, want)
+	}
+	if got, want := items[0].ArtifactKind, sdk.ArtifactKindDoc; got != want {
+		t.Fatalf("preview artifact kind = %q, want %q", got, want)
+	}
+}
+
+func TestAdapterRejectsDocOnlySpecFields(t *testing.T) {
+	t.Parallel()
+
+	adapter := &adapter{}
+	_, err := adapter.Load(context.Background(), sdk.SourceConfig{
+		Name:          "json-docs",
+		Adapter:       adapterName,
+		Kind:          kindDoc,
+		Path:          ".",
+		WorkspaceRoot: t.TempDir(),
+		Options: map[string]any{
+			"status_pointer": "/status",
+		},
+	})
+	if err == nil {
+		t.Fatal("Load() error = nil, want doc/spec option failure")
+	}
+	if !strings.Contains(err.Error(), `options.status_pointer is only supported for kind "json_spec"`) {
+		t.Fatalf("Load() error = %q, want spec-only option detail", err)
+	}
+}
+
+func TestAdapterRejectsMissingMappedField(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "schemas", "broken.json"), `{"title":"Broken"}`)
+
+	adapter := &adapter{}
+	_, err := adapter.Load(context.Background(), sdk.SourceConfig{
+		Name:          "broken-json",
+		Adapter:       adapterName,
+		Kind:          kindSpec,
+		Path:          "schemas",
+		WorkspaceRoot: root,
+		Options: map[string]any{
+			"status_pointer": "/status",
+		},
+	})
+	if err == nil {
+		t.Fatal("Load() error = nil, want missing pointer failure")
+	}
+	if !strings.Contains(err.Error(), `pointer "/status" does not exist`) {
+		t.Fatalf("Load() error = %q, want pointer detail", err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/extensions/json/adapter_test.go
+++ b/extensions/json/adapter_test.go
@@ -192,8 +192,49 @@ func TestAdapterRejectsMissingMappedField(t *testing.T) {
 	if err == nil {
 		t.Fatal("Load() error = nil, want missing pointer failure")
 	}
+	if !strings.Contains(err.Error(), `json "schemas/broken.json"`) {
+		t.Fatalf("Load() error = %q, want workspace-relative path", err)
+	}
 	if !strings.Contains(err.Error(), `pointer "/status" does not exist`) {
 		t.Fatalf("Load() error = %q, want pointer detail", err)
+	}
+	if strings.Contains(err.Error(), root) {
+		t.Fatalf("Load() error = %q, should not leak absolute workspace path", err)
+	}
+}
+
+func TestAdapterRejectsEscapingExplicitJSONFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "schemas", "rate-limit.json"), `{"title":"Rate Limit"}`)
+
+	adapter := &adapter{}
+	_, err := adapter.Preview(context.Background(), sdk.SourceConfig{
+		Name:          "json-docs",
+		Adapter:       adapterName,
+		Kind:          kindDoc,
+		Path:          "schemas",
+		WorkspaceRoot: root,
+		Files:         []string{"../rate-limit.json"},
+	})
+	if err == nil {
+		t.Fatal("Preview() error = nil, want escaping file selector failure")
+	}
+	if !strings.Contains(err.Error(), `files[0]: "../rate-limit.json" escapes the source root`) {
+		t.Fatalf("Preview() error = %q, want escaping path detail", err)
+	}
+}
+
+func TestParsePointerIndexRejectsLeadingZero(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePointerIndex("007", 8)
+	if err == nil {
+		t.Fatal("parsePointerIndex() error = nil, want leading-zero failure")
+	}
+	if !strings.Contains(err.Error(), `array index "007" has invalid leading zero`) {
+		t.Fatalf("parsePointerIndex() error = %q, want leading-zero detail", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,9 +19,12 @@ import (
 const (
 	CurrentSchemaVersion       = 3
 	AdapterFilesystem          = "filesystem"
+	AdapterJSON                = "json"
 	SourceKindSpecBundle       = "spec_bundle"
 	SourceKindMarkdownDocs     = "markdown_docs"
 	SourceKindMarkdownContract = "markdown_contract"
+	SourceKindJSONSpec         = "json_spec"
+	SourceKindJSONDoc          = "json_doc"
 	SourceRoleCanonical        = "canonical"
 	SourceRoleCurrentState     = "current_state"
 	SourceRoleRuntimeAuth      = "runtime_authoritative"
@@ -567,8 +570,16 @@ func validate(cfg *Config) error {
 		}
 
 		filesystemSource := source.Adapter == AdapterFilesystem
-		if strings.TrimSpace(source.Path) == "" && filesystemSource {
+		jsonSource := source.Adapter == AdapterJSON
+		if strings.TrimSpace(source.Path) == "" && (filesystemSource || jsonSource) {
 			errs.add("%s.path: value is required", label)
+		}
+		if jsonSource {
+			switch source.Kind {
+			case SourceKindJSONSpec, SourceKindJSONDoc:
+			default:
+				errs.add("%s.kind: unsupported kind %q for adapter %q", label, source.Kind, source.Adapter)
+			}
 		}
 		files := make([]string, 0, len(source.Files))
 		seenFiles := make(map[string]struct{}, len(source.Files))
@@ -584,6 +595,10 @@ func validate(cfg *Config) error {
 			}
 			if filesystemSource && (source.Kind == SourceKindMarkdownDocs || source.Kind == SourceKindMarkdownContract) && pathpkg.Ext(normalized) != ".md" {
 				errs.add("%s.files[%d]: %q must point to a markdown file for kind %q", label, i, value, source.Kind)
+				continue
+			}
+			if jsonSource && pathpkg.Ext(normalized) != ".json" {
+				errs.add("%s.files[%d]: %q must point to a JSON file for adapter %q", label, i, value, source.Adapter)
 				continue
 			}
 			if _, exists := seenFiles[normalized]; exists {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,9 @@ func init() {
 	sdk.Register("github", func() sdk.Adapter {
 		return nil
 	})
+	sdk.Register(AdapterJSON, func() sdk.Adapter {
+		return nil
+	})
 }
 
 func TestLoadResolvesWorkspaceAndSourcePaths(t *testing.T) {
@@ -480,6 +483,58 @@ files = ["../guide.md"]
 	}
 	if !strings.Contains(err.Error(), `source "docs".files[0]: "../guide.md" escapes the source root`) {
 		t.Fatalf("Load() error = %q, want invalid source-file selector detail", err)
+	}
+}
+
+func TestLoadRejectsJSONSourceWithoutPath(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "json-specs"
+adapter = "json"
+kind = "json_spec"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want missing JSON path error")
+	}
+	if !strings.Contains(err.Error(), `source "json-specs".path: value is required`) {
+		t.Fatalf("Load() error = %q, want missing JSON path detail", err)
+	}
+}
+
+func TestLoadRejectsUnsupportedJSONKind(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "schemas"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "json-specs"
+adapter = "json"
+kind = "spec"
+path = "schemas"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want unsupported JSON kind error")
+	}
+	if !strings.Contains(err.Error(), `source "json-specs".kind: unsupported kind "spec" for adapter "json"`) {
+		t.Fatalf("Load() error = %q, want unsupported JSON kind detail", err)
 	}
 }
 

--- a/internal/source/explain.go
+++ b/internal/source/explain.go
@@ -17,8 +17,11 @@ const (
 	explainReasonNotMatchedByInclude     = "not_matched_by_include"
 	explainReasonExcludedBySelector      = "excluded_by_selector"
 	explainReasonNotMarkdownFile         = "not_markdown_file"
+	explainReasonNotJSONFile             = "not_json_file"
 	explainReasonIndexedMarkdownDoc      = "indexed_markdown_doc"
 	explainReasonIndexedMarkdownContract = "indexed_markdown_contract"
+	explainReasonIndexedJSONSpec         = "indexed_json_spec"
+	explainReasonIndexedJSONDoc          = "indexed_json_doc"
 	explainReasonIndexedSpecBundle       = "indexed_spec_bundle"
 	explainReasonBundleMemberNotIndexed  = "bundle_member_not_indexed_directly"
 	explainReasonNotInSpecBundle         = "not_in_spec_bundle"
@@ -186,6 +189,10 @@ func explainFileInSource(workspaceRoot string, source config.Source, absolutePat
 		return explainMarkdownContractSource(workspaceRoot, explanation, source, absolutePath)
 	case config.SourceKindSpecBundle:
 		return explainSpecBundleSource(workspaceRoot, explanation, source, absolutePath)
+	case "json_spec":
+		return explainJSONSource(explanation, source, model.ArtifactKindSpec, explainReasonIndexedJSONSpec)
+	case "json_doc":
+		return explainJSONSource(explanation, source, model.ArtifactKindDoc, explainReasonIndexedJSONDoc)
 	default:
 		return SourceFileExplanation{}, fmt.Errorf("source %q: unsupported kind %q", source.Name, source.Kind)
 	}
@@ -210,6 +217,28 @@ func explainMarkdownDocSource(explanation SourceFileExplanation, source config.S
 	explanation.Selected = true
 	explanation.ArtifactKind = model.ArtifactKindDoc
 	explanation.Reason = explainReasonIndexedMarkdownDoc
+	return explanation, nil
+}
+
+func explainJSONSource(explanation SourceFileExplanation, source config.Source, artifactKind, indexedReason string) (SourceFileExplanation, error) {
+	selection, err := evaluateSourcePathSelection(source, explanation.RelativePath)
+	if err != nil {
+		return SourceFileExplanation{}, err
+	}
+	populateSelectionMatches(&explanation, selection)
+
+	if filepath.Ext(explanation.RelativePath) != ".json" {
+		explanation.Reason = explainReasonNotJSONFile
+		return explanation, nil
+	}
+	if !selection.Selected {
+		explanation.Reason = selection.Reason
+		return explanation, nil
+	}
+
+	explanation.Selected = true
+	explanation.ArtifactKind = artifactKind
+	explanation.Reason = indexedReason
 	return explanation, nil
 }
 

--- a/internal/source/explain.go
+++ b/internal/source/explain.go
@@ -189,9 +189,9 @@ func explainFileInSource(workspaceRoot string, source config.Source, absolutePat
 		return explainMarkdownContractSource(workspaceRoot, explanation, source, absolutePath)
 	case config.SourceKindSpecBundle:
 		return explainSpecBundleSource(workspaceRoot, explanation, source, absolutePath)
-	case "json_spec":
+	case config.SourceKindJSONSpec:
 		return explainJSONSource(explanation, source, model.ArtifactKindSpec, explainReasonIndexedJSONSpec)
-	case "json_doc":
+	case config.SourceKindJSONDoc:
 		return explainJSONSource(explanation, source, model.ArtifactKindDoc, explainReasonIndexedJSONDoc)
 	default:
 		return SourceFileExplanation{}, fmt.Errorf("source %q: unsupported kind %q", source.Name, source.Kind)

--- a/internal/source/preview.go
+++ b/internal/source/preview.go
@@ -1,11 +1,13 @@
 package source
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/diag"
+	"github.com/dusk-network/pituitary/sdk"
 )
 
 // PreviewResult describes which items each configured source will contribute.
@@ -76,6 +78,10 @@ func previewSource(workspaceRoot string, source config.Source) (SourcePreview, e
 		Exclude: append([]string(nil), source.Exclude...),
 	}
 
+	if source.Adapter != config.AdapterFilesystem {
+		return previewViaAdapter(preview, source)
+	}
+
 	switch source.Kind {
 	case config.SourceKindSpecBundle:
 		bundleDirs, err := discoverSpecBundles(source)
@@ -115,6 +121,45 @@ func previewSource(workspaceRoot string, source config.Source) (SourcePreview, e
 		return SourcePreview{}, fmt.Errorf("source %q: unsupported kind %q", source.Name, source.Kind)
 	}
 
+	preview.ItemCount = len(preview.Items)
+	return preview, nil
+}
+
+func previewViaAdapter(preview SourcePreview, source config.Source) (SourcePreview, error) {
+	factory := LookupAdapter(source.Adapter)
+	if factory == nil {
+		return SourcePreview{}, unknownAdapterError(source.Name, source.Adapter)
+	}
+
+	adapter := factory()
+	previewer, ok := adapter.(sdk.Previewer)
+	if !ok {
+		return SourcePreview{}, fmt.Errorf("source %q: adapter %q does not support preview", source.Name, source.Adapter)
+	}
+
+	items, err := previewer.Preview(context.Background(), sdk.SourceConfig{
+		Name:          source.Name,
+		Adapter:       source.Adapter,
+		Kind:          source.Kind,
+		Repo:          source.ResolvedRepo,
+		Path:          source.Path,
+		Files:         append([]string(nil), source.Files...),
+		Include:       append([]string(nil), source.Include...),
+		Exclude:       append([]string(nil), source.Exclude...),
+		Options:       config.CloneSourceOptions(source.Options),
+		WorkspaceRoot: source.RepoRootPath,
+		PrimaryRepoID: source.PrimaryRepo,
+	})
+	if err != nil {
+		return SourcePreview{}, fmt.Errorf("source %q: %w", source.Name, err)
+	}
+
+	for _, item := range items {
+		preview.Items = append(preview.Items, PreviewItem{
+			ArtifactKind: item.ArtifactKind,
+			Path:         item.Path,
+		})
+	}
 	preview.ItemCount = len(preview.Items)
 	return preview, nil
 }

--- a/sdk/adapter.go
+++ b/sdk/adapter.go
@@ -13,6 +13,18 @@ type AdapterResult struct {
 	Docs  []DocRecord
 }
 
+// Previewer enumerates the items an adapter would index without rebuilding.
+// Adapters that don't support source previews may omit this interface.
+type Previewer interface {
+	Preview(ctx context.Context, cfg SourceConfig) ([]PreviewItem, error)
+}
+
+// PreviewItem describes one source item that an adapter would index.
+type PreviewItem struct {
+	ArtifactKind string `json:"artifact_kind"`
+	Path         string `json:"path"`
+}
+
 // AdapterFactory creates an adapter instance.
 type AdapterFactory func() Adapter
 


### PR DESCRIPTION
## Summary

- add a built-in `json` source adapter for structured intent artifacts
- support `json_spec` and `json_doc` sources with JSON Pointer field mapping and sensible path/body fallbacks
- wire JSON-backed sources through `preview-sources`, `index`, and `explain-file`, and document the configuration

## Backlog / Issue

- closes #156

## Core Trust Surface

- This PR touches config / source / path-resolution behavior.
- It adds adapter-based source loading and preview handling for JSON sources, plus `explain-file` matching for indexed JSON artifacts.
- Blocking checks:
  - `go test ./extensions/json`
  - `go test ./cmd -run 'TestRun(ExplainFileJSONSource|IndexWithJSONAdapter|PreviewSourcesJSON)'`

## Validation

- [ ] I ran `make ci`
- [x] I added or updated tests where needed

## Notes

- `json_spec` defaults `status` to `draft` when unset.
- refs, titles, and domains fall back to path-derived values so sparse JSON documents can still index deterministically.
- full-repo `make ci` was not run; I kept validation to the smallest relevant test surface for this issue.