### PR TITLE
feat(analysis): cap completions, rank sections, and add minimal harness

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -1,0 +1,772 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dusk-network/pituitary/internal/analysis"
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+type benchmarkCase struct {
+	ID           string                `json:"id"`
+	Operation    string                `json:"operation"`
+	Description  string                `json:"description,omitempty"`
+	Request      json.RawMessage       `json:"request"`
+	Expectations benchmarkExpectations `json:"expectations"`
+}
+
+type benchmarkExpectations struct {
+	MustIncludePaths          []string          `json:"must_include_paths,omitempty"`
+	MustIncludeSpecRefs       []string          `json:"must_include_spec_refs,omitempty"`
+	MustIncludeDocRefs        []string          `json:"must_include_doc_refs,omitempty"`
+	MustExcludeDocRefs        []string          `json:"must_exclude_doc_refs,omitempty"`
+	MustIncludeAffectedRefs   []string          `json:"must_include_affected_refs,omitempty"`
+	MustIncludeFindingCodes   []string          `json:"must_include_finding_codes,omitempty"`
+	AssessmentStatuses        map[string]string `json:"assessment_statuses,omitempty"`
+	CompatibilityLevel        string            `json:"compatibility_level,omitempty"`
+	RecommendationContains    []string          `json:"recommendation_contains,omitempty"`
+	MinimumCompliantFindings  int               `json:"minimum_compliant_findings,omitempty"`
+	MaximumConflictFindings   *int              `json:"maximum_conflict_findings,omitempty"`
+	RequireStructuredEvidence bool              `json:"require_structured_evidence,omitempty"`
+}
+
+type benchmarkCheck struct {
+	Name    string `json:"name"`
+	Passed  bool   `json:"passed"`
+	Details string `json:"details,omitempty"`
+}
+
+type benchmarkCaseResult struct {
+	ID                  string           `json:"id"`
+	Operation           string           `json:"operation"`
+	ExecutedOperation   string           `json:"executed_operation"`
+	OperationNote       string           `json:"operation_note,omitempty"`
+	Description         string           `json:"description,omitempty"`
+	LatencyMS           float64          `json:"latency_ms"`
+	JSONValid           bool             `json:"json_valid"`
+	OutputBytes         int              `json:"output_bytes"`
+	AnalysisRuntimeUsed bool             `json:"analysis_runtime_used"`
+	ChatCompletionCalls int              `json:"chat_completion_calls"`
+	PromptSizeBytes     *int             `json:"prompt_size_bytes"`
+	ResponseSizeBytes   *int             `json:"response_size_bytes"`
+	Passed              bool             `json:"passed"`
+	Error               string           `json:"error,omitempty"`
+	Checks              []benchmarkCheck `json:"checks,omitempty"`
+}
+
+type benchmarkSummary struct {
+	TotalCases                   int     `json:"total_cases"`
+	PassedCases                  int     `json:"passed_cases"`
+	FailedCases                  int     `json:"failed_cases"`
+	MeanLatencyMS                float64 `json:"mean_latency_ms"`
+	CasesUsingAnalysisRuntime    int     `json:"cases_using_analysis_runtime"`
+	CasesWithPromptMeasurement   int     `json:"cases_with_prompt_measurement"`
+	CasesWithResponseMeasurement int     `json:"cases_with_response_measurement"`
+}
+
+type benchmarkReport struct {
+	GeneratedAt      string                `json:"generated_at"`
+	ConfigPath       string                `json:"config_path"`
+	CasesDir         string                `json:"cases_dir"`
+	AnalysisProvider string                `json:"analysis_provider"`
+	Summary          benchmarkSummary      `json:"summary"`
+	Cases            []benchmarkCaseResult `json:"cases"`
+}
+
+type analysisCapture struct {
+	Calls         int
+	PromptBytes   int
+	ResponseBytes int
+}
+
+type analysisProxy struct {
+	client  *http.Client
+	server  *httptest.Server
+	target  string
+	mu      sync.Mutex
+	capture analysisCapture
+}
+
+func main() {
+	os.Exit(run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("bench", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var (
+		configPath string
+		casesDir   string
+		format     string
+	)
+	fs.StringVar(&configPath, "config", "pituitary.toml", "path to workspace config")
+	fs.StringVar(&casesDir, "cases-dir", "testdata/bench", "path to benchmark cases")
+	fs.StringVar(&format, "format", "text", "output format: text or json")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "bench: unexpected positional arguments: %s\n", strings.Join(fs.Args(), " "))
+		return 2
+	}
+	if format != "text" && format != "json" {
+		fmt.Fprintf(stderr, "bench: unsupported format %q\n", format)
+		return 2
+	}
+
+	report, err := runBenchmarks(ctx, configPath, casesDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "bench: %v\n", err)
+		return 1
+	}
+
+	if format == "json" {
+		encoded, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "bench: encode json report: %v\n", err)
+			return 1
+		}
+		_, _ = stdout.Write(encoded)
+		_, _ = stdout.Write([]byte("\n"))
+		return 0
+	}
+
+	renderTextReport(stdout, report)
+	return 0
+}
+
+func runBenchmarks(ctx context.Context, configPath, casesDir string) (*benchmarkReport, error) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return nil, err
+	}
+	cases, err := loadBenchmarkCases(casesDir)
+	if err != nil {
+		return nil, err
+	}
+
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("load sources: %w", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		return nil, fmt.Errorf("rebuild index: %w", err)
+	}
+
+	cfg = cloneConfig(cfg)
+	var proxy *analysisProxy
+	if cfg.Runtime.Analysis.Provider == config.RuntimeProviderOpenAI && strings.TrimSpace(cfg.Runtime.Analysis.Endpoint) != "" {
+		proxy, err = newAnalysisProxy(cfg.Runtime.Analysis.Endpoint)
+		if err != nil {
+			return nil, err
+		}
+		defer proxy.Close()
+		cfg.Runtime.Analysis.Endpoint = proxy.server.URL
+	}
+
+	report := &benchmarkReport{
+		GeneratedAt:      time.Now().UTC().Format(time.RFC3339),
+		ConfigPath:       cfg.ConfigPath,
+		CasesDir:         filepath.Clean(casesDir),
+		AnalysisProvider: cfg.Runtime.Analysis.Provider,
+		Cases:            make([]benchmarkCaseResult, 0, len(cases)),
+	}
+
+	var totalLatency float64
+	for _, benchCase := range cases {
+		result := runBenchmarkCase(ctx, cfg, proxy, benchCase)
+		totalLatency += result.LatencyMS
+		report.Cases = append(report.Cases, result)
+	}
+
+	report.Summary = summarizeBenchmarkResults(report.Cases, totalLatency)
+	return report, nil
+}
+
+func loadBenchmarkCases(casesDir string) ([]benchmarkCase, error) {
+	entries, err := os.ReadDir(casesDir)
+	if err != nil {
+		return nil, fmt.Errorf("read cases dir %s: %w", casesDir, err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no benchmark case files found in %s", casesDir)
+	}
+
+	cases := make([]benchmarkCase, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(casesDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read benchmark case %s: %w", path, err)
+		}
+		var benchCase benchmarkCase
+		if err := json.Unmarshal(data, &benchCase); err != nil {
+			return nil, fmt.Errorf("decode benchmark case %s: %w", path, err)
+		}
+		if strings.TrimSpace(benchCase.ID) == "" {
+			return nil, fmt.Errorf("benchmark case %s: id is required", path)
+		}
+		if len(benchCase.Request) == 0 {
+			return nil, fmt.Errorf("benchmark case %s: request is required", path)
+		}
+		cases = append(cases, benchCase)
+	}
+
+	return cases, nil
+}
+
+func runBenchmarkCase(ctx context.Context, cfg *config.Config, proxy *analysisProxy, benchCase benchmarkCase) benchmarkCaseResult {
+	executedOperation, note, err := resolveOperation(benchCase.Operation)
+	result := benchmarkCaseResult{
+		ID:                benchCase.ID,
+		Operation:         benchCase.Operation,
+		ExecutedOperation: executedOperation,
+		OperationNote:     note,
+		Description:       benchCase.Description,
+	}
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+
+	if proxy != nil {
+		proxy.Reset()
+	}
+
+	start := time.Now()
+	output, runErr := executeBenchmarkCase(ctx, cfg, benchCase.Operation, executedOperation, benchCase.Request)
+	result.LatencyMS = float64(time.Since(start).Microseconds()) / 1000.0
+	if runErr != nil {
+		result.Error = runErr.Error()
+		result.Passed = false
+		if proxy != nil {
+			applyCapture(&result, proxy.Snapshot())
+		}
+		return result
+	}
+
+	encoded, marshalErr := json.Marshal(output)
+	result.JSONValid = marshalErr == nil
+	if marshalErr == nil {
+		result.OutputBytes = len(encoded)
+	} else {
+		result.Error = fmt.Sprintf("encode result JSON: %v", marshalErr)
+	}
+
+	if proxy != nil {
+		applyCapture(&result, proxy.Snapshot())
+	}
+
+	result.Checks = evaluateBenchmarkCase(benchCase, output)
+	result.Passed = benchmarkChecksPassed(result.Checks) && result.Error == ""
+	return result
+}
+
+func resolveOperation(operation string) (string, string, error) {
+	switch strings.TrimSpace(operation) {
+	case "compare-specs":
+		return "compare-specs", "", nil
+	case "check-doc-drift":
+		return "check-doc-drift", "", nil
+	case "check-compliance":
+		return "check-compliance", "", nil
+	case "analyze-impact":
+		return "analyze-impact", "", nil
+	case "analyze-impact-severity":
+		return "analyze-impact", "Current ship does not split analyze-impact severity into a separate runtime call, so this case exercises the shipped analyze-impact baseline.", nil
+	default:
+		return "", "", fmt.Errorf("unsupported operation %q", operation)
+	}
+}
+
+func executeBenchmarkCase(ctx context.Context, cfg *config.Config, declaredOperation, executedOperation string, rawRequest json.RawMessage) (any, error) {
+	switch executedOperation {
+	case "compare-specs":
+		var request analysis.CompareRequest
+		if err := json.Unmarshal(rawRequest, &request); err != nil {
+			return nil, fmt.Errorf("decode %s request: %w", declaredOperation, err)
+		}
+		return analysis.CompareSpecsContext(ctx, cfg, request)
+	case "check-doc-drift":
+		var request analysis.DocDriftRequest
+		if err := json.Unmarshal(rawRequest, &request); err != nil {
+			return nil, fmt.Errorf("decode %s request: %w", declaredOperation, err)
+		}
+		return analysis.CheckDocDriftContext(ctx, cfg, request)
+	case "check-compliance":
+		var request analysis.ComplianceRequest
+		if err := json.Unmarshal(rawRequest, &request); err != nil {
+			return nil, fmt.Errorf("decode %s request: %w", declaredOperation, err)
+		}
+		return analysis.CheckComplianceContext(ctx, cfg, request)
+	case "analyze-impact":
+		var request analysis.AnalyzeImpactRequest
+		if err := json.Unmarshal(rawRequest, &request); err != nil {
+			return nil, fmt.Errorf("decode %s request: %w", declaredOperation, err)
+		}
+		return analysis.AnalyzeImpactContext(ctx, cfg, request)
+	default:
+		return nil, fmt.Errorf("unsupported executed operation %q", executedOperation)
+	}
+}
+
+func evaluateBenchmarkCase(benchCase benchmarkCase, output any) []benchmarkCheck {
+	switch result := output.(type) {
+	case *analysis.CompareResult:
+		return evaluateCompareCase(benchCase.Expectations, result)
+	case *analysis.DocDriftResult:
+		return evaluateDocDriftCase(benchCase.Expectations, result)
+	case *analysis.ComplianceResult:
+		return evaluateComplianceCase(benchCase.Expectations, result)
+	case *analysis.AnalyzeImpactResult:
+		return evaluateImpactCase(benchCase.Expectations, result)
+	default:
+		return []benchmarkCheck{{
+			Name:    "unsupported_result_type",
+			Passed:  false,
+			Details: fmt.Sprintf("unsupported result type %T", output),
+		}}
+	}
+}
+
+func evaluateCompareCase(expect benchmarkExpectations, result *analysis.CompareResult) []benchmarkCheck {
+	checks := make([]benchmarkCheck, 0, 4)
+	checks = append(checks, containsAllCheck("spec_refs", result.SpecRefs, expect.MustIncludeSpecRefs))
+	if expect.CompatibilityLevel != "" {
+		checks = append(checks, benchmarkCheck{
+			Name:    "compatibility_level",
+			Passed:  result.Comparison.Compatibility.Level == expect.CompatibilityLevel,
+			Details: fmt.Sprintf("got %q want %q", result.Comparison.Compatibility.Level, expect.CompatibilityLevel),
+		})
+	}
+	if len(expect.RecommendationContains) > 0 {
+		checks = append(checks, containsSubstringsCheck("recommendation", result.Comparison.Recommendation, expect.RecommendationContains))
+	}
+	return checks
+}
+
+func evaluateDocDriftCase(expect benchmarkExpectations, result *analysis.DocDriftResult) []benchmarkCheck {
+	checks := make([]benchmarkCheck, 0, 6)
+	driftDocRefs := make([]string, 0, len(result.DriftItems))
+	specRefs := make([]string, 0)
+	for _, item := range result.DriftItems {
+		driftDocRefs = append(driftDocRefs, item.DocRef)
+		specRefs = append(specRefs, item.SpecRefs...)
+	}
+	checks = append(checks, containsAllCheck("drift_doc_refs", driftDocRefs, expect.MustIncludeDocRefs))
+	checks = append(checks, excludesAllCheck("excluded_doc_refs", driftDocRefs, expect.MustExcludeDocRefs))
+	checks = append(checks, containsAllCheck("spec_refs", uniqueSorted(specRefs), expect.MustIncludeSpecRefs))
+	if len(expect.AssessmentStatuses) > 0 {
+		statuses := make(map[string]string, len(result.Assessments))
+		for _, assessment := range result.Assessments {
+			statuses[assessment.DocRef] = assessment.Status
+		}
+		for docRef, want := range expect.AssessmentStatuses {
+			got := statuses[docRef]
+			checks = append(checks, benchmarkCheck{
+				Name:    "assessment_status:" + docRef,
+				Passed:  got == want,
+				Details: fmt.Sprintf("got %q want %q", got, want),
+			})
+		}
+	}
+	if expect.RequireStructuredEvidence {
+		structured := false
+		for _, item := range result.DriftItems {
+			for _, finding := range item.Findings {
+				if finding.Evidence != nil && finding.Evidence.SpecSection != "" && finding.Evidence.DocSection != "" {
+					structured = true
+					break
+				}
+			}
+		}
+		checks = append(checks, benchmarkCheck{
+			Name:    "structured_evidence",
+			Passed:  structured,
+			Details: "at least one drift finding should include spec/doc sections",
+		})
+	}
+	return checks
+}
+
+func evaluateComplianceCase(expect benchmarkExpectations, result *analysis.ComplianceResult) []benchmarkCheck {
+	checks := make([]benchmarkCheck, 0, 6)
+	relevantSpecRefs := make([]string, 0, len(result.RelevantSpecs))
+	for _, spec := range result.RelevantSpecs {
+		relevantSpecRefs = append(relevantSpecRefs, spec.SpecRef)
+	}
+	checks = append(checks, containsAllCheck("paths", result.Paths, expect.MustIncludePaths))
+	checks = append(checks, containsAllCheck("relevant_spec_refs", uniqueSorted(relevantSpecRefs), expect.MustIncludeSpecRefs))
+	checks = append(checks, benchmarkCheck{
+		Name:    "minimum_compliant_findings",
+		Passed:  len(result.Compliant) >= expect.MinimumCompliantFindings,
+		Details: fmt.Sprintf("got %d want >= %d", len(result.Compliant), expect.MinimumCompliantFindings),
+	})
+	if expect.MaximumConflictFindings != nil {
+		checks = append(checks, benchmarkCheck{
+			Name:    "maximum_conflict_findings",
+			Passed:  len(result.Conflicts) <= *expect.MaximumConflictFindings,
+			Details: fmt.Sprintf("got %d want <= %d", len(result.Conflicts), *expect.MaximumConflictFindings),
+		})
+	}
+	if len(expect.MustIncludeFindingCodes) > 0 {
+		codes := make([]string, 0, len(result.Compliant)+len(result.Conflicts)+len(result.Unspecified))
+		for _, finding := range result.Compliant {
+			codes = append(codes, finding.Code)
+		}
+		for _, finding := range result.Conflicts {
+			codes = append(codes, finding.Code)
+		}
+		for _, finding := range result.Unspecified {
+			codes = append(codes, finding.Code)
+		}
+		checks = append(checks, containsAllCheck("finding_codes", uniqueSorted(codes), expect.MustIncludeFindingCodes))
+	}
+	if expect.RequireStructuredEvidence {
+		structured := false
+		for _, finding := range append(append([]analysis.ComplianceFinding{}, result.Compliant...), result.Conflicts...) {
+			if finding.SectionHeading != "" {
+				structured = true
+				break
+			}
+		}
+		checks = append(checks, benchmarkCheck{
+			Name:    "structured_evidence",
+			Passed:  structured,
+			Details: "at least one compliance finding should include a section heading",
+		})
+	}
+	return checks
+}
+
+func evaluateImpactCase(expect benchmarkExpectations, result *analysis.AnalyzeImpactResult) []benchmarkCheck {
+	checks := make([]benchmarkCheck, 0, 6)
+	affectedSpecRefs := make([]string, 0, len(result.AffectedSpecs))
+	for _, spec := range result.AffectedSpecs {
+		affectedSpecRefs = append(affectedSpecRefs, spec.Ref)
+	}
+	affectedDocRefs := make([]string, 0, len(result.AffectedDocs))
+	for _, doc := range result.AffectedDocs {
+		affectedDocRefs = append(affectedDocRefs, doc.Ref)
+	}
+	affectedRefs := make([]string, 0, len(result.AffectedRefs))
+	for _, ref := range result.AffectedRefs {
+		affectedRefs = append(affectedRefs, ref.Ref)
+	}
+
+	checks = append(checks, containsAllCheck("affected_spec_refs", uniqueSorted(affectedSpecRefs), expect.MustIncludeSpecRefs))
+	checks = append(checks, containsAllCheck("affected_doc_refs", uniqueSorted(affectedDocRefs), expect.MustIncludeDocRefs))
+	checks = append(checks, containsAllCheck("affected_refs", uniqueSorted(affectedRefs), expect.MustIncludeAffectedRefs))
+	if expect.RequireStructuredEvidence {
+		structured := false
+		for _, doc := range result.AffectedDocs {
+			if doc.Evidence != nil && doc.Evidence.SpecSection != "" && doc.Evidence.DocSection != "" && len(doc.SuggestedTargets) > 0 {
+				structured = true
+				break
+			}
+		}
+		checks = append(checks, benchmarkCheck{
+			Name:    "structured_evidence",
+			Passed:  structured,
+			Details: "at least one impacted doc should include linked evidence and suggested targets",
+		})
+	}
+	return checks
+}
+
+func containsAllCheck(name string, got []string, want []string) benchmarkCheck {
+	if len(want) == 0 {
+		return benchmarkCheck{Name: name, Passed: true, Details: "no expectation"}
+	}
+	missing := make([]string, 0)
+	have := make(map[string]struct{}, len(got))
+	for _, value := range got {
+		have[value] = struct{}{}
+	}
+	for _, value := range want {
+		if _, ok := have[value]; !ok {
+			missing = append(missing, value)
+		}
+	}
+	return benchmarkCheck{
+		Name:    name,
+		Passed:  len(missing) == 0,
+		Details: fmt.Sprintf("missing=%v got=%v", missing, got),
+	}
+}
+
+func excludesAllCheck(name string, got []string, excluded []string) benchmarkCheck {
+	if len(excluded) == 0 {
+		return benchmarkCheck{Name: name, Passed: true, Details: "no expectation"}
+	}
+	found := make([]string, 0)
+	have := make(map[string]struct{}, len(got))
+	for _, value := range got {
+		have[value] = struct{}{}
+	}
+	for _, value := range excluded {
+		if _, ok := have[value]; ok {
+			found = append(found, value)
+		}
+	}
+	return benchmarkCheck{
+		Name:    name,
+		Passed:  len(found) == 0,
+		Details: fmt.Sprintf("found=%v got=%v", found, got),
+	}
+}
+
+func containsSubstringsCheck(name string, got string, want []string) benchmarkCheck {
+	missing := make([]string, 0)
+	for _, value := range want {
+		if !strings.Contains(got, value) {
+			missing = append(missing, value)
+		}
+	}
+	return benchmarkCheck{
+		Name:    name,
+		Passed:  len(missing) == 0,
+		Details: fmt.Sprintf("missing=%v got=%q", missing, got),
+	}
+}
+
+func benchmarkChecksPassed(checks []benchmarkCheck) bool {
+	if len(checks) == 0 {
+		return false
+	}
+	for _, check := range checks {
+		if !check.Passed {
+			return false
+		}
+	}
+	return true
+}
+
+func summarizeBenchmarkResults(results []benchmarkCaseResult, totalLatency float64) benchmarkSummary {
+	summary := benchmarkSummary{TotalCases: len(results)}
+	if len(results) > 0 {
+		summary.MeanLatencyMS = totalLatency / float64(len(results))
+	}
+	for _, result := range results {
+		if result.Passed {
+			summary.PassedCases++
+		} else {
+			summary.FailedCases++
+		}
+		if result.AnalysisRuntimeUsed {
+			summary.CasesUsingAnalysisRuntime++
+		}
+		if result.PromptSizeBytes != nil {
+			summary.CasesWithPromptMeasurement++
+		}
+		if result.ResponseSizeBytes != nil {
+			summary.CasesWithResponseMeasurement++
+		}
+	}
+	return summary
+}
+
+func renderTextReport(w io.Writer, report *benchmarkReport) {
+	fmt.Fprintf(w, "Pituitary minimal benchmark harness\n\n")
+	fmt.Fprintf(w, "config: %s\n", report.ConfigPath)
+	fmt.Fprintf(w, "cases: %s\n", report.CasesDir)
+	fmt.Fprintf(w, "analysis runtime: %s\n", defaultString(report.AnalysisProvider, "disabled"))
+	fmt.Fprintf(w, "summary: %d/%d passed | mean latency %.2fms | runtime-used %d case(s)\n\n",
+		report.Summary.PassedCases,
+		report.Summary.TotalCases,
+		report.Summary.MeanLatencyMS,
+		report.Summary.CasesUsingAnalysisRuntime,
+	)
+	for _, result := range report.Cases {
+		prompt := "n/a"
+		if result.PromptSizeBytes != nil {
+			prompt = fmt.Sprintf("%dB", *result.PromptSizeBytes)
+		}
+		response := "n/a"
+		if result.ResponseSizeBytes != nil {
+			response = fmt.Sprintf("%dB", *result.ResponseSizeBytes)
+		}
+		status := "FAIL"
+		if result.Passed {
+			status = "PASS"
+		}
+		fmt.Fprintf(w, "%s | %s | latency %.2fms | prompt %s | response %s | checks %d\n",
+			status, result.ID, result.LatencyMS, prompt, response, len(result.Checks))
+		if result.OperationNote != "" {
+			fmt.Fprintf(w, "  note: %s\n", result.OperationNote)
+		}
+		if result.Error != "" {
+			fmt.Fprintf(w, "  error: %s\n", result.Error)
+			continue
+		}
+		for _, check := range result.Checks {
+			checkStatus := "ok"
+			if !check.Passed {
+				checkStatus = "fail"
+			}
+			fmt.Fprintf(w, "  - %s: %s\n", checkStatus, check.Name)
+		}
+	}
+}
+
+func newAnalysisProxy(target string) (*analysisProxy, error) {
+	target = strings.TrimRight(strings.TrimSpace(target), "/")
+	if target == "" {
+		return nil, errors.New("analysis proxy target is required")
+	}
+	proxy := &analysisProxy{client: &http.Client{}, target: target}
+	proxy.server = httptest.NewServer(http.HandlerFunc(proxy.handle))
+	return proxy, nil
+}
+
+func (p *analysisProxy) handle(w http.ResponseWriter, r *http.Request) {
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read proxy request: %v", err), http.StatusBadGateway)
+		return
+	}
+	_ = r.Body.Close()
+
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, p.target+r.URL.Path, bytes.NewReader(requestBody))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("build upstream request: %v", err), http.StatusBadGateway)
+		return
+	}
+	upstreamReq.Header = r.Header.Clone()
+	upstreamReq.URL.RawQuery = r.URL.RawQuery
+
+	resp, err := p.client.Do(upstreamReq)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("proxy upstream request: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read upstream response: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	p.mu.Lock()
+	p.capture.Calls++
+	p.capture.PromptBytes += len(requestBody)
+	p.capture.ResponseBytes += len(responseBody)
+	p.mu.Unlock()
+
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(responseBody)
+}
+
+func (p *analysisProxy) Reset() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.capture = analysisCapture{}
+}
+
+func (p *analysisProxy) Snapshot() analysisCapture {
+	if p == nil {
+		return analysisCapture{}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.capture
+}
+
+func (p *analysisProxy) Close() {
+	if p == nil || p.server == nil {
+		return
+	}
+	p.server.Close()
+}
+
+func applyCapture(result *benchmarkCaseResult, capture analysisCapture) {
+	result.ChatCompletionCalls = capture.Calls
+	result.AnalysisRuntimeUsed = capture.Calls > 0
+	if capture.Calls == 0 {
+		return
+	}
+	result.PromptSizeBytes = intPtr(capture.PromptBytes)
+	result.ResponseSizeBytes = intPtr(capture.ResponseBytes)
+}
+
+func cloneConfig(cfg *config.Config) *config.Config {
+	if cfg == nil {
+		return nil
+	}
+	cloned := *cfg
+	cloned.Runtime = cfg.Runtime
+	cloned.Runtime.Profiles = make(map[string]config.RuntimeProvider, len(cfg.Runtime.Profiles))
+	for name, profile := range cfg.Runtime.Profiles {
+		cloned.Runtime.Profiles[name] = profile
+	}
+	cloned.Sources = append([]config.Source(nil), cfg.Sources...)
+	return &cloned
+}
+
+func uniqueSorted(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRunBenchmarksOnFixtureWorkspace(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	report, err := runBenchmarks(context.Background(), filepath.Join(root, "pituitary.toml"), filepath.Join(root, "testdata", "bench"))
+	if err != nil {
+		t.Fatalf("runBenchmarks() error = %v", err)
+	}
+	if got, want := report.Summary.TotalCases, 4; got != want {
+		t.Fatalf("summary.total_cases = %d, want %d", got, want)
+	}
+	if got, want := report.Summary.PassedCases, 4; got != want {
+		t.Fatalf("summary.passed_cases = %d, want %d", got, want)
+	}
+	if got, want := report.Summary.CasesUsingAnalysisRuntime, 0; got != want {
+		t.Fatalf("summary.cases_using_analysis_runtime = %d, want %d", got, want)
+	}
+}
+
+func TestRunBenchmarksCapturesAnalysisRuntimeTraffic(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	workspace := t.TempDir()
+	copyTree(t, filepath.Join(root, "specs", "rate-limit-legacy"), filepath.Join(workspace, "specs", "rate-limit-legacy"))
+	copyTree(t, filepath.Join(root, "specs", "rate-limit-v2"), filepath.Join(workspace, "specs", "rate-limit-v2"))
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("path = %s, want /chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"content": `{
+							"shared_scope": ["domain:api"],
+							"differences": [
+								{"spec_ref": "SPEC-008", "items": ["Uses a fixed window."]},
+								{"spec_ref": "SPEC-042", "items": ["Uses tenant-scoped overrides."]}
+							],
+							"tradeoffs": [{"topic": "migration", "summary": "SPEC-042 is the accepted successor."}],
+							"compatibility": {"level": "superseding", "summary": "SPEC-042 replaces SPEC-008."},
+							"recommendation": "prefer SPEC-042 as the accepted successor"
+						}`,
+					},
+				},
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	configPath := filepath.Join(workspace, "pituitary.toml")
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[runtime.analysis]
+provider = "openai_compatible"
+model = "pituitary-analysis"
+endpoint = "`+upstream.URL+`"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	casesDir := filepath.Join(workspace, "cases")
+	if err := os.MkdirAll(casesDir, 0o755); err != nil {
+		t.Fatalf("mkdir cases dir: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(casesDir, "compare.json"), `{
+  "id": "compare-runtime-capture",
+  "operation": "compare-specs",
+  "request": {
+    "spec_refs": ["SPEC-008", "SPEC-042"]
+  },
+  "expectations": {
+    "must_include_spec_refs": ["SPEC-008", "SPEC-042"],
+    "compatibility_level": "superseding",
+    "recommendation_contains": ["SPEC-042"]
+  }
+}`)
+
+	report, err := runBenchmarks(context.Background(), configPath, casesDir)
+	if err != nil {
+		t.Fatalf("runBenchmarks() error = %v", err)
+	}
+	if got, want := report.Summary.TotalCases, 1; got != want {
+		t.Fatalf("summary.total_cases = %d, want %d", got, want)
+	}
+	if got, want := report.Summary.CasesUsingAnalysisRuntime, 1; got != want {
+		t.Fatalf("summary.cases_using_analysis_runtime = %d, want %d", got, want)
+	}
+	caseResult := report.Cases[0]
+	if !caseResult.Passed {
+		t.Fatalf("case result = %+v, want pass", caseResult)
+	}
+	if caseResult.PromptSizeBytes == nil || *caseResult.PromptSizeBytes == 0 {
+		t.Fatalf("prompt_size_bytes = %+v, want measured prompt bytes", caseResult.PromptSizeBytes)
+	}
+	if caseResult.ResponseSizeBytes == nil || *caseResult.ResponseSizeBytes == 0 {
+		t.Fatalf("response_size_bytes = %+v, want measured response bytes", caseResult.ResponseSizeBytes)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func copyTree(t *testing.T, src, dst string) {
+	t.Helper()
+	if err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	}); err != nil {
+		t.Fatalf("copyTree(%s, %s): %v", src, dst, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir parent for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/docs/development/testing-guide.md
+++ b/docs/development/testing-guide.md
@@ -164,11 +164,14 @@ Benchmarks live in:
 
 - `internal/index/benchmark_test.go`
 - `internal/analysis/benchmark_test.go`
+- `testdata/bench/` plus `go run ./cmd/bench` for the minimal golden-case harness
 
 Run them with:
 
 ```sh
 make bench
+go run ./cmd/bench --format text
+go run ./cmd/bench --format json
 ```
 
 Use these when a change affects:

--- a/internal/analysis/adjudicate_compliance.go
+++ b/internal/analysis/adjudicate_compliance.go
@@ -66,7 +66,7 @@ func (p *openAICompatibleAnalysisProvider) AdjudicateCompliance(ctx context.Cont
 	}
 
 	var response complianceAdjudicationResponse
-	if err := p.completeJSON(ctx, openAICompatibleComplianceAdjudicateSystemPrompt, payload, &response); err != nil {
+	if err := p.completeJSON(ctx, payload.Command, openAICompatibleComplianceAdjudicateSystemPrompt, payload, &response); err != nil {
 		return nil, err
 	}
 	response.Adjudications = normalizeAdjudications(response.Adjudications, request.Targets)

--- a/internal/analysis/classify_impact.go
+++ b/internal/analysis/classify_impact.go
@@ -61,7 +61,7 @@ func (p *openAICompatibleAnalysisProvider) ClassifyImpactSeverity(ctx context.Co
 	}
 
 	var response impactSeverityResponse
-	if err := p.completeJSON(ctx, openAICompatibleImpactSeveritySystemPrompt, payload, &response); err != nil {
+	if err := p.completeJSON(ctx, payload.Command, openAICompatibleImpactSeveritySystemPrompt, payload, &response); err != nil {
 		return nil, err
 	}
 	response.Classifications = normalizeImpactClassifications(response.Classifications, request.Items)

--- a/internal/analysis/compare_test.go
+++ b/internal/analysis/compare_test.go
@@ -103,6 +103,9 @@ func TestCompareSpecsUsesAnalysisProviderWhenEnabled(t *testing.T) {
 		if got, want := request.Model, "pituitary-analysis"; got != want {
 			t.Fatalf("request.model = %q, want %q", got, want)
 		}
+		if got, want := request.MaxTokens, 1024; got != want {
+			t.Fatalf("request.max_tokens = %d, want %d", got, want)
+		}
 		if len(request.Messages) != 2 {
 			t.Fatalf("messages = %d, want 2", len(request.Messages))
 		}
@@ -113,6 +116,15 @@ func TestCompareSpecsUsesAnalysisProviderWhenEnabled(t *testing.T) {
 		}
 		if got, want := prompt.OrderedRefs, []string{"SPEC-008", "SPEC-042"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 			t.Fatalf("ordered_refs = %v, want %v", got, want)
+		}
+		if len(prompt.Specs) != 2 {
+			t.Fatalf("spec prompts = %+v, want two prompts", prompt.Specs)
+		}
+		if got, want := prompt.Specs[0].Sections[0].Heading, "Requirements"; got != want {
+			t.Fatalf("first prompt section heading = %q, want %q", got, want)
+		}
+		if got, want := prompt.Specs[1].Sections[0].Heading, "Requirements"; got != want {
+			t.Fatalf("second prompt section heading = %q, want %q", got, want)
 		}
 
 		return `{

--- a/internal/analysis/doc_drift_test.go
+++ b/internal/analysis/doc_drift_test.go
@@ -313,6 +313,9 @@ func TestCheckDocDriftUsesAnalysisProviderWhenEnabled(t *testing.T) {
 
 	configureOpenAIAnalysisProvider(t, cfg, func(t *testing.T, request openAICompatibleChatRequest) string {
 		t.Helper()
+		if got, want := request.MaxTokens, 2048; got != want {
+			t.Fatalf("request.max_tokens = %d, want %d", got, want)
+		}
 		var prompt docDriftAnalysisPrompt
 		if err := json.Unmarshal([]byte(request.Messages[1].Content), &prompt); err != nil {
 			t.Fatalf("unmarshal prompt: %v", err)

--- a/internal/analysis/infer_metadata.go
+++ b/internal/analysis/infer_metadata.go
@@ -69,7 +69,7 @@ func (p *openAICompatibleAnalysisProvider) InferMetadata(ctx context.Context, re
 	}
 
 	var response MetadataInferenceResult
-	if err := p.completeJSON(ctx, openAICompatibleInferMetadataSystemPrompt, payload, &response); err != nil {
+	if err := p.completeJSON(ctx, payload.Command, openAICompatibleInferMetadataSystemPrompt, payload, &response); err != nil {
 		return nil, err
 	}
 	normalizeMetadataInference(&response)

--- a/internal/analysis/openai_provider.go
+++ b/internal/analysis/openai_provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/openaicompat"
+	"github.com/dusk-network/pituitary/internal/ranking"
 )
 
 type qualitativeAnalyzer interface {
@@ -74,7 +75,7 @@ const (
 	openAICompatibleProbeSystemPrompt    = "You are Pituitary's runtime probe. Return only one JSON object with key ok set to true."
 	openAICompatibleCompareSystemPrompt  = "You are Pituitary's compare-specs adjudicator. Use only the provided spec evidence. Return only one JSON object with keys shared_scope, differences, tradeoffs, compatibility, and recommendation. Preserve spec refs exactly. Keep every difference items array concise and limited to concrete design choices from the provided specs."
 	openAICompatibleDocDriftSystemPrompt = "You are Pituitary's doc-drift adjudicator. Use only the provided deterministic findings and cited spec/doc evidence. Return only one JSON object with keys findings and suggestions. Do not invent new finding codes or spec refs. Findings must correspond to the provided deterministic findings, and suggestions must stay actionable and bounded to the same contradictions."
-	analysisPromptSectionLimit           = 6
+	analysisPromptSectionLimit           = 4
 	analysisPromptSectionContentLimit    = 500
 	openAICompatibleAnalysisRuntime      = "runtime.analysis"
 )
@@ -121,7 +122,7 @@ func (p *openAICompatibleAnalysisProvider) Probe(ctx context.Context) error {
 	var response struct {
 		OK bool `json:"ok"`
 	}
-	if err := p.completeJSON(ctx, openAICompatibleProbeSystemPrompt, map[string]any{
+	if err := p.completeJSON(ctx, "runtime-probe", openAICompatibleProbeSystemPrompt, map[string]any{
 		"command": "runtime-probe",
 	}, &response); err != nil {
 		return err
@@ -136,12 +137,12 @@ func (p *openAICompatibleAnalysisProvider) Compare(ctx context.Context, orderedR
 	payload := compareAnalysisPrompt{
 		Command:     "compare-specs",
 		OrderedRefs: append([]string(nil), orderedRefs...),
-		Specs:       analysisSpecsFromMap(specs, orderedRefs),
+		Specs:       analysisSpecsForComparison(specs, orderedRefs),
 		Baseline:    base,
 	}
 
 	var provided Comparison
-	if err := p.completeJSON(ctx, openAICompatibleCompareSystemPrompt, payload, &provided); err != nil {
+	if err := p.completeJSON(ctx, payload.Command, openAICompatibleCompareSystemPrompt, payload, &provided); err != nil {
 		return Comparison{}, err
 	}
 	return normalizeProvidedComparison(base, provided, orderedRefs, specs), nil
@@ -150,8 +151,8 @@ func (p *openAICompatibleAnalysisProvider) Compare(ctx context.Context, orderedR
 func (p *openAICompatibleAnalysisProvider) RefineDocDrift(ctx context.Context, doc docDocument, specs map[string]specDocument, item DriftItem, remediation *DocRemediationItem) (*DriftItem, *DocRemediationItem, error) {
 	prompt := docDriftAnalysisPrompt{
 		Command:               "check-doc-drift",
-		Doc:                   analysisDocFromDocument(doc),
-		RelevantSpecs:         analysisSpecsFromSlice(specs),
+		Doc:                   analysisDocFromDocument(doc, flattenedSectionsFromSpecs(specs)),
+		RelevantSpecs:         analysisSpecsForDocDrift(specs, doc),
 		DeterministicFindings: append([]DriftFinding(nil), item.Findings...),
 	}
 	if remediation != nil {
@@ -159,7 +160,7 @@ func (p *openAICompatibleAnalysisProvider) RefineDocDrift(ctx context.Context, d
 	}
 
 	var provided docDriftAnalysisResponse
-	if err := p.completeJSON(ctx, openAICompatibleDocDriftSystemPrompt, prompt, &provided); err != nil {
+	if err := p.completeJSON(ctx, prompt.Command, openAICompatibleDocDriftSystemPrompt, prompt, &provided); err != nil {
 		return nil, nil, err
 	}
 
@@ -174,7 +175,7 @@ func (p *openAICompatibleAnalysisProvider) RefineDocDrift(ctx context.Context, d
 	return &refinedItem, refinedRemediation, nil
 }
 
-func (p *openAICompatibleAnalysisProvider) completeJSON(ctx context.Context, systemPrompt string, input any, target any) error {
+func (p *openAICompatibleAnalysisProvider) completeJSON(ctx context.Context, command string, systemPrompt string, input any, target any) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -184,7 +185,7 @@ func (p *openAICompatibleAnalysisProvider) completeJSON(ctx context.Context, sys
 		return fmt.Errorf("encode runtime.analysis prompt: %w", err)
 	}
 
-	responseBody, err := p.requestChatCompletion(ctx, []openaicompat.ChatMessage{
+	responseBody, err := p.requestChatCompletion(ctx, command, []openaicompat.ChatMessage{
 		{Role: "system", Content: systemPrompt},
 		{Role: "user", Content: string(body)},
 	})
@@ -198,8 +199,8 @@ func (p *openAICompatibleAnalysisProvider) completeJSON(ctx context.Context, sys
 	return nil
 }
 
-func (p *openAICompatibleAnalysisProvider) requestChatCompletion(ctx context.Context, messages []openaicompat.ChatMessage) (string, error) {
-	text, err := p.client.ChatCompletionText(ctx, messages, 0)
+func (p *openAICompatibleAnalysisProvider) requestChatCompletion(ctx context.Context, command string, messages []openaicompat.ChatMessage) (string, error) {
+	text, err := p.client.ChatCompletionText(ctx, messages, 0, analysisResponseTokenLimit(command, p.client.MaxResponseTokens))
 	if err != nil {
 		return "", err
 	}
@@ -242,28 +243,54 @@ func (p *openAICompatibleAnalysisProvider) dependencyError(failureClass, format 
 	return openaicompat.NewDependencyUnavailableWithDetails(details, format, args...)
 }
 
-func analysisSpecsFromMap(specs map[string]specDocument, orderedRefs []string) []analysisSpecPrompt {
+func analysisSpecsFromMap(specs map[string]specDocument, orderedRefs []string, sectionSelector func(specDocument) []analysisSectionPrompt) []analysisSpecPrompt {
 	result := make([]analysisSpecPrompt, 0, len(orderedRefs))
 	for _, ref := range orderedRefs {
 		spec, ok := specs[ref]
 		if !ok {
 			continue
 		}
-		result = append(result, analysisSpecFromDocument(spec))
+		result = append(result, analysisSpecFromDocument(spec, sectionSelector(spec)))
 	}
 	return result
 }
 
-func analysisSpecsFromSlice(specs map[string]specDocument) []analysisSpecPrompt {
+func analysisSpecsFromSlice(specs map[string]specDocument, sectionSelector func(specDocument) []analysisSectionPrompt) []analysisSpecPrompt {
 	refs := make([]string, 0, len(specs))
 	for ref := range specs {
 		refs = append(refs, ref)
 	}
 	sort.Strings(refs)
-	return analysisSpecsFromMap(specs, refs)
+	return analysisSpecsFromMap(specs, refs, sectionSelector)
 }
 
-func analysisSpecFromDocument(spec specDocument) analysisSpecPrompt {
+func analysisSpecsForComparison(specs map[string]specDocument, orderedRefs []string) []analysisSpecPrompt {
+	counterparts := make(map[string][]embeddedSection, len(orderedRefs))
+	for _, ref := range orderedRefs {
+		for _, otherRef := range orderedRefs {
+			if otherRef == ref {
+				continue
+			}
+			counterparts[ref] = append(counterparts[ref], specs[otherRef].Sections...)
+		}
+	}
+	return analysisSpecsFromMap(specs, orderedRefs, func(spec specDocument) []analysisSectionPrompt {
+		return analysisSectionsFromEmbedded(spec.Sections, counterparts[spec.Record.Ref])
+	})
+}
+
+func analysisSpecsForDocDrift(specs map[string]specDocument, doc docDocument) []analysisSpecPrompt {
+	return analysisSpecsFromSlice(specs, func(spec specDocument) []analysisSectionPrompt {
+		return analysisSectionsFromEmbedded(spec.Sections, doc.Sections)
+	})
+}
+
+func analysisSpecFromDocument(spec specDocument, sections ...[]analysisSectionPrompt) analysisSpecPrompt {
+	selectedSections := analysisSectionsFromEmbedded(spec.Sections)
+	if len(sections) > 0 {
+		selectedSections = sections[0]
+	}
+
 	relations := make([]analysisRelationPrompt, 0, len(spec.Record.Relations))
 	for _, relation := range spec.Record.Relations {
 		relations = append(relations, analysisRelationPrompt{
@@ -278,35 +305,125 @@ func analysisSpecFromDocument(spec specDocument) analysisSpecPrompt {
 		Domain:    spec.Record.Domain,
 		AppliesTo: append([]string(nil), spec.Record.AppliesTo...),
 		Relations: relations,
-		Sections:  analysisSectionsFromEmbedded(spec.Sections),
+		Sections:  selectedSections,
 	}
 }
 
-func analysisDocFromDocument(doc docDocument) analysisDocPrompt {
+func analysisDocFromDocument(doc docDocument, counterpartSections []embeddedSection) analysisDocPrompt {
 	return analysisDocPrompt{
 		Ref:       doc.Record.Ref,
 		Title:     doc.Record.Title,
 		SourceRef: doc.Record.SourceRef,
-		Sections:  analysisSectionsFromEmbedded(doc.Sections),
+		Sections:  analysisSectionsFromEmbedded(doc.Sections, counterpartSections),
 	}
 }
 
-func analysisSectionsFromEmbedded(sections []embeddedSection) []analysisSectionPrompt {
-	result := make([]analysisSectionPrompt, 0, minInt(len(sections), analysisPromptSectionLimit))
-	for _, section := range sections {
-		if len(result) == analysisPromptSectionLimit {
-			break
-		}
+func flattenedSectionsFromSpecs(specs map[string]specDocument) []embeddedSection {
+	refs := make([]string, 0, len(specs))
+	for ref := range specs {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+
+	sections := make([]embeddedSection, 0)
+	for _, ref := range refs {
+		sections = append(sections, specs[ref].Sections...)
+	}
+	return sections
+}
+
+type scoredAnalysisSection struct {
+	section    embeddedSection
+	score      float64
+	index      int
+	comparable bool
+}
+
+func analysisSectionsFromEmbedded(sections []embeddedSection, counterpartSections ...[]embeddedSection) []analysisSectionPrompt {
+	var counterparts []embeddedSection
+	if len(counterpartSections) > 0 {
+		counterparts = counterpartSections[0]
+	}
+
+	scored := make([]scoredAnalysisSection, 0, len(sections))
+	anyComparable := false
+	for index, section := range sections {
 		content := strings.TrimSpace(section.Content)
 		if content == "" {
 			continue
 		}
+		score, comparable := analysisSectionRelevance(section, counterparts)
+		anyComparable = anyComparable || comparable
+		scored = append(scored, scoredAnalysisSection{
+			section:    section,
+			score:      score,
+			index:      index,
+			comparable: comparable,
+		})
+	}
+	if anyComparable {
+		sort.SliceStable(scored, func(i, j int) bool {
+			switch {
+			case scored[i].score != scored[j].score:
+				return scored[i].score > scored[j].score
+			case scored[i].comparable != scored[j].comparable:
+				return scored[i].comparable
+			default:
+				return scored[i].index < scored[j].index
+			}
+		})
+	}
+	if len(scored) > analysisPromptSectionLimit {
+		scored = scored[:analysisPromptSectionLimit]
+	}
+
+	result := make([]analysisSectionPrompt, 0, len(scored))
+	for _, candidate := range scored {
 		result = append(result, analysisSectionPrompt{
-			Heading: strings.TrimSpace(section.Heading),
-			Content: truncateForAnalysisPrompt(content, analysisPromptSectionContentLimit),
+			Heading: strings.TrimSpace(candidate.section.Heading),
+			Content: truncateForAnalysisPrompt(strings.TrimSpace(candidate.section.Content), analysisPromptSectionContentLimit),
 		})
 	}
 	return result
+}
+
+func analysisSectionRelevance(section embeddedSection, counterpartSections []embeddedSection) (float64, bool) {
+	if len(section.Embedding) == 0 {
+		return 0, false
+	}
+
+	var (
+		bestScore float64
+		found     bool
+	)
+	for _, counterpart := range counterpartSections {
+		if len(counterpart.Embedding) == 0 {
+			continue
+		}
+		score := cosineSimilarity(section.Embedding, counterpart.Embedding)
+		score = ranking.AdjustHistoricalSectionScore(score, section.Heading, false)
+		if !found || score > bestScore {
+			bestScore = score
+			found = true
+		}
+	}
+	return bestScore, found
+}
+
+func analysisResponseTokenLimit(command string, configured int) int {
+	if configured > 0 {
+		return configured
+	}
+	switch strings.TrimSpace(command) {
+	case "check-doc-drift", "check-compliance-adjudicate":
+		return 2048
+	case "compare-specs", "analyze-impact-severity":
+		return 1024
+	case "runtime-probe":
+		return 64
+	default:
+		return 1024
+	}
 }
 
 func truncateForAnalysisPrompt(text string, limit int) string {

--- a/internal/analysis/openai_provider_test.go
+++ b/internal/analysis/openai_provider_test.go
@@ -111,11 +111,14 @@ func TestCompleteJSONSendsExplicitTemperatureZero(t *testing.T) {
 	provider := rawProvider.(*openAICompatibleAnalysisProvider)
 
 	var response map[string]any
-	if err := provider.completeJSON(context.Background(), "system", map[string]string{"ping": "pong"}, &response); err != nil {
+	if err := provider.completeJSON(context.Background(), "compare-specs", "system", map[string]string{"ping": "pong"}, &response); err != nil {
 		t.Fatalf("completeJSON() error = %v", err)
 	}
 	if got, ok := captured["temperature"]; !ok || got.(float64) != 0 {
 		t.Fatalf("temperature field = %#v, want explicit 0", captured["temperature"])
+	}
+	if got, ok := captured["max_tokens"]; !ok || int(got.(float64)) != 1024 {
+		t.Fatalf("max_tokens field = %#v, want 1024", captured["max_tokens"])
 	}
 }
 
@@ -129,6 +132,9 @@ func TestProbeProviderContextUsesLightweightJSONProbe(t *testing.T) {
 		}
 		if len(request.Messages) != 2 {
 			t.Fatalf("messages = %+v, want system and user prompt", request.Messages)
+		}
+		if got, want := request.MaxTokens, 64; got != want {
+			t.Fatalf("request.max_tokens = %d, want %d", got, want)
 		}
 		if !strings.Contains(request.Messages[0].Content, "runtime probe") {
 			t.Fatalf("system prompt = %q, want runtime probe guidance", request.Messages[0].Content)
@@ -186,7 +192,7 @@ func TestOpenAICompatibleAnalysisProviderParsesStringErrorBodies(t *testing.T) {
 	provider := rawProvider.(*openAICompatibleAnalysisProvider)
 
 	var response map[string]any
-	err = provider.completeJSON(context.Background(), "system", map[string]string{"ping": "pong"}, &response)
+	err = provider.completeJSON(context.Background(), "compare-specs", "system", map[string]string{"ping": "pong"}, &response)
 	if err == nil {
 		t.Fatal("completeJSON() error = nil, want dependency-unavailable failure")
 	}
@@ -239,7 +245,7 @@ func TestOpenAICompatibleAnalysisProviderClassifiesSchemaMismatchDiagnostics(t *
 	provider := rawProvider.(*openAICompatibleAnalysisProvider)
 
 	var response map[string]any
-	err = provider.completeJSON(context.Background(), "system", map[string]string{"ping": "pong"}, &response)
+	err = provider.completeJSON(context.Background(), "compare-specs", "system", map[string]string{"ping": "pong"}, &response)
 	if err == nil {
 		t.Fatal("completeJSON() error = nil, want dependency-unavailable failure")
 	}
@@ -252,5 +258,92 @@ func TestOpenAICompatibleAnalysisProviderClassifiesSchemaMismatchDiagnostics(t *
 	}
 	if got, want := details["request_type"], "analysis"; got != want {
 		t.Fatalf("details.request_type = %#v, want %q", got, want)
+	}
+}
+
+func TestCompleteJSONUsesConfiguredMaxResponseTokensOverride(t *testing.T) {
+	t.Parallel()
+
+	var captured openAICompatibleChatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"content": `{"ok":true}`}},
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	rawProvider, err := newOpenAICompatibleAnalysisProvider(config.RuntimeProvider{
+		Provider:          config.RuntimeProviderOpenAI,
+		Model:             "pituitary-analysis",
+		Endpoint:          server.URL,
+		TimeoutMS:         1000,
+		MaxRetries:        0,
+		MaxResponseTokens: 333,
+	})
+	if err != nil {
+		t.Fatalf("newOpenAICompatibleAnalysisProvider() error = %v", err)
+	}
+	provider := rawProvider.(*openAICompatibleAnalysisProvider)
+
+	var response map[string]any
+	if err := provider.completeJSON(context.Background(), "check-doc-drift", "system", map[string]string{"ping": "pong"}, &response); err != nil {
+		t.Fatalf("completeJSON() error = %v", err)
+	}
+	if got, want := captured.MaxTokens, 333; got != want {
+		t.Fatalf("request.max_tokens = %d, want %d", got, want)
+	}
+}
+
+func TestAnalysisSectionsFromEmbeddedRanksByCounterpartRelevance(t *testing.T) {
+	t.Parallel()
+
+	got := analysisSectionsFromEmbedded(
+		[]embeddedSection{
+			{Heading: "Overview", Content: "low", Embedding: []float64{1, 0}},
+			{Heading: "Requirements", Content: "high", Embedding: []float64{0, 1}},
+			{Heading: "Design Decisions", Content: "mid", Embedding: []float64{0.6, 0.8}},
+			{Heading: "Appendix", Content: "also-mid", Embedding: []float64{0.5, 0.5}},
+			{Heading: "History", Content: "trimmed by limit", Embedding: []float64{0.4, 0.4}},
+		},
+		[]embeddedSection{
+			{Heading: "Counterpart", Content: "target", Embedding: []float64{0, 1}},
+		},
+	)
+
+	if got, want := len(got), analysisPromptSectionLimit; got != want {
+		t.Fatalf("len(sections) = %d, want %d", got, want)
+	}
+	if got[0].Heading != "Requirements" || got[1].Heading != "Design Decisions" || got[2].Heading != "Appendix" {
+		t.Fatalf("ordered headings = %+v, want relevance-ranked sections", got)
+	}
+}
+
+func TestAnalysisSectionsFromEmbeddedFallsBackToOriginalOrderWithoutComparableCounterparts(t *testing.T) {
+	t.Parallel()
+
+	got := analysisSectionsFromEmbedded(
+		[]embeddedSection{
+			{Heading: "Overview", Content: "first", Embedding: []float64{1, 0}},
+			{Heading: "Requirements", Content: "second", Embedding: []float64{0, 1}},
+			{Heading: "Design Decisions", Content: "third", Embedding: []float64{0.6, 0.8}},
+		},
+		[]embeddedSection{
+			{Heading: "Counterpart", Content: "missing embedding"},
+		},
+	)
+
+	if len(got) != 3 {
+		t.Fatalf("len(sections) = %d, want 3", len(got))
+	}
+	if got[0].Heading != "Overview" || got[1].Heading != "Requirements" || got[2].Heading != "Design Decisions" {
+		t.Fatalf("ordered headings = %+v, want original order fallback", got)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,20 +98,22 @@ type Runtime struct {
 
 // RuntimeProvider describes one configured runtime dependency.
 type RuntimeProvider struct {
-	Profile    string
-	Provider   string
-	Model      string
-	Endpoint   string
-	APIKeyEnv  string
-	TimeoutMS  int
-	MaxRetries int
+	Profile           string
+	Provider          string
+	Model             string
+	Endpoint          string
+	APIKeyEnv         string
+	TimeoutMS         int
+	MaxRetries        int
+	MaxResponseTokens int
 
-	providerSet   bool
-	modelSet      bool
-	endpointSet   bool
-	apiKeyEnvSet  bool
-	timeoutMSSet  bool
-	maxRetriesSet bool
+	providerSet          bool
+	modelSet             bool
+	endpointSet          bool
+	apiKeyEnvSet         bool
+	timeoutMSSet         bool
+	maxRetriesSet        bool
+	maxResponseTokensSet bool
 }
 
 type Terminology struct {
@@ -181,13 +183,14 @@ type rawTerminologyPolicy struct {
 }
 
 type rawRuntimeProvider struct {
-	Profile    string `toml:"profile"`
-	Provider   string `toml:"provider"`
-	Model      string `toml:"model"`
-	Endpoint   string `toml:"endpoint"`
-	APIKeyEnv  string `toml:"api_key_env"`
-	TimeoutMS  *int   `toml:"timeout_ms"`
-	MaxRetries *int   `toml:"max_retries"`
+	Profile           string `toml:"profile"`
+	Provider          string `toml:"provider"`
+	Model             string `toml:"model"`
+	Endpoint          string `toml:"endpoint"`
+	APIKeyEnv         string `toml:"api_key_env"`
+	TimeoutMS         *int   `toml:"timeout_ms"`
+	MaxRetries        *int   `toml:"max_retries"`
+	MaxResponseTokens *int   `toml:"max_response_tokens"`
 }
 
 type validationErrors struct {
@@ -923,6 +926,9 @@ func validateRuntime(runtime *Runtime) error {
 	if runtime.Embedder.MaxRetries < 0 {
 		errs.add("runtime.embedder.max_retries: must be >= 0")
 	}
+	if runtime.Embedder.MaxResponseTokens < 0 {
+		errs.add("runtime.embedder.max_response_tokens: must be >= 0")
+	}
 
 	runtime.Analysis = resolveRuntimeProvider(runtime.Analysis, runtime.Profiles, RuntimeProviderDisabled)
 	if profile := strings.TrimSpace(runtime.Analysis.Profile); profile != "" {
@@ -968,24 +974,29 @@ func validateRuntime(runtime *Runtime) error {
 	if runtime.Analysis.MaxRetries < 0 {
 		errs.add("runtime.analysis.max_retries: must be >= 0")
 	}
+	if runtime.Analysis.MaxResponseTokens < 0 {
+		errs.add("runtime.analysis.max_response_tokens: must be >= 0")
+	}
 	return errs.err()
 }
 
 func buildRuntimeProvider(raw rawRuntimeProvider, defaultProvider string) RuntimeProvider {
 	return RuntimeProvider{
-		Profile:       strings.TrimSpace(raw.Profile),
-		Provider:      defaultString(strings.TrimSpace(raw.Provider), defaultProvider),
-		Model:         strings.TrimSpace(raw.Model),
-		Endpoint:      strings.TrimSpace(raw.Endpoint),
-		APIKeyEnv:     strings.TrimSpace(raw.APIKeyEnv),
-		TimeoutMS:     defaultOptionalInt(raw.TimeoutMS, 1000),
-		MaxRetries:    defaultOptionalInt(raw.MaxRetries, 0),
-		providerSet:   strings.TrimSpace(raw.Provider) != "",
-		modelSet:      strings.TrimSpace(raw.Model) != "",
-		endpointSet:   strings.TrimSpace(raw.Endpoint) != "",
-		apiKeyEnvSet:  strings.TrimSpace(raw.APIKeyEnv) != "",
-		timeoutMSSet:  raw.TimeoutMS != nil,
-		maxRetriesSet: raw.MaxRetries != nil,
+		Profile:              strings.TrimSpace(raw.Profile),
+		Provider:             defaultString(strings.TrimSpace(raw.Provider), defaultProvider),
+		Model:                strings.TrimSpace(raw.Model),
+		Endpoint:             strings.TrimSpace(raw.Endpoint),
+		APIKeyEnv:            strings.TrimSpace(raw.APIKeyEnv),
+		TimeoutMS:            defaultOptionalInt(raw.TimeoutMS, 1000),
+		MaxRetries:           defaultOptionalInt(raw.MaxRetries, 0),
+		MaxResponseTokens:    defaultOptionalInt(raw.MaxResponseTokens, 0),
+		providerSet:          strings.TrimSpace(raw.Provider) != "",
+		modelSet:             strings.TrimSpace(raw.Model) != "",
+		endpointSet:          strings.TrimSpace(raw.Endpoint) != "",
+		apiKeyEnvSet:         strings.TrimSpace(raw.APIKeyEnv) != "",
+		timeoutMSSet:         raw.TimeoutMS != nil,
+		maxRetriesSet:        raw.MaxRetries != nil,
+		maxResponseTokensSet: raw.MaxResponseTokens != nil,
 	}
 }
 
@@ -1003,6 +1014,7 @@ func resolveRuntimeProvider(provider RuntimeProvider, profiles map[string]Runtim
 	apiKeyEnvResolved := provider.apiKeyEnvSet
 	timeoutResolved := provider.timeoutMSSet
 	maxRetriesResolved := provider.maxRetriesSet
+	maxResponseTokensResolved := provider.maxResponseTokensSet
 
 	if !providerResolved && hasProfile && profile.providerSet {
 		resolved.Provider = profile.Provider
@@ -1028,6 +1040,10 @@ func resolveRuntimeProvider(provider RuntimeProvider, profiles map[string]Runtim
 		resolved.MaxRetries = profile.MaxRetries
 		maxRetriesResolved = true
 	}
+	if !maxResponseTokensResolved && hasProfile && profile.maxResponseTokensSet {
+		resolved.MaxResponseTokens = profile.MaxResponseTokens
+		maxResponseTokensResolved = true
+	}
 	if !providerResolved {
 		resolved.Provider = defaultProvider
 	}
@@ -1036,6 +1052,9 @@ func resolveRuntimeProvider(provider RuntimeProvider, profiles map[string]Runtim
 	}
 	if !maxRetriesResolved {
 		resolved.MaxRetries = 0
+	}
+	if !maxResponseTokensResolved {
+		resolved.MaxResponseTokens = 0
 	}
 	if strings.TrimSpace(resolved.Provider) == RuntimeProviderFixture && !modelResolved {
 		resolved.Model = "fixture-8d"
@@ -1074,6 +1093,9 @@ func validateRuntimeProfileFields(errs *validationErrors, label string, profile 
 	}
 	if profile.MaxRetries < 0 {
 		errs.add("%s.max_retries: must be >= 0", label)
+	}
+	if profile.MaxResponseTokens < 0 {
+		errs.add("%s.max_response_tokens: must be >= 0", label)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -241,6 +241,7 @@ model = "nomic-embed-text-v1.5"
 profile = "local-lm-studio"
 model = "qwen3.5-35b"
 timeout_ms = 120000
+max_response_tokens = 2048
 
 [[sources]]
 name = "specs"
@@ -281,6 +282,9 @@ path = "specs"
 	}
 	if got, want := cfg.Runtime.Analysis.TimeoutMS, 120000; got != want {
 		t.Fatalf("runtime.analysis.timeout_ms = %d, want %d", got, want)
+	}
+	if got, want := cfg.Runtime.Analysis.MaxResponseTokens, 2048; got != want {
+		t.Fatalf("runtime.analysis.max_response_tokens = %d, want %d", got, want)
 	}
 }
 
@@ -1272,12 +1276,13 @@ func TestRenderRoundTripsRuntimeProfiles(t *testing.T) {
 				MaxRetries: 1,
 			},
 			Analysis: RuntimeProvider{
-				Profile:    "local-lm-studio",
-				Provider:   RuntimeProviderOpenAI,
-				Model:      "qwen3.5-35b",
-				Endpoint:   "http://127.0.0.1:1234/v1",
-				TimeoutMS:  120000,
-				MaxRetries: 1,
+				Profile:           "local-lm-studio",
+				Provider:          RuntimeProviderOpenAI,
+				Model:             "qwen3.5-35b",
+				Endpoint:          "http://127.0.0.1:1234/v1",
+				TimeoutMS:         120000,
+				MaxRetries:        1,
+				MaxResponseTokens: 2048,
 			},
 		},
 		Sources: []Source{
@@ -1313,6 +1318,9 @@ func TestRenderRoundTripsRuntimeProfiles(t *testing.T) {
 	}
 	if got, want := loaded.Runtime.Analysis.TimeoutMS, 120000; got != want {
 		t.Fatalf("loaded runtime.analysis.timeout_ms = %d, want %d", got, want)
+	}
+	if got, want := loaded.Runtime.Analysis.MaxResponseTokens, 2048; got != want {
+		t.Fatalf("loaded runtime.analysis.max_response_tokens = %d, want %d", got, want)
 	}
 }
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -117,6 +117,9 @@ func writeRuntimeProviderConfig(builder *strings.Builder, provider RuntimeProvid
 	if base == nil || provider.MaxRetries != base.MaxRetries {
 		fmt.Fprintf(builder, "max_retries = %d\n", provider.MaxRetries)
 	}
+	if base == nil || provider.MaxResponseTokens != base.MaxResponseTokens {
+		fmt.Fprintf(builder, "max_response_tokens = %d\n", provider.MaxResponseTokens)
+	}
 }
 
 func writeQuotedArray(builder *strings.Builder, key string, values []string) {

--- a/internal/openaicompat/client.go
+++ b/internal/openaicompat/client.go
@@ -20,14 +20,15 @@ import (
 const responseSizeLimit = 4 << 20
 
 type Client struct {
-	Runtime    string
-	Provider   string
-	Model      string
-	Endpoint   string
-	Token      string
-	TimeoutMS  int
-	MaxRetries int
-	HTTPClient *http.Client
+	Runtime           string
+	Provider          string
+	Model             string
+	Endpoint          string
+	Token             string
+	TimeoutMS         int
+	MaxRetries        int
+	MaxResponseTokens int
+	HTTPClient        *http.Client
 }
 
 type EmbeddingsRequest struct {
@@ -49,6 +50,7 @@ type ChatRequest struct {
 	Model       string        `json:"model"`
 	Messages    []ChatMessage `json:"messages"`
 	Temperature float64       `json:"temperature"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
 }
 
 type ChatMessage struct {
@@ -93,14 +95,15 @@ func NewClient(provider config.RuntimeProvider, runtime string) (*Client, error)
 	}
 
 	return &Client{
-		Runtime:    strings.TrimSpace(runtime),
-		Provider:   config.RuntimeProviderOpenAI,
-		Model:      strings.TrimSpace(provider.Model),
-		Endpoint:   endpoint,
-		Token:      token,
-		TimeoutMS:  provider.TimeoutMS,
-		MaxRetries: provider.MaxRetries,
-		HTTPClient: httpClient,
+		Runtime:           strings.TrimSpace(runtime),
+		Provider:          config.RuntimeProviderOpenAI,
+		Model:             strings.TrimSpace(provider.Model),
+		Endpoint:          endpoint,
+		Token:             token,
+		TimeoutMS:         provider.TimeoutMS,
+		MaxRetries:        provider.MaxRetries,
+		MaxResponseTokens: provider.MaxResponseTokens,
+		HTTPClient:        httpClient,
 	}, nil
 }
 
@@ -132,11 +135,12 @@ func (c *Client) Embeddings(ctx context.Context, input []string) (*EmbeddingsRes
 	})
 }
 
-func (c *Client) ChatCompletionText(ctx context.Context, messages []ChatMessage, temperature float64) (string, error) {
+func (c *Client) ChatCompletionText(ctx context.Context, messages []ChatMessage, temperature float64, maxTokens int) (string, error) {
 	body, err := json.Marshal(ChatRequest{
 		Model:       c.Model,
 		Messages:    messages,
 		Temperature: temperature,
+		MaxTokens:   maxTokens,
 	})
 	if err != nil {
 		return "", fmt.Errorf("encode %s request: %w", c.Runtime, err)

--- a/testdata/bench/README.md
+++ b/testdata/bench/README.md
@@ -1,0 +1,19 @@
+# Minimal Benchmark Cases
+
+These cases are the intentionally small golden dataset for issue `#273`.
+
+- They run against the shipped fixture workspace in this repo.
+- They are meant to catch obvious regressions and compare prompt/runtime changes quickly.
+- They are not the broader model matrix or parameter sweep tracked separately in `#285`.
+
+Run the harness with:
+
+```sh
+go run ./cmd/bench --format text
+go run ./cmd/bench --format json
+```
+
+Notes:
+
+- Prompt and response byte counts are reported when `runtime.analysis` is configured and the harness can observe `/chat/completions` traffic.
+- The impact case uses the shipped `analyze-impact` baseline even though the case name stays aligned with the planned `analyze-impact-severity` slice.

--- a/testdata/bench/analyze-impact-rate-limit.json
+++ b/testdata/bench/analyze-impact-rate-limit.json
@@ -1,0 +1,21 @@
+{
+  "id": "analyze-impact-rate-limit",
+  "operation": "analyze-impact-severity",
+  "description": "Trace the downstream docs, refs, and dependent specs touched by accepting SPEC-042.",
+  "request": {
+    "spec_ref": "SPEC-042",
+    "change_type": "accepted"
+  },
+  "expectations": {
+    "must_include_spec_refs": [
+      "SPEC-055"
+    ],
+    "must_include_doc_refs": [
+      "doc://guides/api-rate-limits"
+    ],
+    "must_include_affected_refs": [
+      "code://src/api/middleware/ratelimiter.go"
+    ],
+    "require_structured_evidence": true
+  }
+}

--- a/testdata/bench/check-compliance-rate-limit-diff.json
+++ b/testdata/bench/check-compliance-rate-limit-diff.json
@@ -1,0 +1,20 @@
+{
+  "id": "check-compliance-rate-limit-diff",
+  "operation": "check-compliance",
+  "description": "A tenant-scoped limiter diff should comply with the accepted rate-limit and burst-handling specs.",
+  "request": {
+    "diff_text": "diff --git a/src/api/middleware/ratelimiter.go b/src/api/middleware/ratelimiter.go\n--- a/src/api/middleware/ratelimiter.go\n+++ b/src/api/middleware/ratelimiter.go\n@@ -0,0 +1,6 @@\n+package middleware\n+\n+// Apply limits per tenant rather than per API key.\n+// Enforce a default limit of 200 requests per minute.\n+// Allow short bursts above the steady-state tenant limit.\n+// Use a sliding-window limiter and tenant-specific overrides.\n"
+  },
+  "expectations": {
+    "must_include_paths": [
+      "src/api/middleware/ratelimiter.go"
+    ],
+    "must_include_spec_refs": [
+      "SPEC-042",
+      "SPEC-055"
+    ],
+    "minimum_compliant_findings": 1,
+    "maximum_conflict_findings": 0,
+    "require_structured_evidence": true
+  }
+}

--- a/testdata/bench/check-doc-drift-rate-limit-guide.json
+++ b/testdata/bench/check-doc-drift-rate-limit-guide.json
@@ -1,0 +1,24 @@
+{
+  "id": "check-doc-drift-rate-limit-guide",
+  "operation": "check-doc-drift",
+  "description": "The public API guide should drift while the rollout runbook stays aligned to the accepted rate-limit specs.",
+  "request": {
+    "scope": "all"
+  },
+  "expectations": {
+    "must_include_doc_refs": [
+      "doc://guides/api-rate-limits"
+    ],
+    "must_exclude_doc_refs": [
+      "doc://runbooks/rate-limit-rollout"
+    ],
+    "must_include_spec_refs": [
+      "SPEC-042"
+    ],
+    "assessment_statuses": {
+      "doc://guides/api-rate-limits": "drift",
+      "doc://runbooks/rate-limit-rollout": "aligned"
+    },
+    "require_structured_evidence": true
+  }
+}

--- a/testdata/bench/compare-specs-rate-limit.json
+++ b/testdata/bench/compare-specs-rate-limit.json
@@ -1,0 +1,21 @@
+{
+  "id": "compare-specs-rate-limit",
+  "operation": "compare-specs",
+  "description": "Compare the legacy API-key rate-limit spec against the accepted tenant-scoped successor.",
+  "request": {
+    "spec_refs": [
+      "SPEC-008",
+      "SPEC-042"
+    ]
+  },
+  "expectations": {
+    "must_include_spec_refs": [
+      "SPEC-008",
+      "SPEC-042"
+    ],
+    "compatibility_level": "superseding",
+    "recommendation_contains": [
+      "SPEC-042"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `max_response_tokens` support for OpenAI-compatible analysis chat requests and apply command-specific `max_tokens` caps
- rank compare/doc-drift prompt sections by section relevance instead of positional truncation
- add the minimal golden benchmark harness and fixture cases for `compare-specs`, `check-doc-drift`, `check-compliance`, and `analyze-impact`
- keep the benchmark scope intentionally small; broader benchmark expansion remains tracked in `#285`

## Testing
- `go test ./cmd/bench ./internal/analysis ./internal/config`
- `go run ./cmd/bench --format text`

Closes #271
Closes #272
Closes #273