### PR TITLE
[codex] Add runtime provenance and terminology exclude paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,7 +64,7 @@ The first shipping slice should be intentionally narrow. It exists to prove that
 - Database-backed source adapters
 - Incremental index updates
 - Stored code-summary embeddings
-- Provider-backed code-compliance adjudication beyond the shipped deterministic CLI slice
+- Broad provider-backed code-compliance adjudication beyond the shipped deterministic CLI slice; only bounded re-adjudication of deterministic findings is in scope
 
 ### Also shipped in this repo during v1
 
@@ -408,7 +408,7 @@ Step 6: Atomic Swap
 - The current runtime supports two embedder providers: `fixture` and `openai_compatible`.
 - The current runtime supports two analysis providers: `disabled` and `openai_compatible`.
 - Retrieval, indexing, and candidate shortlisting remain deterministic even when provider-backed analysis is enabled.
-- Provider-backed analysis currently applies only to bounded adjudication steps in `compare-specs` and `check-doc-drift`; `review-spec` inherits those refined results.
+- Provider-backed analysis currently applies only to bounded adjudication steps in `compare-specs`, `check-doc-drift`, and `check-compliance`; `review-spec` inherits those refined results.
 - Tests and CI should use the deterministic fixture embedder and require no live model credentials.
 - Unsupported runtime providers should fail during config validation with clear, intentional errors.
 - Provider-backed embeddings and bounded provider-backed analysis are both now part of the runtime contract.
@@ -616,6 +616,7 @@ CLI exit codes should stay simple:
   - Result: `{ "spec_ref": "SPEC-042", "change_type": "accepted", "affected_specs": [...], "affected_refs": [...], "affected_docs": [{ "ref": "doc://guides/api-rate-limits", "score": 0.0, "classification": "semantic_neighbor" | "governed_surface_neighbor", "reasons": ["..."], "evidence": { "spec_ref": "SPEC-042", "spec_source_ref": "file://specs/...", "spec_section": "...", "doc_source_ref": "file://docs/...", "doc_section": "...", "link_reason": "..." }, "suggested_targets": [{ "source_ref": "file://docs/...", "section": "...", "excerpt": "...", "reason": "...", "suggested_bullets": ["..."] }] }] }`
 - `check_terminology` (`pituitary check-terminology`)
   - Request: `{ "terms": ["repo", "workflow"], "canonical_terms": ["locality", "continuity"], "spec_ref": "SPEC-LOCALITY", "scope": "all" | "docs" | "specs" }` or `{ "spec_ref": "SPEC-LOCALITY" }` when config-backed `[[terminology.policies]]` should supply the governed terms
+  - Config may also declare `[terminology].exclude_paths` to skip historically frozen files from terminology sweeps and `compile` without removing them from indexing
   - Result: `{ "scope": { "mode": "workspace" | "spec_ref", "artifact_kinds": ["doc", "spec"], "spec_ref": "SPEC-LOCALITY" }, "terms": [...], "canonical_terms": [...], "anchor_specs": [...], "findings": [{ "ref": "...", "kind": "doc" | "spec", "terms": [...], "sections": [{ "section": "...", "terms": [...], "matches": [{ "term": "repo", "classification": "historical_alias", "context": "current_state" | "historical", "severity": "warning" | "error" | "ignore", "replacement": "locality", "tolerated": false }], "excerpt": "...", "assessment": "...", "evidence": { "spec_ref": "SPEC-LOCALITY", "section": "...", "score": 0.0 } | null }] }], "tolerated": [{ "ref": "...", "kind": "doc" | "spec", "terms": [...], "sections": [...] }] }`
 - `check_doc_drift` (`pituitary check-doc-drift`)
   - Request: exactly one of `{ "doc_ref": "doc://guides/api-rate-limits" }`, `{ "doc_refs": ["doc://guides/api-rate-limits"] }`, `{ "scope": "all" }`, or `{ "diff_text": "..." }`; the CLI also accepts `--diff-file PATH|-` and resolves that into the same diff-backed request shape
@@ -741,6 +742,8 @@ Output:
   compliant[]
   conflicts[]
   unspecified[]
+  unspecified_summary
+  runtime.analysis
 ```
 
 #### Tool: `check_doc_drift`
@@ -759,6 +762,7 @@ Output:
   implicated_specs[]
   implicated_docs[]
   drift_items[]
+  runtime.analysis
 ```
 
 Exactly one selector must be present in v1: `doc_ref`, `doc_refs`, `scope`, or `diff_text`. The only valid `scope` value is `"all"`. The CLI additionally supports `--diff-file PATH|-` so git diffs can be piped in directly without manually embedding them in JSON.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ All commands output JSON with `--format json`. Agents can set `PITUITARY_FORMAT=
 
 One `pituitary.toml` can also span multiple repository roots. Bind a source to a named repo root with `repo = "..."`, and Pituitary carries that repo identity through search, drift, impact, status, and index output so cross-repo results stay unambiguous.
 
-For terminology migrations, you can keep running ad hoc audits with `--term` / `--canonical-term`, or declare reusable `[[terminology.policies]]` in config and run `pituitary check-terminology` directly. Results now separate actionable current-state violations from tolerated historical uses and include replacement suggestions in both text and JSON output.
+For terminology migrations, you can keep running ad hoc audits with `--term` / `--canonical-term`, or declare reusable `[[terminology.policies]]` in config and run `pituitary check-terminology` directly. Results now separate actionable current-state violations from tolerated historical uses, support terminology-only `exclude_paths` for historical containers such as `CHANGELOG.md`, and include replacement suggestions in both text and JSON output.
 
 `analyze-impact`, `check-doc-drift`, and `review-spec` now emit section-level evidence chains in JSON: source refs on both sides of the match, a `classification`, a `link_reason`, and likely edit targets or suggested bullets. That gives agents enough structure to explain the next manual edit without scraping prose or auto-editing speculative changes.
 
@@ -251,7 +251,7 @@ pituitary index --rebuild
 
 `pituitary status` now shows the active runtime profile plus the resolved provider, model, endpoint, timeout, and retry settings for both embedder and analysis. `--check-runtime` probes those resolved settings directly.
 
-Retrieval remains deterministic. The analysis model only sees narrowly shortlisted context for `compare-specs` and `check-doc-drift`. Any OpenAI-compatible embedding or analysis API works. See [runtime docs](docs/runtime.md) for full setup.
+Retrieval remains deterministic. The analysis model only sees narrowly shortlisted context for `compare-specs`, `check-doc-drift`, and bounded re-adjudication in `check-compliance`, and those result envelopes now record the configured analysis runtime plus whether it was consulted during the run. Any OpenAI-compatible embedding or analysis API works. See [runtime docs](docs/runtime.md) for full setup.
 
 </details>
 

--- a/cmd/check_compliance_test.go
+++ b/cmd/check_compliance_test.go
@@ -433,6 +433,67 @@ func buildLimiter() {}
 	}
 }
 
+func TestRunCheckComplianceJSONIncludesUnspecifiedSummaryBreakout(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	writeComplianceSourceFile(t, repo, "src/api/middleware/ratelimiter.go", `
+package middleware
+
+func buildLimiter() {}
+`)
+	writeComplianceSourceFile(t, repo, "notes/ungoverned.txt", `
+zxqv aurora lattice
+plinth ember quartz
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		rebuildSearchWorkspaceIndex(t)
+		return runCheckCompliance([]string{
+			"--path", "src/api/middleware/ratelimiter.go",
+			"--path", "notes/ungoverned.txt",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckCompliance() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckCompliance() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Unspecified []struct {
+				Path         string `json:"path"`
+				Traceability string `json:"traceability"`
+			} `json:"unspecified"`
+			UnspecifiedSummary struct {
+				Total                     int `json:"total"`
+				MissingGovernanceEdge     int `json:"missing_governance_edge"`
+				ExplicitButUnderexercised int `json:"explicit_but_underexercised"`
+			} `json:"unspecified_summary"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal unspecified-summary payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("payload errors = %+v, want none", payload.Errors)
+	}
+	if got, want := payload.Result.UnspecifiedSummary.Total, len(payload.Result.Unspecified); got != want {
+		t.Fatalf("unspecified_summary.total = %d, want %d", got, want)
+	}
+	if got, want := payload.Result.UnspecifiedSummary.MissingGovernanceEdge, 1; got != want {
+		t.Fatalf("missing_governance_edge = %d, want %d", got, want)
+	}
+	if got, want := payload.Result.UnspecifiedSummary.ExplicitButUnderexercised, 2; got != want {
+		t.Fatalf("explicit_but_underexercised = %d, want %d", got, want)
+	}
+}
+
 func TestRunCheckComplianceDiffFromStdinJSON(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 
@@ -586,6 +647,108 @@ index 1111111..0000000
 		if item.LimitingFactor != "code_evidence_gap" {
 			t.Fatalf("unspecified finding = %+v, want code_evidence_gap limiting factor", item)
 		}
+	}
+}
+
+func TestRunCheckComplianceCollapsesDuplicateMirrorTargets(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	content := `
+package middleware
+
+// Apply limits per tenant rather than per API key.
+// Enforce a default limit of 200 requests per minute.
+// Allow short bursts above the steady-state tenant limit.
+// Use a sliding-window limiter and tenant-specific overrides.
+func buildLimiter() {}
+`
+	writeComplianceSourceFile(t, repo, "src/api/middleware/ratelimiter.go", content)
+	writeComplianceSourceFile(t, repo, ".claude/skills/ratelimiter.go", content)
+	writeComplianceSourceFile(t, repo, ".gemini/skills/ratelimiter.go", content)
+
+	oldStdin := cliStdin
+	cliStdin = strings.NewReader(strings.TrimSpace(`
+diff --git a/src/api/middleware/ratelimiter.go b/src/api/middleware/ratelimiter.go
+index 0000000..1111111 100644
+--- a/src/api/middleware/ratelimiter.go
++++ b/src/api/middleware/ratelimiter.go
+@@ -0,0 +1,7 @@
++package middleware
++
++// Apply limits per tenant rather than per API key.
++// Enforce a default limit of 200 requests per minute.
++// Allow short bursts above the steady-state tenant limit.
++// Use a sliding-window limiter and tenant-specific overrides.
++func buildLimiter() {}
+diff --git a/.claude/skills/ratelimiter.go b/.claude/skills/ratelimiter.go
+index 0000000..1111111 100644
+--- a/.claude/skills/ratelimiter.go
++++ b/.claude/skills/ratelimiter.go
+@@ -0,0 +1,7 @@
++package middleware
++
++// Apply limits per tenant rather than per API key.
++// Enforce a default limit of 200 requests per minute.
++// Allow short bursts above the steady-state tenant limit.
++// Use a sliding-window limiter and tenant-specific overrides.
++func buildLimiter() {}
+diff --git a/.gemini/skills/ratelimiter.go b/.gemini/skills/ratelimiter.go
+index 0000000..1111111 100644
+--- a/.gemini/skills/ratelimiter.go
++++ b/.gemini/skills/ratelimiter.go
+@@ -0,0 +1,7 @@
++package middleware
++
++// Apply limits per tenant rather than per API key.
++// Enforce a default limit of 200 requests per minute.
++// Allow short bursts above the steady-state tenant limit.
++// Use a sliding-window limiter and tenant-specific overrides.
++func buildLimiter() {}
+`))
+	t.Cleanup(func() {
+		cliStdin = oldStdin
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		rebuildSearchWorkspaceIndex(t)
+		return runCheckCompliance([]string{
+			"--diff-file", "-",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckCompliance(--diff-file -) exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckCompliance(--diff-file -) wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Paths     []string `json:"paths"`
+			Compliant []struct {
+				Path string `json:"path"`
+			} `json:"compliant"`
+			Unspecified []any `json:"unspecified"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal duplicate-target payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("payload errors = %+v, want none", payload.Errors)
+	}
+	if got, want := len(payload.Result.Paths), 3; got != want {
+		t.Fatalf("len(result.paths) = %d, want %d", got, want)
+	}
+	if len(payload.Result.Compliant) == 0 {
+		t.Fatalf("result.compliant = %+v, want compliant findings for the canonical target", payload.Result.Compliant)
+	}
+	if len(payload.Result.Unspecified) != 0 {
+		t.Fatalf("result.unspecified = %+v, want duplicate mirror findings collapsed", payload.Result.Unspecified)
 	}
 }
 

--- a/cmd/check_terminology_test.go
+++ b/cmd/check_terminology_test.go
@@ -188,6 +188,52 @@ func TestRunCheckTerminologyWithRequestFileJSON(t *testing.T) {
 	}
 }
 
+func TestRunCheckTerminologyHonorsExcludePaths(t *testing.T) {
+	repo := writeTerminologyExcludeWorkspaceCmd(t)
+	indexStdout := bytes.Buffer{}
+	indexStderr := bytes.Buffer{}
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &indexStdout, &indexStderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr: %q)", exitCode, indexStderr.String())
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode = withWorkingDir(t, repo, func() int {
+		return runCheckTerminology([]string{"--scope", "docs", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckTerminology() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckTerminology() stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Findings []struct {
+				Ref       string `json:"ref"`
+				SourceRef string `json:"source_ref"`
+			} `json:"findings"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal excluded terminology payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if len(payload.Result.Findings) != 1 {
+		t.Fatalf("findings = %+v, want only the non-excluded doc", payload.Result.Findings)
+	}
+	if got, want := payload.Result.Findings[0].SourceRef, "file://docs/guides/repo-kernel.md"; got != want {
+		t.Fatalf("source_ref = %q, want %q", got, want)
+	}
+}
+
 func writeTerminologyWorkspaceCmd(t *testing.T) string {
 	t.Helper()
 
@@ -254,6 +300,69 @@ adapter = "filesystem"
 kind = "markdown_docs"
 path = "docs"
 include = ["guides/*.md"]
+`)
+	return root
+}
+
+func writeTerminologyExcludeWorkspaceCmd(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	mustWriteFileCmd(t, root+"/specs/kernel-locality/spec.toml", `
+id = "SPEC-LOCALITY"
+title = "Kernel Locality Contract"
+status = "accepted"
+domain = "kernel"
+body = "body.md"
+`)
+	mustWriteFileCmd(t, root+"/specs/kernel-locality/body.md", `
+# Kernel Locality Contract
+
+The runtime is locality-centric and treats repository adapters as optional extensions.
+`)
+	mustWriteFileCmd(t, root+"/docs/guides/repo-kernel.md", `
+# Repo Kernel Guide
+
+Repository storage is the default operator model.
+`)
+	mustWriteFileCmd(t, root+"/CHANGELOG.md", `
+# Changelog
+
+- Repository storage became the default operator model in v0.6.2.
+`)
+	mustWriteIndexFixture(t, root, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[terminology]
+exclude_paths = ["CHANGELOG.md"]
+
+[[terminology.policies]]
+preferred = "locality"
+historical_aliases = ["repo"]
+forbidden_current = ["repository"]
+docs_severity = "error"
+specs_severity = "warning"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "."
+files = ["CHANGELOG.md", "docs/guides/repo-kernel.md"]
 `)
 	return root
 }

--- a/cmd/compile_test.go
+++ b/cmd/compile_test.go
@@ -182,6 +182,47 @@ func TestRunCompileRequiresScopeFlag(t *testing.T) {
 	}
 }
 
+func TestRunCompileHonorsTerminologyExcludePaths(t *testing.T) {
+	repo := writeTerminologyExcludeWorkspaceCmd(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runCompile([]string{"--scope", "docs", "--dry-run", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCompile() exit code = %d, want 0\nstdout: %s\nstderr: %s", exitCode, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCompile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Files []struct {
+				Path string `json:"path"`
+			} `json:"files"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\nraw: %s", err, stdout.String())
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if len(payload.Result.Files) != 1 {
+		t.Fatalf("result.files = %+v, want only the non-excluded doc", payload.Result.Files)
+	}
+	if got := payload.Result.Files[0].Path; !strings.HasSuffix(got, "/docs/guides/repo-kernel.md") {
+		t.Fatalf("planned path = %q, want repo-kernel suffix", got)
+	}
+}
+
 func writeCompileWorkspaceCmd(t *testing.T) string {
 	t.Helper()
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,6 +122,9 @@ timeout_ms = 120000
 `check-terminology` can also load reusable policy from config instead of requiring `--term` flags every time:
 
 ```toml
+[terminology]
+exclude_paths = ["CHANGELOG.md", "docs/archive/*.md"]
+
 [[terminology.policies]]
 preferred = "locality"
 historical_aliases = ["repo"]
@@ -148,6 +151,8 @@ Severity is configured per artifact scope:
 - `specs_severity`: `ignore`, `warning`, or `error`
 
 When `pituitary check-terminology` runs without `--term`, Pituitary audits every governed term from `[[terminology.policies]]`, infers `canonical_terms` from the configured `preferred` values, and emits structured `classification`, `context`, `severity`, `replacement`, and `tolerated` fields in JSON output.
+
+Use `[terminology].exclude_paths` when you want terminology sweeps and `compile` to skip historically frozen containers such as `CHANGELOG.md`, release notes, or archive folders without dropping those files from indexing, drift, or compliance.
 
 ### Example: Optional GitHub issues source
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -38,7 +38,7 @@ pituitary status --check-runtime embedder
 pituitary index --rebuild
 ```
 
-For provider-backed qualitative analysis used by `compare-specs` and `check-doc-drift`:
+For provider-backed qualitative analysis used by `compare-specs`, `check-doc-drift`, and bounded re-adjudication in `check-compliance`:
 
 ```toml
 [runtime.analysis]
@@ -52,7 +52,7 @@ Retrieval stays deterministic. The analysis model only touches narrowly shortlis
 
 Set `runtime.analysis.max_response_tokens` when you want one explicit cap on chat-completion output across Pituitary's qualitative analysis requests. If you omit it, Pituitary keeps bounded per-command defaults instead, so runtime probes stay tiny while `compare-specs`, impact severity checks, doc-drift refinement, and compliance adjudication get slightly larger response budgets.
 
-For `compare-specs` and `check-doc-drift`, Pituitary selects section-level evidence by relevance to the counterpart spec or document instead of taking the first sections by position. That keeps the prompt bundle small while preferring semantically related sections.
+For `compare-specs` and `check-doc-drift`, Pituitary selects section-level evidence by relevance to the counterpart spec or document instead of taking the first sections by position. `check-doc-drift` still starts from deterministic drift items; the analysis runtime only refines those shortlisted findings, so different models can legitimately emit the same structural result.
 
 When choosing `runtime.analysis`, optimize for bounded semantic adjudication rather than open-ended chat:
 
@@ -72,6 +72,8 @@ pituitary status --check-runtime all
 ```
 
 `pituitary status` reports the resolved runtime config for `runtime.embedder` and `runtime.analysis`, including the active profile name when one is selected. `pituitary status --check-runtime ...` uses those resolved values for the live probe and echoes the same profile / provider / model / endpoint / timeout assumptions in the probe output.
+
+`check-compliance` and `check-doc-drift` also record the configured analysis runtime in their JSON `result.runtime.analysis` block, including whether the command actually consulted the model during that run.
 
 For Nomic-compatible models, Pituitary automatically applies the required `search_document:` / `search_query:` prefixes.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -18,6 +18,8 @@ When a changed path has no explicit governance, findings include a `limiting_fac
 - `spec_metadata_gap`: missing `applies_to`; tighten governance in the spec
 - `code_evidence_gap`: governance is explicit, but the code does not expose enough literal evidence
 
+The JSON result also carries `unspecified_summary`, which splits `unspecified` findings into `missing_governance_edge` versus `explicit_but_underexercised` so CI and operators do not treat those remediations as the same class of problem.
+
 ## Commands
 
 | Command | What it does |
@@ -80,6 +82,8 @@ The result now separates:
 
 - `findings`: actionable current-state violations
 - `tolerated`: historical or compatibility-only uses that are still indexed for context
+
+Use `[terminology].exclude_paths` when specific files or folders are historically frozen and should be skipped by terminology sweeps and `compile` without being removed from the wider index.
 
 Each matched term includes structured `classification`, `context`, `severity`, and `replacement` fields so CI or editor tooling can turn JSON output into warnings or errors without scraping prose.
 

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	pathpkg "path"
@@ -127,12 +128,14 @@ type ComplianceFinding struct {
 
 // ComplianceResult is the structured compliance output.
 type ComplianceResult struct {
-	Paths         []string                 `json:"paths"`
-	RelevantSpecs []ComplianceRelevantSpec `json:"relevant_specs,omitempty"`
-	Compliant     []ComplianceFinding      `json:"compliant"`
-	Conflicts     []ComplianceFinding      `json:"conflicts"`
-	Unspecified   []ComplianceFinding      `json:"unspecified"`
-	ContentTrust  *resultmeta.ContentTrust `json:"content_trust,omitempty"`
+	Paths              []string                      `json:"paths"`
+	RelevantSpecs      []ComplianceRelevantSpec      `json:"relevant_specs,omitempty"`
+	Compliant          []ComplianceFinding           `json:"compliant"`
+	Conflicts          []ComplianceFinding           `json:"conflicts"`
+	Unspecified        []ComplianceFinding           `json:"unspecified"`
+	UnspecifiedSummary *ComplianceUnspecifiedSummary `json:"unspecified_summary,omitempty"`
+	Runtime            *CommandRuntime               `json:"runtime,omitempty"`
+	ContentTrust       *resultmeta.ContentTrust      `json:"content_trust,omitempty"`
 }
 
 type complianceTarget struct {
@@ -140,6 +143,7 @@ type complianceTarget struct {
 	RefCandidates []string
 	Content       string
 	Embedding     []float64
+	DuplicateKey  string
 	RemovedOnly   bool
 }
 
@@ -164,6 +168,15 @@ type parsedDiffTarget struct {
 	Added   []string
 	Context []string
 	Removed []string
+}
+
+// ComplianceUnspecifiedSummary breaks unspecified findings into actionable
+// categories so consumers can distinguish missing governance from already-
+// governed-but-underexercised surfaces.
+type ComplianceUnspecifiedSummary struct {
+	Total                     int `json:"total"`
+	MissingGovernanceEdge     int `json:"missing_governance_edge"`
+	ExplicitButUnderexercised int `json:"explicit_but_underexercised"`
 }
 
 type complianceAdjudicationCandidate struct {
@@ -203,12 +216,20 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	if err != nil {
 		return nil, err
 	}
+	evaluationTargets = collapseComplianceDuplicateEvaluationTargets(evaluationTargets)
+
+	analysisRuntime := newAnalysisRuntimeUsage(cfg.Runtime.Analysis)
+	var runtime *CommandRuntime
+	if analysisRuntime != nil {
+		runtime = &CommandRuntime{Analysis: analysisRuntime}
+	}
 
 	result := &ComplianceResult{
 		Paths:        complianceTargetPaths(targets),
 		Compliant:    []ComplianceFinding{},
 		Conflicts:    []ComplianceFinding{},
 		Unspecified:  []ComplianceFinding{},
+		Runtime:      runtime,
 		ContentTrust: resultmeta.UntrustedWorkspaceText(),
 	}
 	relevant := map[string]*complianceRelevantAccumulator{}
@@ -272,6 +293,9 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 		return nil, err
 	}
 	if adjudicator, ok := analyzer.(complianceAdjudicator); ok && len(adjudicationCandidates) > 0 {
+		if result.Runtime != nil && result.Runtime.Analysis != nil {
+			result.Runtime.Analysis.Used = true
+		}
 		adjFindings, err := runComplianceAdjudication(ctx, adjudicator, repo, adjudicationCandidates, result)
 		if err != nil {
 			return nil, err
@@ -295,6 +319,7 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	sortComplianceFindings(result.Compliant)
 	sortComplianceFindings(result.Conflicts)
 	sortComplianceFindings(result.Unspecified)
+	result.UnspecifiedSummary = buildComplianceUnspecifiedSummary(result.Unspecified)
 	return result, nil
 }
 
@@ -436,7 +461,7 @@ func loadComplianceTargetsContext(ctx context.Context, cfg *config.Config, reque
 	if len(request.Paths) > 0 {
 		return loadPathComplianceTargetsContext(ctx, cfg, request.Paths)
 	}
-	return loadDiffComplianceTargetsContext(ctx, request.DiffText)
+	return loadDiffComplianceTargetsContext(ctx, cfg, request.DiffText)
 }
 
 func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, paths []string) ([]complianceTarget, error) {
@@ -466,20 +491,21 @@ func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, p
 			Path:          relPath,
 			RefCandidates: governedRefsForPath(relPath),
 			Content:       string(data),
+			DuplicateKey:  complianceContentDigest(string(data)),
 		})
 	}
 	return targets, nil
 }
 
-func loadDiffComplianceTargetsContext(ctx context.Context, diffText string) ([]complianceTarget, error) {
+func loadDiffComplianceTargetsContext(ctx context.Context, cfg *config.Config, diffText string) ([]complianceTarget, error) {
 	parsed, err := parseDiffTargets(diffText)
 	if err != nil {
 		return nil, err
 	}
-	return loadParsedDiffComplianceTargetsContext(ctx, parsed)
+	return loadParsedDiffComplianceTargetsContext(ctx, cfg, parsed)
 }
 
-func loadParsedDiffComplianceTargetsContext(ctx context.Context, parsed []parsedDiffTarget) ([]complianceTarget, error) {
+func loadParsedDiffComplianceTargetsContext(ctx context.Context, cfg *config.Config, parsed []parsedDiffTarget) ([]complianceTarget, error) {
 	targets := make([]complianceTarget, 0, len(parsed))
 	for _, item := range parsed {
 		content, removedOnly := parsedDiffTargetContent(item)
@@ -490,6 +516,7 @@ func loadParsedDiffComplianceTargetsContext(ctx context.Context, parsed []parsed
 			Path:          item.Path,
 			RefCandidates: governedRefsForPath(item.Path),
 			Content:       content,
+			DuplicateKey:  complianceDuplicateKey(cfg.Workspace.RootPath, item.Path, content),
 			RemovedOnly:   removedOnly,
 		})
 	}
@@ -522,6 +549,140 @@ func prepareComplianceEvaluationTargetsContext(ctx context.Context, repo *analys
 		return nil, err
 	}
 	return prepared, nil
+}
+
+func collapseComplianceDuplicateEvaluationTargets(targets []complianceEvaluationTarget) []complianceEvaluationTarget {
+	if len(targets) < 2 {
+		return targets
+	}
+
+	groups := make(map[string][]int)
+	for i, item := range targets {
+		key := stringsTrimSpace(item.Target.DuplicateKey)
+		if key == "" || item.Target.RemovedOnly {
+			continue
+		}
+		groups[key] = append(groups[key], i)
+	}
+	if len(groups) == 0 {
+		return targets
+	}
+
+	keep := make([]bool, len(targets))
+	for i := range keep {
+		keep[i] = true
+	}
+
+	for _, indexes := range groups {
+		if len(indexes) < 2 {
+			continue
+		}
+		rep, ok := complianceDuplicateRepresentativeIndex(targets, indexes)
+		if !ok {
+			continue
+		}
+		for _, idx := range indexes {
+			if idx != rep {
+				keep[idx] = false
+			}
+		}
+	}
+
+	result := make([]complianceEvaluationTarget, 0, len(targets))
+	for i, item := range targets {
+		if keep[i] {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func complianceDuplicateRepresentativeIndex(targets []complianceEvaluationTarget, indexes []int) (int, bool) {
+	explicitSignatures := map[string]struct{}{}
+	explicitIndexes := make([]int, 0, len(indexes))
+	for _, idx := range indexes {
+		signature := complianceExplicitRefSignature(targets[idx].ExplicitRefs)
+		if signature == "" {
+			continue
+		}
+		explicitSignatures[signature] = struct{}{}
+		explicitIndexes = append(explicitIndexes, idx)
+	}
+	if len(explicitSignatures) > 1 {
+		return 0, false
+	}
+
+	candidates := indexes
+	if len(explicitIndexes) > 0 {
+		candidates = explicitIndexes
+	}
+	best := candidates[0]
+	for _, idx := range candidates[1:] {
+		if complianceRepresentativePathLess(targets[idx].Target.Path, targets[best].Target.Path) {
+			best = idx
+		}
+	}
+	return best, true
+}
+
+func complianceExplicitRefSignature(refs []string) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), refs...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, "\x00")
+}
+
+func complianceRepresentativePathLess(left, right string) bool {
+	leftHidden, leftDepth := compliancePathPreference(left)
+	rightHidden, rightDepth := compliancePathPreference(right)
+	switch {
+	case leftHidden != rightHidden:
+		return leftHidden < rightHidden
+	case leftDepth != rightDepth:
+		return leftDepth < rightDepth
+	case len(left) != len(right):
+		return len(left) < len(right)
+	default:
+		return left < right
+	}
+}
+
+func compliancePathPreference(path string) (hiddenSegments int, depth int) {
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" {
+			continue
+		}
+		depth++
+		if strings.HasPrefix(segment, ".") {
+			hiddenSegments++
+		}
+	}
+	return hiddenSegments, depth
+}
+
+func complianceDuplicateKey(workspaceRoot, relPath, fallbackContent string) string {
+	if workspaceRoot != "" && relPath != "" {
+		_, absPath, err := resolveWorkspaceFilePath(workspaceRoot, relPath)
+		if err == nil {
+			if data, readErr := os.ReadFile(absPath); readErr == nil {
+				return complianceContentDigest(string(data))
+			}
+		}
+	}
+	if stringsTrimSpace(fallbackContent) == "" {
+		return ""
+	}
+	return complianceContentDigest(fallbackContent)
+}
+
+func complianceContentDigest(content string) string {
+	if content == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(content))
+	return fmt.Sprintf("%x", sum[:])
 }
 
 func embedComplianceFallbackTargetsContext(ctx context.Context, cfg *config.Config, targets []complianceEvaluationTarget, indexes []int) error {
@@ -1071,6 +1232,22 @@ func primaryGovernedRefForPath(path string) string {
 	default:
 		return "code://" + normalizeCompliancePath(path)
 	}
+}
+
+func buildComplianceUnspecifiedSummary(findings []ComplianceFinding) *ComplianceUnspecifiedSummary {
+	if len(findings) == 0 {
+		return nil
+	}
+
+	summary := &ComplianceUnspecifiedSummary{Total: len(findings)}
+	for _, finding := range findings {
+		if finding.Traceability == "explicit_applies_to" {
+			summary.ExplicitButUnderexercised++
+			continue
+		}
+		summary.MissingGovernanceEdge++
+	}
+	return summary
 }
 
 func complianceRequestsPerMinuteConflict(statement, content string) (string, string, bool) {

--- a/internal/analysis/compliance_runtime_test.go
+++ b/internal/analysis/compliance_runtime_test.go
@@ -1,0 +1,136 @@
+package analysis
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+func TestCheckComplianceIncludesAnalysisRuntimeProvenance(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeComplianceRuntimeWorkspace(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	configureOpenAIAnalysisProvider(t, cfg, func(t *testing.T, request openAICompatibleChatRequest) string {
+		t.Helper()
+		var prompt complianceAdjudicatePrompt
+		if err := json.Unmarshal([]byte(request.Messages[1].Content), &prompt); err != nil {
+			t.Fatalf("unmarshal prompt: %v", err)
+		}
+		if got, want := prompt.Command, "check-compliance-adjudicate"; got != want {
+			t.Fatalf("command = %q, want %q", got, want)
+		}
+		if got, want := prompt.Targets[0].Path, "src/service/handler.go"; got != want {
+			t.Fatalf("target path = %q, want %q", got, want)
+		}
+
+		return `{
+			"adjudications": [
+				{
+					"path": "src/service/handler.go",
+					"classification": "conflict",
+					"violated_section": "Requirements",
+					"evidence": "handler omits the required audit log call",
+					"confidence": 0.87,
+					"message": "handler omits the audit log required by the accepted spec",
+					"expected": "emit an audit log before mutating state",
+					"observed": "mutates state without any audit log"
+				}
+			]
+		}`
+	})
+
+	result, err := CheckCompliance(cfg, ComplianceRequest{Paths: []string{"src/service/handler.go"}})
+	if err != nil {
+		t.Fatalf("CheckCompliance() error = %v", err)
+	}
+	if result.Runtime == nil || result.Runtime.Analysis == nil {
+		t.Fatalf("runtime = %+v, want analysis provenance", result.Runtime)
+	}
+	if got, want := result.Runtime.Analysis.Provider, config.RuntimeProviderOpenAI; got != want {
+		t.Fatalf("runtime.analysis.provider = %q, want %q", got, want)
+	}
+	if got, want := result.Runtime.Analysis.Model, "pituitary-analysis"; got != want {
+		t.Fatalf("runtime.analysis.model = %q, want %q", got, want)
+	}
+	if !result.Runtime.Analysis.Used {
+		t.Fatalf("runtime.analysis.used = false, want true")
+	}
+
+	var found bool
+	for _, finding := range result.Conflicts {
+		if finding.Path == "src/service/handler.go" && finding.Provenance == ProvenanceModelAdjudication {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("conflicts = %+v, want model-adjudicated conflict", result.Conflicts)
+	}
+}
+
+func writeComplianceRuntimeWorkspace(tb testing.TB) *config.Config {
+	tb.Helper()
+
+	root := tb.TempDir()
+	indexPath := filepath.Join(root, ".pituitary", "pituitary.db")
+	configPath := filepath.Join(root, "pituitary.toml")
+
+	mustWriteFile(tb, filepath.Join(root, "specs", "audit-logging", "spec.toml"), `
+id = "SPEC-AUDIT"
+title = "Audit Logging for Stateful Mutations"
+status = "accepted"
+domain = "runtime"
+body = "body.md"
+applies_to = ["code://src/service/handler.go"]
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "audit-logging", "body.md"), `
+# Audit Logging for Stateful Mutations
+
+## Requirements
+
+Every stateful mutation must emit an audit log before writing state.
+`)
+	mustWriteFile(tb, filepath.Join(root, "src", "service", "handler.go"), `
+package service
+
+func HandleCreate() {
+	writeState()
+}
+`)
+	mustWriteFile(tb, configPath, fmt.Sprintf(`
+[workspace]
+root = %q
+index_path = %q
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = %q
+`, root, indexPath, filepath.Join(root, "specs")))
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
+}

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -171,6 +171,7 @@ type DocDriftResult struct {
 	Assessments     []DocDriftAssessment     `json:"assessments,omitempty"`
 	SpecInferences  []SpecInference          `json:"spec_inferences,omitempty"`
 	Remediation     *DocRemediationResult    `json:"remediation"`
+	Runtime         *CommandRuntime          `json:"runtime,omitempty"`
 	Warnings        []Warning                `json:"warnings,omitempty"`
 	ContentTrust    *resultmeta.ContentTrust `json:"content_trust,omitempty"`
 }
@@ -231,6 +232,7 @@ func CheckDocDriftContext(ctx context.Context, cfg *config.Config, request DocDr
 	if err != nil {
 		return nil, err
 	}
+	analysisRuntime := newAnalysisRuntimeUsage(cfg.Runtime.Analysis)
 
 	var (
 		selectedDocs    map[string]docDocument
@@ -267,7 +269,7 @@ func CheckDocDriftContext(ctx context.Context, cfg *config.Config, request DocDr
 		}
 	}
 
-	result, err := buildDocDriftResult(ctx, analyzer, scope, selectedDocs, specs, repo.loadAllSpecs)
+	result, err := buildDocDriftResult(ctx, analyzer, analysisRuntime, scope, selectedDocs, specs, repo.loadAllSpecs)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +279,7 @@ func CheckDocDriftContext(ctx context.Context, cfg *config.Config, request DocDr
 	return result, nil
 }
 
-func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, scope DocDriftScope, selectedDocs map[string]docDocument, specs map[string]specDocument, loadAllSpecs func() (map[string]specDocument, error)) (*DocDriftResult, error) {
+func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, analysisRuntime *RuntimeUsage, scope DocDriftScope, selectedDocs map[string]docDocument, specs map[string]specDocument, loadAllSpecs func() (map[string]specDocument, error)) (*DocDriftResult, error) {
 	driftItems := make([]DriftItem, 0, len(selectedDocs))
 	assessments := make([]DocDriftAssessment, 0, len(selectedDocs))
 	remediationItems := make([]DocRemediationItem, 0, len(selectedDocs))
@@ -378,6 +380,10 @@ func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, scop
 	refined := make([]refinedResult, len(pending))
 
 	if len(pending) > 0 {
+		if analysisRuntime != nil && analyzer != nil {
+			analysisRuntime.Used = true
+		}
+
 		var mu sync.Mutex
 		g, gctx := errgroup.WithContext(ctx)
 		g.SetLimit(adjudicationConcurrency)
@@ -443,6 +449,11 @@ func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, scop
 	}
 	relevantSpecRefs = uniqueStrings(relevantSpecRefs)
 
+	var runtime *CommandRuntime
+	if analysisRuntime != nil {
+		runtime = &CommandRuntime{Analysis: analysisRuntime}
+	}
+
 	return &DocDriftResult{
 		Scope:          scope,
 		DriftItems:     driftItems,
@@ -451,6 +462,7 @@ func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, scop
 		Remediation: &DocRemediationResult{
 			Items: remediationItems,
 		},
+		Runtime:      runtime,
 		Warnings:     buildSpecInferenceWarnings("doc-drift analysis", warningSpecs...),
 		ContentTrust: resultmeta.UntrustedWorkspaceText(),
 	}, nil

--- a/internal/analysis/doc_drift_diff.go
+++ b/internal/analysis/doc_drift_diff.go
@@ -64,7 +64,7 @@ func resolveDiffDocDriftContext(ctx context.Context, repo *analysisRepository, c
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
-	targets, err := loadParsedDiffComplianceTargetsContext(ctx, parsed)
+	targets, err := loadParsedDiffComplianceTargetsContext(ctx, cfg, parsed)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}

--- a/internal/analysis/doc_drift_test.go
+++ b/internal/analysis/doc_drift_test.go
@@ -393,6 +393,15 @@ func TestCheckDocDriftUsesAnalysisProviderWhenEnabled(t *testing.T) {
 	if got, want := suggestion.SuggestedEdit.Note, "Point readers at state.db as the canonical store and downgrade work_queue.json to optional cache status."; got != want {
 		t.Fatalf("suggested_edit.note = %q, want %q", got, want)
 	}
+	if result.Runtime == nil || result.Runtime.Analysis == nil {
+		t.Fatalf("runtime = %+v, want analysis provenance", result.Runtime)
+	}
+	if !result.Runtime.Analysis.Used {
+		t.Fatalf("runtime.analysis.used = false, want true")
+	}
+	if got, want := result.Runtime.Analysis.Model, "pituitary-analysis"; got != want {
+		t.Fatalf("runtime.analysis.model = %q, want %q", got, want)
+	}
 }
 
 func TestCheckDocDriftSurfacesPossibleDriftForConceptualNearMatch(t *testing.T) {

--- a/internal/analysis/review.go
+++ b/internal/analysis/review.go
@@ -112,7 +112,7 @@ func ReviewSpecContext(ctx context.Context, cfg *config.Config, request ReviewRe
 		if err != nil {
 			return nil, err
 		}
-		docDrift, err = buildDocDriftResult(ctx, analyzer, DocDriftScope{Mode: "doc_refs", DocRefs: uniqueStrings(impactDocRefs)}, impactDocs, docDriftSpecs, repo.loadAllSpecs)
+		docDrift, err = buildDocDriftResult(ctx, analyzer, newAnalysisRuntimeUsage(cfg.Runtime.Analysis), DocDriftScope{Mode: "doc_refs", DocRefs: uniqueStrings(impactDocRefs)}, impactDocs, docDriftSpecs, repo.loadAllSpecs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/analysis/runtime_metadata.go
+++ b/internal/analysis/runtime_metadata.go
@@ -1,0 +1,36 @@
+package analysis
+
+import (
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+// CommandRuntime captures runtime provenance for one analysis result.
+type CommandRuntime struct {
+	Analysis *RuntimeUsage `json:"analysis,omitempty"`
+}
+
+// RuntimeUsage records the configured runtime surface and whether the command
+// consulted it during this run.
+type RuntimeUsage struct {
+	Profile  string `json:"profile,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
+	Used     bool   `json:"used"`
+}
+
+func newAnalysisRuntimeUsage(provider config.RuntimeProvider) *RuntimeUsage {
+	resolvedProvider := strings.TrimSpace(provider.Provider)
+	if resolvedProvider == "" || resolvedProvider == config.RuntimeProviderDisabled {
+		return nil
+	}
+
+	return &RuntimeUsage{
+		Profile:  strings.TrimSpace(provider.Profile),
+		Provider: resolvedProvider,
+		Model:    strings.TrimSpace(provider.Model),
+		Endpoint: strings.TrimSpace(provider.Endpoint),
+	}
+}

--- a/internal/analysis/terminology.go
+++ b/internal/analysis/terminology.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"context"
 	"fmt"
+	pathpkg "path"
 	"regexp"
 	"sort"
 	"strings"
@@ -182,6 +183,7 @@ func CheckTerminologyContext(ctx context.Context, cfg *config.Config, request Te
 	if err != nil {
 		return nil, err
 	}
+	artifacts = filterTerminologyArtifactsByExcludePaths(artifacts, cfg.Terminology.ExcludePaths)
 
 	anchors, evidenceSections, warnings, err := loadTerminologyAnchors(repo, normalized.TerminologyAuditRequest, anchor)
 	if err != nil {
@@ -345,6 +347,42 @@ func loadTerminologyArtifacts(repo *analysisRepository, request TerminologyAudit
 		}
 	})
 	return artifacts, nil
+}
+
+func filterTerminologyArtifactsByExcludePaths(artifacts []terminologyArtifact, patterns []string) []terminologyArtifact {
+	if len(artifacts) == 0 || len(patterns) == 0 {
+		return artifacts
+	}
+
+	filtered := make([]terminologyArtifact, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if terminologyArtifactExcluded(artifact, patterns) {
+			continue
+		}
+		filtered = append(filtered, artifact)
+	}
+	return filtered
+}
+
+func terminologyArtifactExcluded(artifact terminologyArtifact, patterns []string) bool {
+	sourcePath := strings.TrimSpace(strings.TrimPrefix(artifact.SourceRef, "file://"))
+	if sourcePath == "" {
+		return false
+	}
+
+	candidates := []string{pathpkg.Clean(sourcePath)}
+	if repoID := strings.TrimSpace(artifact.Metadata["repo_id"]); repoID != "" {
+		candidates = append(candidates, repoID+":"+pathpkg.Clean(sourcePath))
+	}
+	for _, pattern := range patterns {
+		for _, candidate := range candidates {
+			ok, err := pathpkg.Match(pattern, candidate)
+			if err == nil && ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func terminologyArtifactsFromDocs(docs map[string]docDocument) []terminologyArtifact {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,7 +117,8 @@ type RuntimeProvider struct {
 }
 
 type Terminology struct {
-	Policies []TerminologyPolicy
+	ExcludePaths []string
+	Policies     []TerminologyPolicy
 }
 
 type TerminologyPolicy struct {
@@ -170,7 +171,8 @@ type rawSource struct {
 }
 
 type rawTerminology struct {
-	Policies []rawTerminologyPolicy `toml:"policies"`
+	ExcludePaths []string               `toml:"exclude_paths"`
+	Policies     []rawTerminologyPolicy `toml:"policies"`
 }
 
 type rawTerminologyPolicy struct {
@@ -297,7 +299,8 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 			Analysis: buildRuntimeProvider(raw.Runtime.Analysis, RuntimeProviderDisabled),
 		},
 		Terminology: Terminology{
-			Policies: make([]TerminologyPolicy, 0, len(raw.Terminology.Policies)),
+			ExcludePaths: uniqueStringList(raw.Terminology.ExcludePaths),
+			Policies:     make([]TerminologyPolicy, 0, len(raw.Terminology.Policies)),
 		},
 		Sources: make([]Source, 0, len(raw.Sources)),
 	}
@@ -691,6 +694,16 @@ func validateTerminology(terminology *Terminology) error {
 	var errs validationErrors
 	seenPreferred := make(map[string]string, len(terminology.Policies))
 	seenGoverned := make(map[string]string)
+	terminology.ExcludePaths = uniqueStringList(terminology.ExcludePaths)
+	for i, pattern := range terminology.ExcludePaths {
+		if strings.TrimSpace(pattern) == "" {
+			errs.add("terminology.exclude_paths[%d]: patterns must not be empty", i)
+			continue
+		}
+		if _, err := pathpkg.Match(pattern, "placeholder"); err != nil {
+			errs.add("terminology.exclude_paths[%d]: invalid pattern %q: %v", i, pattern, err)
+		}
+	}
 	for i := range terminology.Policies {
 		policy := &terminology.Policies[i]
 		label := fmt.Sprintf("terminology.policies[%d]", i)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1377,6 +1377,40 @@ path = "specs"
 	}
 }
 
+func TestLoadTerminologyExcludePaths(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[terminology]
+exclude_paths = ["CHANGELOG.md", "docs/archive/*.md"]
+
+[[terminology.policies]]
+preferred = "locality"
+historical_aliases = ["repo"]
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got, want := cfg.Terminology.ExcludePaths, []string{"CHANGELOG.md", "docs/archive/*.md"}; !equalStringSlices(got, want) {
+		t.Fatalf("exclude_paths = %#v, want %#v", got, want)
+	}
+}
+
 func TestLoadRejectsInvalidTerminologySeverity(t *testing.T) {
 	t.Parallel()
 
@@ -1424,6 +1458,7 @@ func TestRenderRoundTripsTerminologyPolicies(t *testing.T) {
 			IndexPath: ".pituitary/pituitary.db",
 		},
 		Terminology: Terminology{
+			ExcludePaths: []string{"CHANGELOG.md", "docs/archive/*.md"},
 			Policies: []TerminologyPolicy{
 				{
 					Preferred:         "locality",
@@ -1459,6 +1494,9 @@ func TestRenderRoundTripsTerminologyPolicies(t *testing.T) {
 	}
 	if got, want := len(loaded.Terminology.Policies), 1; got != want {
 		t.Fatalf("len(loaded terminology policies) = %d, want %d", got, want)
+	}
+	if got, want := loaded.Terminology.ExcludePaths, []string{"CHANGELOG.md", "docs/archive/*.md"}; !equalStringSlices(got, want) {
+		t.Fatalf("loaded exclude_paths = %#v, want %#v", got, want)
 	}
 	policy := loaded.Terminology.Policies[0]
 	if got, want := policy.Preferred, "locality"; got != want {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -48,6 +48,11 @@ func Render(cfg *Config) (string, error) {
 		writeRuntimeProviderConfig(&builder, cfg.Runtime.Analysis, runtimeProfileBase(cfg.Runtime.Profiles, cfg.Runtime.Analysis.Profile))
 	}
 
+	if len(cfg.Terminology.ExcludePaths) > 0 {
+		builder.WriteString("\n[terminology]\n")
+		writeQuotedArray(&builder, "exclude_paths", cfg.Terminology.ExcludePaths)
+	}
+
 	for _, policy := range cfg.Terminology.Policies {
 		builder.WriteString("\n[[terminology.policies]]\n")
 		fmt.Fprintf(&builder, "preferred = %s\n", strconv.Quote(policy.Preferred))


### PR DESCRIPTION
## Summary
- add `result.runtime.analysis` provenance to compliance and doc-drift results and record whether analysis was actually used during the run
- split compliance `unspecified` findings into a machine-readable summary and collapse byte-identical mirror targets onto one representative path
- add `[terminology].exclude_paths` for terminology sweeps and `compile`, with docs and regression coverage

## Validation
- `go test ./internal/config -run 'TestLoadTerminologyExcludePaths|TestRenderRoundTripsTerminologyPolicies|TestLoadTerminologyPolicies' -count=1`
- `go test ./cmd -run 'TestRunCheckComplianceJSONIncludesUnspecifiedSummaryBreakout|TestRunCheckComplianceCollapsesDuplicateMirrorTargets|TestRunCheckTerminologyHonorsExcludePaths|TestRunCompileHonorsTerminologyExcludePaths' -count=1`
- `go test ./internal/analysis -run 'TestCheckComplianceIncludesAnalysisRuntimeProvenance|TestCheckDocDriftUsesAnalysisProviderWhenEnabled' -count=1`

Closes #290
Closes #291
Closes #292
Closes #293
Closes #294