### PR TITLE
[codex] Improve source debugging and runtime diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ pituitary status                       # index health at a glance
 | Find stale docs | `pituitary check-doc-drift --scope all` |
 | Find stale docs implicated by a diff | `git diff origin/main...HEAD \| pituitary check-doc-drift --diff-file -` |
 | Check a PR diff against specs | `git diff origin/main...HEAD \| pituitary check-compliance --diff-file -` |
+| Debug why a file is in or out of scope | `pituitary explain-file PATH` |
 | Full spec review | `pituitary review-spec --path specs/X` |
 | Auto-fix deterministic drift | `pituitary fix --scope all --dry-run` |
 | Search specs semantically | `pituitary search-specs --query "rate limiting"` |
@@ -92,6 +93,8 @@ pituitary status                       # index health at a glance
 | Inspect command contracts | `pituitary schema review-spec --format json` |
 
 All commands output JSON with `--format json`. Agents can set `PITUITARY_FORMAT=json`, and redirected stdout defaults to JSON automatically. `review-spec` also supports `--format markdown` and `--format html` for shareable reports with full evidence chains.
+
+When file selection looks wrong, start with `pituitary explain-file PATH`. It is the fastest way to confirm which source matched a file, which selectors fired, and why a path was rejected before you debug drift or compliance output.
 
 One `pituitary.toml` can also span multiple repository roots. Bind a source to a named repo root with `repo = "..."`, and Pituitary carries that repo identity through search, drift, impact, status, and index output so cross-repo results stay unambiguous.
 

--- a/cmd/check_compliance.go
+++ b/cmd/check_compliance.go
@@ -31,7 +31,7 @@ func runCheckCompliance(args []string, stdout, stderr io.Writer) int {
 func runCheckComplianceContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("check-compliance", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-compliance", "pituitary [--config PATH] check-compliance (--path PATH... | --diff-file PATH|- | --request-file PATH|-) [--format FORMAT]")
+	help := newCommandHelp("check-compliance", "pituitary [--config PATH] check-compliance (--path PATH... | --diff-file PATH|- | --request-file PATH|-) [--format FORMAT] [--timings]")
 
 	var (
 		paths       compliancePathList
@@ -40,6 +40,7 @@ func runCheckComplianceContext(ctx context.Context, args []string, stdout, stder
 		format      string
 		configPath  string
 		atDate      string
+		timings     bool
 	)
 	fs.Var(&paths, "path", "workspace-relative or absolute file path; repeat to check multiple files")
 	fs.StringVar(&diffFile, "diff-file", "", "path to a unified diff file, or - for stdin")
@@ -47,6 +48,7 @@ func runCheckComplianceContext(ctx context.Context, args []string, stdout, stder
 	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 	fs.StringVar(&configPath, "config", "", "path to workspace config")
 	fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
+	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
 	var minConfidence string
 	fs.StringVar(&minConfidence, "min-confidence", "", "minimum confidence tier: extracted, inferred, or ambiguous")
@@ -135,12 +137,14 @@ func runCheckComplianceContext(ctx context.Context, args []string, stdout, stder
 	if trimmedConf := strings.TrimSpace(minConfidence); trimmedConf != "" {
 		request.MinConfidence = trimmedConf
 	}
+	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
+
 	operation := app.CheckCompliance(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
 		return writeCLIError(stdout, stderr, format, "check-compliance", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
-	return writeCLISuccess(stdout, stderr, format, "check-compliance", operation.Request, operation.Result, nil)
+	return writeCLISuccessWithTimings(stdout, stderr, format, "check-compliance", operation.Request, operation.Result, nil, snapshotCommandTimings(tracker, started))
 }
 
 func complianceRequestFromFlags(workspaceRoot string, paths []string, diffFile string) (analysis.ComplianceRequest, error) {

--- a/cmd/check_compliance_test.go
+++ b/cmd/check_compliance_test.go
@@ -494,6 +494,102 @@ plinth ember quartz
 	}
 }
 
+func TestRunCheckComplianceJSONIncludesTopSuggestionsAndTimings(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	writeComplianceSourceFile(t, repo, "src/api/middleware/ratelimiter.go", `
+package middleware
+
+func buildLimiter() {}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		rebuildSearchWorkspaceIndex(t)
+		return runCheckCompliance([]string{
+			"--path", "src/api/middleware/ratelimiter.go",
+			"--format", "json",
+			"--timings",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckCompliance() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckCompliance() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			TopSuggestions []string `json:"top_suggestions"`
+		} `json:"result"`
+		Timings struct {
+			TotalMS    int64 `json:"total_ms"`
+			IndexingMS int64 `json:"indexing_ms"`
+		} `json:"timings"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal compliance timings payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("payload errors = %+v, want none", payload.Errors)
+	}
+	if len(payload.Result.TopSuggestions) == 0 || !strings.Contains(payload.Result.TopSuggestions[0], "already governs") {
+		t.Fatalf("top_suggestions = %+v, want surfaced compliance guidance", payload.Result.TopSuggestions)
+	}
+	if payload.Timings.TotalMS <= 0 {
+		t.Fatalf("timings.total_ms = %d, want > 0", payload.Timings.TotalMS)
+	}
+	if payload.Timings.IndexingMS <= 0 {
+		t.Fatalf("timings.indexing_ms = %d, want > 0", payload.Timings.IndexingMS)
+	}
+}
+
+func TestRunCheckComplianceJSONTimingsIncludeEmbeddingCalls(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	writeComplianceSourceFile(t, repo, "notes/ungoverned.txt", `
+zxqv aurora lattice
+plinth ember quartz
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		rebuildSearchWorkspaceIndex(t)
+		return runCheckCompliance([]string{
+			"--path", "notes/ungoverned.txt",
+			"--format", "json",
+			"--timings",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckCompliance() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckCompliance() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Timings struct {
+			EmbeddingMS    int64 `json:"embedding_ms"`
+			EmbeddingCalls int   `json:"embedding_calls"`
+		} `json:"timings"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal compliance embedding timings payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("payload errors = %+v, want none", payload.Errors)
+	}
+	if payload.Timings.EmbeddingMS <= 0 || payload.Timings.EmbeddingCalls <= 0 {
+		t.Fatalf("timings = %+v, want semantic lookup embedding timings", payload.Timings)
+	}
+}
+
 func TestRunCheckComplianceDiffFromStdinJSON(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 

--- a/cmd/check_doc_drift.go
+++ b/cmd/check_doc_drift.go
@@ -30,7 +30,7 @@ func runCheckDocDrift(args []string, stdout, stderr io.Writer) int {
 func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("check-doc-drift", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-doc-drift", "pituitary [--config PATH] check-doc-drift ([--doc-ref REF | --path PATH]... | [--scope all] | [--diff-file PATH|-]) [--request-file PATH|-] [--format FORMAT]")
+	help := newCommandHelp("check-doc-drift", "pituitary [--config PATH] check-doc-drift ([--doc-ref REF | --path PATH]... | [--scope all] | [--diff-file PATH|-]) [--request-file PATH|-] [--format FORMAT] [--timings]")
 
 	var (
 		docRefs     docRefList
@@ -41,6 +41,7 @@ func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr 
 		format      string
 		configPath  string
 		atDate      string
+		timings     bool
 	)
 	fs.Var(&docRefs, "doc-ref", "target doc ref; repeat to supply doc_refs")
 	fs.Var(&docPaths, "path", "workspace-relative or absolute path to an indexed doc; repeat to supply paths")
@@ -50,6 +51,7 @@ func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr 
 	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 	fs.StringVar(&configPath, "config", "", "path to workspace config")
 	fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
+	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
 	var minConfidence string
 	fs.StringVar(&minConfidence, "min-confidence", "", "minimum confidence tier: extracted, inferred, or ambiguous")
@@ -146,12 +148,14 @@ func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr 
 	if trimmedConf := strings.TrimSpace(minConfidence); trimmedConf != "" {
 		request.MinConfidence = trimmedConf
 	}
+	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
+
 	operation := app.CheckDocDrift(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
 		return writeCLIError(stdout, stderr, format, "check-doc-drift", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
-	return writeCLISuccess(stdout, stderr, format, "check-doc-drift", operation.Request, operation.Result, nil)
+	return writeCLISuccessWithTimings(stdout, stderr, format, "check-doc-drift", operation.Request, operation.Result, nil, snapshotCommandTimings(tracker, started))
 }
 
 func docDriftRequestFromFlags(workspaceRoot string, docRefs []string, scope, diffFile string) (analysis.DocDriftRequest, error) {

--- a/cmd/check_terminology.go
+++ b/cmd/check_terminology.go
@@ -30,7 +30,7 @@ func runCheckTerminology(args []string, stdout, stderr io.Writer) int {
 func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("check-terminology", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-terminology", "pituitary [--config PATH] check-terminology ([--term TERM]... [--canonical-term TERM]... [--spec-ref REF | --path PATH] [--scope SCOPE] | --request-file PATH|-) [--format FORMAT]")
+	help := newCommandHelp("check-terminology", "pituitary [--config PATH] check-terminology ([--term TERM]... [--canonical-term TERM]... [--spec-ref REF | --path PATH] [--scope SCOPE] | --request-file PATH|-) [--format FORMAT] [--timings]")
 
 	var (
 		terms          stringList
@@ -41,6 +41,7 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 		requestFile    string
 		format         string
 		configPath     string
+		timings        bool
 	)
 	fs.Var(&terms, "term", "displaced or governed term to audit; repeat to narrow a configured policy set or supply ad hoc terms")
 	fs.Var(&canonicalTerms, "canonical-term", "replacement or canonical term; repeat to supply multiple terms")
@@ -50,6 +51,7 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 	fs.StringVar(&requestFile, "request-file", "", "path to terminology audit request JSON, or - for stdin")
 	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 	fs.StringVar(&configPath, "config", "", "path to workspace config")
+	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
 	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
 		return writeCLIError(stdout, stderr, format, "check-terminology", nil, cliIssue{
@@ -130,12 +132,14 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 		}
 	}
 
+	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
+
 	operation := app.CheckTerminology(ctx, resolvedConfigPath, request)
 	if operation.Issue != nil {
 		return writeCLIError(stdout, stderr, format, "check-terminology", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
 	}
 
-	return writeCLISuccess(stdout, stderr, format, "check-terminology", operation.Request, operation.Result, nil)
+	return writeCLISuccessWithTimings(stdout, stderr, format, "check-terminology", operation.Request, operation.Result, nil, snapshotCommandTimings(tracker, started))
 }
 
 func countNonEmptyStrings(values []string) int {

--- a/cmd/check_terminology_test.go
+++ b/cmd/check_terminology_test.go
@@ -304,6 +304,45 @@ include = ["guides/*.md"]
 	return root
 }
 
+func TestRunCheckTerminologyJSONIncludesTimings(t *testing.T) {
+	repo := writeTerminologyWorkspaceCmd(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runCheckTerminology([]string{"--format", "json", "--timings"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckTerminology() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckTerminology() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Timings struct {
+			TotalMS        int64 `json:"total_ms"`
+			IndexingMS     int64 `json:"indexing_ms"`
+			EmbeddingMS    int64 `json:"embedding_ms"`
+			EmbeddingCalls int   `json:"embedding_calls"`
+		} `json:"timings"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal terminology timings payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if payload.Timings.TotalMS <= 0 || payload.Timings.IndexingMS <= 0 {
+		t.Fatalf("timings = %+v, want total/indexing timing metadata", payload.Timings)
+	}
+}
+
 func writeTerminologyExcludeWorkspaceCmd(t *testing.T) string {
 	t.Helper()
 

--- a/cmd/compile.go
+++ b/cmd/compile.go
@@ -11,9 +11,10 @@ import (
 )
 
 type compileCLIRequest struct {
-	Scope  string `json:"scope,omitempty"`
-	DryRun bool   `json:"dry_run,omitempty"`
-	Yes    bool   `json:"yes,omitempty"`
+	Scope   string `json:"scope,omitempty"`
+	DryRun  bool   `json:"dry_run,omitempty"`
+	Yes     bool   `json:"yes,omitempty"`
+	Timings bool   `json:"timings,omitempty"`
 }
 
 func runCompile(args []string, stdout, stderr io.Writer) int {
@@ -23,7 +24,7 @@ func runCompile(args []string, stdout, stderr io.Writer) int {
 func runCompileContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("compile", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	help := newCommandHelp("compile", "pituitary [--config PATH] compile --scope SCOPE [--dry-run] [--yes] [--format FORMAT]")
+	help := newCommandHelp("compile", "pituitary [--config PATH] compile --scope SCOPE [--dry-run] [--yes] [--format FORMAT] [--timings]")
 
 	var (
 		scope      string
@@ -31,12 +32,14 @@ func runCompileContext(ctx context.Context, args []string, stdout, stderr io.Wri
 		yes        bool
 		format     string
 		configPath string
+		timings    bool
 	)
 	fs.StringVar(&scope, "scope", "", "target scope: accepted spec ref or all")
 	fs.BoolVar(&dryRun, "dry-run", false, "plan deterministic edits without writing files")
 	fs.BoolVar(&yes, "yes", false, "apply all planned edits without prompting")
 	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 	fs.StringVar(&configPath, "config", "", "path to workspace config")
+	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
 	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
 		return writeCLIError(stdout, stderr, format, "compile", nil, cliIssue{
@@ -54,9 +57,10 @@ func runCompileContext(ctx context.Context, args []string, stdout, stderr io.Wri
 	}
 
 	request := compileCLIRequest{
-		Scope:  strings.TrimSpace(scope),
-		DryRun: dryRun,
-		Yes:    yes,
+		Scope:   strings.TrimSpace(scope),
+		DryRun:  dryRun,
+		Yes:     yes,
+		Timings: timings,
 	}
 	if err := validateCLIFormat("compile", format); err != nil {
 		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
@@ -93,6 +97,8 @@ func runCompileContext(ctx context.Context, args []string, stdout, stderr io.Wri
 		apply = false
 	}
 
+	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
+
 	response := app.CompileTerminology(ctx, resolvedConfigPath, app.CompileRequest{
 		Scope: request.Scope,
 		Apply: apply,
@@ -108,5 +114,5 @@ func runCompileContext(ctx context.Context, args []string, stdout, stderr io.Wri
 		response.Result.Guidance = append(response.Result.Guidance, "Showing planned edits (dry-run). Re-run with --yes to apply.")
 	}
 
-	return writeCLISuccess(stdout, stderr, format, "compile", request, response.Result, nil)
+	return writeCLISuccessWithTimings(stdout, stderr, format, "compile", request, response.Result, nil, snapshotCommandTimings(tracker, started))
 }

--- a/cmd/compile_test.go
+++ b/cmd/compile_test.go
@@ -292,3 +292,47 @@ include = ["guides/*.md"]
 `)
 	return root
 }
+
+func TestRunCompileJSONIncludesTimings(t *testing.T) {
+	repo := writeCompileWorkspaceCmd(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runCompile([]string{"--scope", "all", "--dry-run", "--format", "json", "--timings"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCompile() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCompile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request struct {
+			Timings bool `json:"timings"`
+		} `json:"request"`
+		Timings struct {
+			TotalMS        int64 `json:"total_ms"`
+			IndexingMS     int64 `json:"indexing_ms"`
+			EmbeddingCalls int   `json:"embedding_calls"`
+		} `json:"timings"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal compile timings payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if !payload.Request.Timings {
+		t.Fatalf("request.timings = false, want true")
+	}
+	if payload.Timings.TotalMS <= 0 || payload.Timings.IndexingMS <= 0 {
+		t.Fatalf("timings = %+v, want total/indexing timing metadata", payload.Timings)
+	}
+}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -56,8 +56,18 @@ func printCommandHelp(w io.Writer, fs *flag.FlagSet, help commandHelp) {
 		printSharedConfigResolution(w)
 	}
 	fmt.Fprintln(w)
+	printCommandDebugTip(w, help.Name)
 	fmt.Fprintln(w, "flags:")
 	printFlagSetDefaults(w, fs)
+}
+
+func printCommandDebugTip(w io.Writer, name string) {
+	switch name {
+	case "preview-sources", "check-doc-drift", "check-compliance", "check-terminology", "compile":
+		fmt.Fprintln(w, "debug tip:")
+		fmt.Fprintln(w, "  if a file looks unexpectedly included, excluded, or misclassified, run `pituitary explain-file PATH` first")
+		fmt.Fprintln(w)
+	}
 }
 
 func printSharedConfigResolution(w io.Writer) {

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/analysis"
 	"github.com/dusk-network/pituitary/internal/app"
+	"github.com/dusk-network/pituitary/internal/resultmeta"
 	"github.com/dusk-network/pituitary/internal/source"
 )
 
@@ -20,6 +21,7 @@ type cliIssue struct {
 type cliEnvelope struct {
 	Request  any        `json:"request"`
 	Result   any        `json:"result"`
+	Timings  *resultmeta.Timings `json:"timings,omitempty"`
 	Warnings []cliIssue `json:"warnings"`
 	Errors   []cliIssue `json:"errors"`
 }
@@ -48,6 +50,10 @@ func validateCLIFormat(command, format string) error {
 }
 
 func writeCLISuccess(stdout, stderr io.Writer, format, command string, request, result any, warnings []cliIssue) int {
+	return writeCLISuccessWithTimings(stdout, stderr, format, command, request, result, warnings, nil)
+}
+
+func writeCLISuccessWithTimings(stdout, stderr io.Writer, format, command string, request, result any, warnings []cliIssue, timings *resultmeta.Timings) int {
 	if len(warnings) == 0 {
 		warnings = cliWarningsForResult(result)
 	}
@@ -55,6 +61,7 @@ func writeCLISuccess(stdout, stderr io.Writer, format, command string, request, 
 		return writeCLIJSON(stdout, cliEnvelope{
 			Request:  request,
 			Result:   result,
+			Timings:  timings,
 			Warnings: warnings,
 			Errors:   []cliIssue{},
 		})

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -19,11 +19,11 @@ type cliIssue struct {
 }
 
 type cliEnvelope struct {
-	Request  any        `json:"request"`
-	Result   any        `json:"result"`
+	Request  any                 `json:"request"`
+	Result   any                 `json:"result"`
 	Timings  *resultmeta.Timings `json:"timings,omitempty"`
-	Warnings []cliIssue `json:"warnings"`
-	Errors   []cliIssue `json:"errors"`
+	Warnings []cliIssue          `json:"warnings"`
+	Errors   []cliIssue          `json:"errors"`
 }
 
 func isSupportedFormat(format string) bool {

--- a/cmd/preview_sources.go
+++ b/cmd/preview_sources.go
@@ -11,7 +11,9 @@ import (
 	"github.com/dusk-network/pituitary/internal/source"
 )
 
-type previewSourcesRequest struct{}
+type previewSourcesRequest struct {
+	Verbose bool `json:"verbose,omitempty"`
+}
 
 func runPreviewSources(args []string, stdout, stderr io.Writer) int {
 	return runPreviewSourcesContext(context.Background(), args, stdout, stderr)
@@ -20,14 +22,16 @@ func runPreviewSources(args []string, stdout, stderr io.Writer) int {
 func runPreviewSourcesContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("preview-sources", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	help := newCommandHelp("preview-sources", "pituitary [--config PATH] preview-sources [--format FORMAT]")
+	help := newCommandHelp("preview-sources", "pituitary [--config PATH] preview-sources [--verbose] [--format FORMAT]")
 
 	var (
 		format     string
 		configPath string
+		verbose    bool
 	)
 	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 	fs.StringVar(&configPath, "config", "", "path to workspace config")
+	fs.BoolVar(&verbose, "verbose", false, "show selector-match diagnostics for previewed files")
 
 	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
 		return writeCLIError(stdout, stderr, format, "preview-sources", nil, cliIssue{
@@ -50,7 +54,7 @@ func runPreviewSourcesContext(ctx context.Context, args []string, stdout, stderr
 		}, 2)
 	}
 
-	request := previewSourcesRequest{}
+	request := previewSourcesRequest{Verbose: verbose}
 
 	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
 	if err != nil {
@@ -68,7 +72,10 @@ func runPreviewSourcesContext(ctx context.Context, args []string, stdout, stderr
 		}, 2)
 	}
 
-	result, err := source.PreviewFromConfigWithOptions(cfg, source.PreviewOptions{Logger: cliLoggerFromContext(ctx)})
+	result, err := source.PreviewFromConfigWithOptions(cfg, source.PreviewOptions{
+		Logger:  cliLoggerFromContext(ctx),
+		Verbose: verbose,
+	})
 	if err != nil {
 		return writeCLIError(stdout, stderr, format, "preview-sources", request, cliIssue{
 			Code:    "source_error",

--- a/cmd/preview_sources_test.go
+++ b/cmd/preview_sources_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -132,5 +133,116 @@ title_pointer = "/info/title"
 	}
 	if got, want := source.Items[0].Path, "schemas/rate-limit.json"; got != want {
 		t.Fatalf("item path = %q, want %q", got, want)
+	}
+}
+
+func TestRunPreviewSourcesVerboseJSONIncludesSelectorDiagnostics(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+exclude = ["guides/private.md"]
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "docs", "guides", "public.md"), "# Public\n")
+	mustWriteFileCmd(t, filepath.Join(repo, "docs", "guides", "private.md"), "# Private\n")
+	mustWriteFileCmd(t, filepath.Join(repo, "docs", "notes", "other.md"), "# Other\n")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runPreviewSources([]string{"--verbose", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runPreviewSources() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runPreviewSources() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Sources []struct {
+				CandidateCount int `json:"candidate_count"`
+				ItemCount      int `json:"item_count"`
+				Items          []struct {
+					Path           string   `json:"path"`
+					IncludeMatches []string `json:"include_matches"`
+				} `json:"items"`
+				RejectedItems []struct {
+					Path           string   `json:"path"`
+					Reason         string   `json:"reason"`
+					IncludeMatches []string `json:"include_matches"`
+					ExcludeMatches []string `json:"exclude_matches"`
+				} `json:"rejected_items"`
+			} `json:"sources"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal verbose preview payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	source := payload.Result.Sources[0]
+	if got, want := source.CandidateCount, 3; got != want {
+		t.Fatalf("candidate_count = %d, want %d", got, want)
+	}
+	if got, want := source.ItemCount, 1; got != want {
+		t.Fatalf("item_count = %d, want %d", got, want)
+	}
+	if got, want := source.Items[0].Path, "docs/guides/public.md"; got != want {
+		t.Fatalf("selected item path = %q, want %q", got, want)
+	}
+	if len(source.Items[0].IncludeMatches) != 1 || source.Items[0].IncludeMatches[0] != "guides/*.md" {
+		t.Fatalf("include_matches = %+v, want guides/*.md", source.Items[0].IncludeMatches)
+	}
+	if got, want := len(source.RejectedItems), 2; got != want {
+		t.Fatalf("rejected_items = %+v, want %d entries", source.RejectedItems, want)
+	}
+}
+
+func TestRunPreviewSourcesTextExplainsSelectorMismatch(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "docs", "notes", "other.md"), "# Other\n")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runPreviewSources([]string{}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runPreviewSources() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"candidate files: 1",
+		"no matching items (candidate files were found under the source root, but the selectors excluded them)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("preview output %q does not contain %q", output, want)
+		}
 	}
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -547,7 +547,10 @@ func renderPreviewSourcesResult(w io.Writer, result *source.PreviewResult) {
 	}
 
 	for i, preview := range result.Sources {
-		fmt.Fprintf(w, "source: %s | %s | root: %s | items: %d\n", preview.Name, preview.Kind, preview.Path, preview.ItemCount)
+		fmt.Fprintf(w, "source: %s | %s | path: %s | items: %d\n", preview.Name, preview.Kind, preview.Path, preview.ItemCount)
+		if preview.ResolvedPath != "" {
+			fmt.Fprintf(w, "resolved path: %s\n", preview.ResolvedPath)
+		}
 		if len(preview.Files) > 0 {
 			fmt.Fprintf(w, "files: %s\n", strings.Join(preview.Files, ", "))
 		}
@@ -557,16 +560,57 @@ func renderPreviewSourcesResult(w io.Writer, result *source.PreviewResult) {
 		if len(preview.Exclude) > 0 {
 			fmt.Fprintf(w, "exclude: %s\n", strings.Join(preview.Exclude, ", "))
 		}
+		if preview.CandidateCount > 0 {
+			fmt.Fprintf(w, "candidate files: %d\n", preview.CandidateCount)
+		}
 		if len(preview.Items) == 0 {
-			fmt.Fprintln(w, "no matching items")
+			fmt.Fprint(w, "no matching items")
+			if preview.CandidateCount > 0 {
+				fmt.Fprint(w, " (candidate files were found under the source root, but the selectors excluded them)")
+			}
+			fmt.Fprintln(w)
 		} else {
 			for _, item := range preview.Items {
 				fmt.Fprintf(w, "- %s | %s\n", item.ArtifactKind, item.Path)
+				if len(item.FilesMatched) > 0 {
+					fmt.Fprintf(w, "  files matched: %s\n", strings.Join(item.FilesMatched, ", "))
+				}
+				if len(item.IncludeMatches) > 0 {
+					fmt.Fprintf(w, "  include matches: %s\n", strings.Join(item.IncludeMatches, ", "))
+				}
+			}
+		}
+		if len(preview.RejectedItems) > 0 {
+			fmt.Fprintln(w, "rejected candidates:")
+			for _, item := range preview.RejectedItems {
+				fmt.Fprintf(w, "- %s | %s\n", item.Path, humanizePreviewRejectionReason(item.Reason))
+				if len(item.FilesMatched) > 0 {
+					fmt.Fprintf(w, "  files matched: %s\n", strings.Join(item.FilesMatched, ", "))
+				}
+				if len(item.IncludeMatches) > 0 {
+					fmt.Fprintf(w, "  include matches: %s\n", strings.Join(item.IncludeMatches, ", "))
+				}
+				if len(item.ExcludeMatches) > 0 {
+					fmt.Fprintf(w, "  exclude matches: %s\n", strings.Join(item.ExcludeMatches, ", "))
+				}
 			}
 		}
 		if i < len(result.Sources)-1 {
 			fmt.Fprintln(w)
 		}
+	}
+}
+
+func humanizePreviewRejectionReason(reason string) string {
+	switch reason {
+	case "not_listed_in_files":
+		return "not listed in files selectors"
+	case "not_matched_by_include":
+		return "not matched by include selectors"
+	case "excluded_by_selector":
+		return "excluded by exclude selectors"
+	default:
+		return reason
 	}
 }
 
@@ -914,6 +958,13 @@ func renderComplianceResult(w io.Writer, result *analysis.ComplianceResult) {
 	renderComplianceFindingGroup(w, "conflicts", result.Conflicts)
 	renderComplianceFindingGroup(w, "compliant", result.Compliant)
 	renderComplianceFindingGroup(w, "unspecified", result.Unspecified)
+	if suggestions := complianceTopSuggestions(result); len(suggestions) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  %s %d\n", p.white("TOP SUGGESTIONS:"), len(suggestions))
+		for _, suggestion := range suggestions {
+			fmt.Fprintf(w, "     %s %s\n", p.arrow(), truncateRenderLine(suggestion, 160))
+		}
+	}
 }
 
 func renderComplianceFindingGroup(w io.Writer, label string, findings []analysis.ComplianceFinding) {
@@ -943,6 +994,54 @@ func renderComplianceFindingGroup(w io.Writer, label string, findings []analysis
 			fmt.Fprintf(w, "     %s %s\n", p.arrow(), item.Suggestion)
 		}
 	}
+}
+
+func complianceTopSuggestions(result *analysis.ComplianceResult) []string {
+	if result == nil {
+		return nil
+	}
+	if len(result.TopSuggestions) > 0 {
+		return result.TopSuggestions
+	}
+
+	seen := make(map[string]struct{})
+	suggestions := make([]string, 0, 3)
+	appendSuggestions := func(findings []analysis.ComplianceFinding) {
+		for _, finding := range findings {
+			suggestion := strings.TrimSpace(finding.Suggestion)
+			if suggestion == "" {
+				continue
+			}
+			if _, ok := seen[suggestion]; ok {
+				continue
+			}
+			seen[suggestion] = struct{}{}
+			suggestions = append(suggestions, suggestion)
+			if len(suggestions) == 3 {
+				return
+			}
+		}
+	}
+
+	appendSuggestions(result.Conflicts)
+	if len(suggestions) < 3 {
+		appendSuggestions(result.Unspecified)
+	}
+	if len(suggestions) < 3 {
+		appendSuggestions(result.Compliant)
+	}
+	return suggestions
+}
+
+func truncateRenderLine(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	if limit <= 3 {
+		return value[:limit]
+	}
+	return value[:limit-3] + "..."
 }
 
 func renderTerminologyAuditResult(w io.Writer, result *analysis.TerminologyAuditResult) {

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -401,6 +401,7 @@ func TestRenderComplianceResultIncludesTraceabilityGuidance(t *testing.T) {
 		"━━◈ check-compliance",
 		"paths: src/api/middleware/tenant_limiter.go",
 		"UNSPECIFIED: 1",
+		"TOP SUGGESTIONS: 1",
 		"traceability semantic_neighbor_without_applies_to",
 		"limiting factor accepted spec metadata is missing explicit applies_to coverage",
 		`If SPEC-042 governs src/api/middleware/tenant_limiter.go, add applies_to = ["code://src/api/middleware/tenant_limiter.go"] to that accepted spec and rebuild the index.`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,8 +34,8 @@ func commandRegistry() map[string]commandSpec {
 		"index":                {Description: "rebuild or validate the local Pituitary index", Formats: commandFormats(), Run: runIndexContext},
 		"status":               {Description: "show current index status", Formats: commandFormats(), Run: runStatusContext},
 		"version":              {Description: "show Pituitary and Go runtime versions", Formats: commandFormats(), Run: runVersionContext},
-		"preview-sources":      {Description: "show which files each source will index", Formats: commandFormats(), Run: runPreviewSourcesContext},
-		"explain-file":         {Description: "explain how one file is treated by configured sources", Formats: commandFormats(), Run: runExplainFileContext},
+		"preview-sources":      {Description: "preview indexed files per source and selector diagnostics", Formats: commandFormats(), Run: runPreviewSourcesContext},
+		"explain-file":         {Description: "debug why one file is in or out of scope for configured sources", Formats: commandFormats(), Run: runExplainFileContext},
 		"search-specs":         {Description: "search spec sections semantically", Formats: commandFormats(commandFormatTable), Run: runSearchSpecsContext},
 		"check-overlap":        {Description: "find overlapping specs", Formats: commandFormats(), Run: runCheckOverlapContext},
 		"compare-specs":        {Description: "compare design tradeoffs across specs", Formats: commandFormats(), Run: runCompareSpecsContext},
@@ -155,6 +155,9 @@ func printHelp(w io.Writer) {
 		fmt.Fprintf(w, "  %-16s %s\n", name, commandDescription(name))
 	}
 
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "debugging:")
+	fmt.Fprintln(w, "  when a file looks unexpectedly included or excluded, run `pituitary explain-file PATH` first")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "run `pituitary <command> --help` for command-specific usage")
 }

--- a/cmd/timings.go
+++ b/cmd/timings.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/dusk-network/pituitary/internal/resultmeta"
+)
+
+func withCommandTimings(ctx context.Context, enabled bool) (context.Context, *resultmeta.TimingTracker, time.Time) {
+	if !enabled {
+		return ctx, nil, time.Time{}
+	}
+	tracker := resultmeta.NewTimingTracker()
+	return resultmeta.WithTimingTracker(ctx, tracker), tracker, time.Now()
+}
+
+func snapshotCommandTimings(tracker *resultmeta.TimingTracker, started time.Time) *resultmeta.Timings {
+	if tracker == nil || started.IsZero() {
+		return nil
+	}
+	return tracker.Snapshot(time.Since(started))
+}

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -10,6 +10,7 @@ pituitary init --path . --dry-run               # preview without writing
 pituitary new --title "Rate limiting policy" --domain api  # scaffold a draft spec
 pituitary discover --path .                     # propose sources (lower-level)
 pituitary preview-sources                       # show what will be indexed
+pituitary preview-sources --verbose             # include rejected candidates + selector matches
 pituitary explain-file README.md                # why is this file in/out of scope?
 ```
 
@@ -118,6 +119,15 @@ Tools exposed: `search_specs`, `check_overlap`, `compare_specs`, `analyze_impact
 --show-delta      # show governance graph changes (index --update)
 --show-families   # show spec families via graph clustering (status)
 --family N        # filter results to a spec family (search-specs)
+--timings         # add total/indexing/embedder/analysis timing metadata to JSON output
+```
+
+## Debugging First
+
+```sh
+pituitary explain-file PATH                     # first stop when scope/classification looks wrong
+pituitary preview-sources --verbose             # confirm include/exclude decisions across a whole source
+pituitary check-compliance --path PATH --format json --timings   # inspect runtime call counts
 ```
 
 ## Typical Flows

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,8 @@ include = ["guides/*.md"]
 
 Pituitary keeps source paths repo-relative, adds `repo` to search/drift/impact/status JSON, and scopes non-primary generated doc refs as `doc://<repo>/...` so duplicate paths from sibling repos stay distinct.
 
+Important path-resolution rule: `workspace.root` and `[[workspace.repos]].root` resolve relative to the config file's base directory, not the current working directory. That matters when you keep a scratch config outside the repo, for example `/tmp/pit-fake.toml` with `root = ".."`. In that case `..` resolves relative to `/tmp`, not relative to the shell directory where you invoked `pituitary`. If the resolved root is wrong, Pituitary now reports the derived absolute path in the validation error so the cause is visible immediately.
+
 ### Runtime Profiles
 
 Runtime config also supports reusable named profiles under `[runtime.profiles.<name>]`. Select one from `[runtime.embedder]` or `[runtime.analysis]` with `profile = "..."`, then override only the fields that differ:
@@ -248,6 +250,11 @@ Selectors are evaluated relative to the configured source `path`:
 - For `markdown_docs` and `markdown_contract`, `files` entries must point to `.md` files
 
 Selectors narrow what gets indexed but do not rewrite refs.
+
+Two debugging commands are worth learning early:
+
+- `pituitary preview-sources` shows what each source would index. Use `--verbose` to list rejected candidates and the include/exclude selectors that decided them.
+- `pituitary explain-file PATH` explains one file end-to-end: matching source, selector results, and why it was included or excluded. When a file looks wrong, run this first.
 
 ## Config Resolution
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,6 +19,7 @@ For quick command lookup, start with the [cheatsheet](cheatsheet.md).
 - New user evaluating Pituitary on an existing repo:
   - [docs/install.md](install.md)
   - [docs/cheatsheet.md](cheatsheet.md)
+  - Run `pituitary explain-file PATH` first when scope or source matching looks wrong
 - Repo owner wiring Pituitary into CI:
   - [docs/workflows.md](workflows.md)
   - [docs/development/ci-recipes.md](development/ci-recipes.md)

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -38,7 +38,7 @@ pituitary status --check-runtime embedder
 pituitary index --rebuild
 ```
 
-For provider-backed qualitative analysis used by `compare-specs`, `check-doc-drift`, and bounded re-adjudication in `check-compliance`:
+For provider-backed qualitative analysis used by `compare-specs`, `check-doc-drift`, impact-severity enrichment in `analyze-impact`, metadata inference in `canonicalize`, and bounded re-adjudication in `check-compliance`:
 
 ```toml
 [runtime.analysis]
@@ -75,6 +75,27 @@ pituitary status --check-runtime all
 
 `check-compliance` and `check-doc-drift` also record the configured analysis runtime in their JSON `result.runtime.analysis` block, including whether the command actually consulted the model during that run.
 
+## Runtime Matrix
+
+The most common operator mistake is assuming `runtime.analysis.model` affects every semantic command. It does not. The command/runtime relationship today is:
+
+| Command | `runtime.embedder` | `runtime.analysis` |
+|---|---|---|
+| `check-compliance` | Yes, for semantic retrieval / fallback target embedding | Optional bounded adjudication |
+| `check-doc-drift` | No live provider call; uses the existing index | Optional refinement of deterministic drift items |
+| `check-terminology` | Optional semantic near-miss search when a real embedder is configured | No |
+| `compile` | Same as `check-terminology`, because it runs the terminology audit first | No |
+| `compare-specs` | No | Optional qualitative comparison refinement |
+| `analyze-impact` | No | Optional severity enrichment |
+| `canonicalize` | No | Optional metadata inference |
+
+Two consequences follow from that table:
+
+- Changing `runtime.analysis.model` will not change `check-terminology` or `compile`.
+- Changing `runtime.embedder` does not retroactively affect an existing index until you rebuild it.
+
+When you are unsure why a result changed, confirm both the command/runtime matrix and the index freshness before assuming the wrong model is being consulted.
+
 For Nomic-compatible models, Pituitary automatically applies the required `search_document:` / `search_query:` prefixes.
 
 ## Retrieval Mode Matters
@@ -96,6 +117,33 @@ When you run `pituitary index --rebuild`:
 Use `--full` to skip reuse and force a complete re-embed.
 
 Query commands validate index freshness before executing. A stale index fails fast with a rebuild hint.
+
+## JSON Timings
+
+`check-compliance`, `check-doc-drift`, `check-terminology`, and `compile` accept `--timings` with `--format json`. The CLI envelope then includes a top-level `timings` block:
+
+```json
+{
+  "request": { "...": "..." },
+  "result": { "...": "..." },
+  "timings": {
+    "total_ms": 37,
+    "indexing_ms": 6,
+    "embedding_ms": 12,
+    "analysis_ms": 9,
+    "analysis_calls": 2,
+    "embedding_calls": 1
+  },
+  "warnings": [],
+  "errors": []
+}
+```
+
+Use this to answer operational questions such as:
+
+- did the command actually call an embedder or analysis model?
+- did a runtime change increase `analysis_calls` or `embedding_calls`?
+- is time going into freshness validation/index loading versus model work?
 
 ## Output Formats
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -20,6 +20,8 @@ When a changed path has no explicit governance, findings include a `limiting_fac
 
 The JSON result also carries `unspecified_summary`, which splits `unspecified` findings into `missing_governance_edge` versus `explicit_but_underexercised` so CI and operators do not treat those remediations as the same class of problem.
 
+Text output now also promotes the strongest per-finding guidance into a short `TOP SUGGESTIONS` block, and JSON mirrors that guidance in `result.top_suggestions`, so operators do not need to dig through every individual finding to see the best next action.
+
 ## Commands
 
 | Command | What it does |
@@ -28,6 +30,7 @@ The JSON result also carries `unspecified_summary`, which splits `unspecified` f
 | `discover --path .` | Scan a repo and propose conservative sources |
 | `migrate-config --path FILE --write` | Upgrade a legacy config to the current schema |
 | `preview-sources` | Show which files each configured source will index |
+| `preview-sources --verbose` | Add rejected candidates plus selector-match diagnostics |
 | `explain-file PATH` | Explain how one file is classified by configured sources |
 | `canonicalize --path PATH` | Promote one inferred contract into a spec bundle |
 | `index --rebuild [--full]` | Rebuild the SQLite index |
@@ -52,6 +55,8 @@ The JSON result also carries `unspecified_summary`, which splits `unspecified` f
 | `serve --config FILE` | Start MCP server over stdio |
 
 `fix` is intentionally narrow: it only applies deterministic `replace_claim` remediations that `check-doc-drift` can justify from accepted specs and exact document evidence. Use `--dry-run` first, then rerun with `--yes` when the replacements look correct. After any successful apply, run `pituitary index --rebuild`.
+
+When file selection or classification looks wrong, run `pituitary explain-file PATH` before anything else. It is the fastest way to confirm which source matched the file, which selectors fired, and whether the path was excluded on purpose.
 
 ## Diff-Driven Doc Drift
 
@@ -86,6 +91,8 @@ The result now separates:
 Use `[terminology].exclude_paths` when specific files or folders are historically frozen and should be skipped by terminology sweeps and `compile` without being removed from the wider index.
 
 Each matched term includes structured `classification`, `context`, `severity`, and `replacement` fields so CI or editor tooling can turn JSON output into warnings or errors without scraping prose.
+
+`check-compliance`, `check-doc-drift`, `check-terminology`, and `compile` also accept `--timings` with JSON output. The top-level CLI envelope then includes `total_ms`, `indexing_ms`, `embedding_ms`, `analysis_ms`, and call counts so local runs and CI can spot unexpected runtime regressions.
 
 ## Temporal Governance Queries
 

--- a/internal/analysis/compare.go
+++ b/internal/analysis/compare.go
@@ -87,6 +87,7 @@ func CompareSpecsContext(ctx context.Context, cfg *config.Config, request Compar
 	if err != nil {
 		return nil, err
 	}
+	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
 
 	var candidate *specDocument
 	orderedRefs := append([]string{}, refs...)

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -134,6 +134,7 @@ type ComplianceResult struct {
 	Conflicts          []ComplianceFinding           `json:"conflicts"`
 	Unspecified        []ComplianceFinding           `json:"unspecified"`
 	UnspecifiedSummary *ComplianceUnspecifiedSummary `json:"unspecified_summary,omitempty"`
+	TopSuggestions     []string                      `json:"top_suggestions,omitempty"`
 	Runtime            *CommandRuntime               `json:"runtime,omitempty"`
 	ContentTrust       *resultmeta.ContentTrust      `json:"content_trust,omitempty"`
 }
@@ -292,7 +293,9 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	if err != nil {
 		return nil, err
 	}
+	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
 	if adjudicator, ok := analyzer.(complianceAdjudicator); ok && len(adjudicationCandidates) > 0 {
+		adjudicator = complianceAdjudicatorWithTimings(ctx, adjudicator)
 		if result.Runtime != nil && result.Runtime.Analysis != nil {
 			result.Runtime.Analysis.Used = true
 		}
@@ -320,6 +323,7 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	sortComplianceFindings(result.Conflicts)
 	sortComplianceFindings(result.Unspecified)
 	result.UnspecifiedSummary = buildComplianceUnspecifiedSummary(result.Unspecified)
+	result.TopSuggestions = buildComplianceTopSuggestions(result)
 	return result, nil
 }
 
@@ -690,6 +694,7 @@ func embedComplianceFallbackTargetsContext(ctx context.Context, cfg *config.Conf
 	if err != nil {
 		return err
 	}
+	embedder = embedderWithTimings(ctx, embedder)
 
 	texts := make([]string, 0, len(indexes))
 	for _, idx := range indexes {
@@ -1248,6 +1253,40 @@ func buildComplianceUnspecifiedSummary(findings []ComplianceFinding) *Compliance
 		summary.MissingGovernanceEdge++
 	}
 	return summary
+}
+
+func buildComplianceTopSuggestions(result *ComplianceResult) []string {
+	if result == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	suggestions := make([]string, 0, 3)
+	appendSuggestions := func(findings []ComplianceFinding) {
+		for _, finding := range findings {
+			suggestion := strings.TrimSpace(finding.Suggestion)
+			if suggestion == "" {
+				continue
+			}
+			if _, ok := seen[suggestion]; ok {
+				continue
+			}
+			seen[suggestion] = struct{}{}
+			suggestions = append(suggestions, suggestion)
+			if len(suggestions) == 3 {
+				return
+			}
+		}
+	}
+
+	appendSuggestions(result.Conflicts)
+	if len(suggestions) < 3 {
+		appendSuggestions(result.Unspecified)
+	}
+	if len(suggestions) < 3 {
+		appendSuggestions(result.Compliant)
+	}
+	return suggestions
 }
 
 func complianceRequestsPerMinuteConflict(statement, content string) (string, string, bool) {

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -232,6 +232,7 @@ func CheckDocDriftContext(ctx context.Context, cfg *config.Config, request DocDr
 	if err != nil {
 		return nil, err
 	}
+	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
 	analysisRuntime := newAnalysisRuntimeUsage(cfg.Runtime.Analysis)
 
 	var (

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -174,6 +174,7 @@ func AnalyzeImpactContext(ctx context.Context, cfg *config.Config, request Analy
 	// This is non-fatal enrichment — errors are swallowed so the
 	// deterministic result is always returned.
 	analyzer, _ := newQualitativeAnalyzer(cfg.Runtime.Analysis)
+	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
 	if classifier, ok := analyzer.(impactSeverityClassifier); ok {
 		classifyImpactSeverities(ctx, classifier, candidate, result)
 		// Rebuild summary after severity is populated so severity-based

--- a/internal/analysis/infer_metadata.go
+++ b/internal/analysis/infer_metadata.go
@@ -173,6 +173,7 @@ func InferSpecMetadataWithSpecs(ctx context.Context, cfg *config.Config, title, 
 	if err != nil {
 		return nil, err
 	}
+	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
 	inferrer, ok := analyzer.(metadataInferrer)
 	if !ok {
 		return nil, nil

--- a/internal/analysis/review.go
+++ b/internal/analysis/review.go
@@ -53,6 +53,7 @@ func ReviewSpecContext(ctx context.Context, cfg *config.Config, request ReviewRe
 	if err != nil {
 		return nil, err
 	}
+	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
 
 	candidate, err := loadCandidate(repo, overlapRequest, nil)
 	if err != nil {

--- a/internal/analysis/semantic_terminology.go
+++ b/internal/analysis/semantic_terminology.go
@@ -47,6 +47,7 @@ func semanticTerminologyNearMisses(ctx context.Context, cfg *config.Config, repo
 	if err != nil {
 		return nil, fmt.Errorf("resolve embedder for semantic terminology: %w", err)
 	}
+	embedder = embedderWithTimings(ctx, embedder)
 
 	// Build embedding queries from governed terms: "term: <preferred> (replaces: <displaced>)"
 	// Sort keys for deterministic selection when truncating at the max limit.

--- a/internal/analysis/timings.go
+++ b/internal/analysis/timings.go
@@ -1,0 +1,141 @@
+package analysis
+
+import (
+	"context"
+	"time"
+
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/resultmeta"
+)
+
+func qualitativeAnalyzerWithTimings(ctx context.Context, analyzer qualitativeAnalyzer) qualitativeAnalyzer {
+	tracker := resultmeta.TimingTrackerFromContext(ctx)
+	if analyzer == nil || tracker == nil {
+		return analyzer
+	}
+	return timedQualitativeAnalyzer{inner: analyzer, tracker: tracker}
+}
+
+func complianceAdjudicatorWithTimings(ctx context.Context, adjudicator complianceAdjudicator) complianceAdjudicator {
+	tracker := resultmeta.TimingTrackerFromContext(ctx)
+	if adjudicator == nil || tracker == nil {
+		return adjudicator
+	}
+	return timedComplianceAdjudicator{inner: adjudicator, tracker: tracker}
+}
+
+func impactSeverityClassifierWithTimings(ctx context.Context, classifier impactSeverityClassifier) impactSeverityClassifier {
+	tracker := resultmeta.TimingTrackerFromContext(ctx)
+	if classifier == nil || tracker == nil {
+		return classifier
+	}
+	return timedImpactSeverityClassifier{inner: classifier, tracker: tracker}
+}
+
+func metadataInferrerWithTimings(ctx context.Context, inferrer metadataInferrer) metadataInferrer {
+	tracker := resultmeta.TimingTrackerFromContext(ctx)
+	if inferrer == nil || tracker == nil {
+		return inferrer
+	}
+	return timedMetadataInferrer{inner: inferrer, tracker: tracker}
+}
+
+func embedderWithTimings(ctx context.Context, embedder index.Embedder) index.Embedder {
+	tracker := resultmeta.TimingTrackerFromContext(ctx)
+	if embedder == nil || tracker == nil {
+		return embedder
+	}
+	return timedEmbedder{inner: embedder, tracker: tracker}
+}
+
+type timedQualitativeAnalyzer struct {
+	inner   qualitativeAnalyzer
+	tracker *resultmeta.TimingTracker
+}
+
+func (t timedQualitativeAnalyzer) Probe(ctx context.Context) error {
+	start := time.Now()
+	err := t.inner.Probe(ctx)
+	t.tracker.AddAnalysis(time.Since(start), 1)
+	return err
+}
+
+func (t timedQualitativeAnalyzer) Compare(ctx context.Context, orderedRefs []string, specs map[string]specDocument, base Comparison) (Comparison, error) {
+	start := time.Now()
+	result, err := t.inner.Compare(ctx, orderedRefs, specs, base)
+	t.tracker.AddAnalysis(time.Since(start), 1)
+	return result, err
+}
+
+func (t timedQualitativeAnalyzer) RefineDocDrift(ctx context.Context, doc docDocument, specs map[string]specDocument, item DriftItem, remediation *DocRemediationItem) (*DriftItem, *DocRemediationItem, error) {
+	start := time.Now()
+	refined, remediated, err := t.inner.RefineDocDrift(ctx, doc, specs, item, remediation)
+	t.tracker.AddAnalysis(time.Since(start), 1)
+	return refined, remediated, err
+}
+
+type timedComplianceAdjudicator struct {
+	inner   complianceAdjudicator
+	tracker *resultmeta.TimingTracker
+}
+
+func (t timedComplianceAdjudicator) AdjudicateCompliance(ctx context.Context, request complianceAdjudicationRequest) (*complianceAdjudicationResponse, error) {
+	start := time.Now()
+	result, err := t.inner.AdjudicateCompliance(ctx, request)
+	t.tracker.AddAnalysis(time.Since(start), 1)
+	return result, err
+}
+
+type timedImpactSeverityClassifier struct {
+	inner   impactSeverityClassifier
+	tracker *resultmeta.TimingTracker
+}
+
+func (t timedImpactSeverityClassifier) ClassifyImpactSeverity(ctx context.Context, request impactSeverityRequest) (*impactSeverityResponse, error) {
+	start := time.Now()
+	result, err := t.inner.ClassifyImpactSeverity(ctx, request)
+	t.tracker.AddAnalysis(time.Since(start), 1)
+	return result, err
+}
+
+type timedMetadataInferrer struct {
+	inner   metadataInferrer
+	tracker *resultmeta.TimingTracker
+}
+
+func (t timedMetadataInferrer) InferMetadata(ctx context.Context, request metadataInferenceRequest) (*MetadataInferenceResult, error) {
+	start := time.Now()
+	result, err := t.inner.InferMetadata(ctx, request)
+	t.tracker.AddAnalysis(time.Since(start), 1)
+	return result, err
+}
+
+type timedEmbedder struct {
+	inner   index.Embedder
+	tracker *resultmeta.TimingTracker
+}
+
+func (t timedEmbedder) Fingerprint() string {
+	return t.inner.Fingerprint()
+}
+
+func (t timedEmbedder) Dimension(ctx context.Context) (int, error) {
+	start := time.Now()
+	dimension, err := t.inner.Dimension(ctx)
+	t.tracker.AddEmbedding(time.Since(start), 1)
+	return dimension, err
+}
+
+func (t timedEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float64, error) {
+	start := time.Now()
+	vectors, err := t.inner.EmbedDocuments(ctx, texts)
+	t.tracker.AddEmbedding(time.Since(start), 1)
+	return vectors, err
+}
+
+func (t timedEmbedder) EmbedQueries(ctx context.Context, texts []string) ([][]float64, error) {
+	start := time.Now()
+	vectors, err := t.inner.EmbedQueries(ctx, texts)
+	t.tracker.AddEmbedding(time.Since(start), 1)
+	return vectors, err
+}

--- a/internal/app/operations.go
+++ b/internal/app/operations.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dusk-network/pituitary/internal/analysis"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/resultmeta"
 )
 
 const (
@@ -222,7 +224,11 @@ func loadConfig(configPath string) (*config.Config, *Issue) {
 }
 
 func ensureFreshIndex(ctx context.Context, cfg *config.Config) *Issue {
+	started := time.Now()
 	err := index.ValidateFreshnessContext(ctx, cfg)
+	if tracker := resultmeta.TimingTrackerFromContext(ctx); tracker != nil {
+		tracker.AddIndexing(time.Since(started))
+	}
 	switch {
 	case err == nil:
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -485,9 +485,17 @@ func validate(cfg *Config) error {
 		info, err := os.Stat(cfg.Workspace.RootPath)
 		switch {
 		case err == nil && !info.IsDir():
-			errs.add("workspace.root: %q is not a directory", cfg.Workspace.Root)
+			errs.add(
+				"workspace.root: %q is not a directory (%s)",
+				cfg.Workspace.Root,
+				pathResolutionDetail("workspace.root", cfg.Workspace.Root, cfg.ConfigDir, cfg.Workspace.RootPath),
+			)
 		case err != nil:
-			errs.add("workspace.root: %q does not exist", cfg.Workspace.Root)
+			errs.add(
+				"workspace.root: %q does not exist (%s)",
+				cfg.Workspace.Root,
+				pathResolutionDetail("workspace.root", cfg.Workspace.Root, cfg.ConfigDir, cfg.Workspace.RootPath),
+			)
 		}
 	}
 
@@ -521,9 +529,19 @@ func validate(cfg *Config) error {
 		info, err := os.Stat(repo.RootPath)
 		switch {
 		case err == nil && !info.IsDir():
-			errs.add("%s.root: %q is not a directory", label, repo.Root)
+			errs.add(
+				"%s.root: %q is not a directory (%s)",
+				label,
+				repo.Root,
+				pathResolutionDetail(label+".root", repo.Root, cfg.ConfigDir, repo.RootPath),
+			)
 		case err != nil:
-			errs.add("%s.root: %q does not exist", label, repo.Root)
+			errs.add(
+				"%s.root: %q does not exist (%s)",
+				label,
+				repo.Root,
+				pathResolutionDetail(label+".root", repo.Root, cfg.ConfigDir, repo.RootPath),
+			)
 		}
 	}
 
@@ -659,18 +677,40 @@ func validate(cfg *Config) error {
 			info, err := os.Stat(source.ResolvedPath)
 			switch {
 			case err == nil && !info.IsDir():
-				errs.add("%s.path: %q is not a directory", label, source.Path)
+				errs.add(
+					"%s.path: %q is not a directory (%s)",
+					label,
+					source.Path,
+					sourcePathResolutionDetail(cfg, source, repoRootPath),
+				)
 			case err != nil:
-				errs.add("%s.path: %q does not exist", label, source.Path)
+				errs.add(
+					"%s.path: %q does not exist (%s)",
+					label,
+					source.Path,
+					sourcePathResolutionDetail(cfg, source, repoRootPath),
+				)
 			}
 			for i, relFile := range source.Files {
 				resolvedFile := resolvePath(source.ResolvedPath, filepath.FromSlash(relFile))
 				info, err := os.Stat(resolvedFile)
 				switch {
 				case err == nil && info.IsDir():
-					errs.add("%s.files[%d]: %q is a directory", label, i, relFile)
+					errs.add(
+						"%s.files[%d]: %q is a directory (%s)",
+						label,
+						i,
+						relFile,
+						pathResolutionDetail(label+".files", relFile, source.ResolvedPath, resolvedFile),
+					)
 				case err != nil:
-					errs.add("%s.files[%d]: %q does not exist", label, i, relFile)
+					errs.add(
+						"%s.files[%d]: %q does not exist (%s)",
+						label,
+						i,
+						relFile,
+						pathResolutionDetail(label+".files", relFile, source.ResolvedPath, resolvedFile),
+					)
 				}
 			}
 		}
@@ -1121,6 +1161,48 @@ func resolvePath(base, value string) string {
 		return filepath.Clean(value)
 	}
 	return filepath.Clean(filepath.Join(base, value))
+}
+
+func pathResolutionDetail(label, raw, base, resolved string) string {
+	return fmt.Sprintf(
+		"%s %q resolves relative to %q as %q",
+		label,
+		raw,
+		filepath.ToSlash(filepath.Clean(base)),
+		filepath.ToSlash(filepath.Clean(resolved)),
+	)
+}
+
+func sourcePathResolutionDetail(cfg *Config, source *Source, repoRootPath string) string {
+	if source == nil {
+		return ""
+	}
+	scope := "workspace.root"
+	rootRaw := cfg.Workspace.Root
+	if source.Repo != "" {
+		scope = "workspace.repos[" + source.Repo + "].root"
+		if root, ok := lookupWorkspaceRepoRootRaw(cfg.Workspace, source.Repo); ok {
+			rootRaw = root
+		}
+	}
+	return fmt.Sprintf(
+		"%s %q resolves relative to config base %q as %q, so source path %q resolves to %q",
+		scope,
+		rootRaw,
+		filepath.ToSlash(filepath.Clean(cfg.ConfigDir)),
+		filepath.ToSlash(filepath.Clean(repoRootPath)),
+		source.Path,
+		filepath.ToSlash(filepath.Clean(source.ResolvedPath)),
+	)
+}
+
+func lookupWorkspaceRepoRootRaw(workspace Workspace, repoID string) (string, bool) {
+	for _, repo := range workspace.Repos {
+		if repo.ID == repoID {
+			return repo.Root, true
+		}
+	}
+	return "", false
 }
 
 func stripComment(line string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -182,6 +182,69 @@ path = "docs"
 	}
 }
 
+func TestLoadUnknownTerminologyPolicyFieldSuggestsNearestValidFields(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[terminology.policies]]
+exclude_paths = ["CHANGELOG.md"]
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want unsupported terminology policy field failure")
+	}
+	if !strings.Contains(err.Error(), `unsupported terminology.policies field "exclude_paths"; did you mean one of:`) ||
+		!strings.Contains(err.Error(), `"preferred"`) {
+		t.Fatalf("Load() error = %q, want nearest-field suggestion", err)
+	}
+}
+
+func TestLoadSourcePathErrorExplainsWorkspaceRootResolution(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustMkdirAll(t, filepath.Join(root, "project", "docs"))
+	configDir := filepath.Join(root, "tmp")
+	mustMkdirAll(t, configDir)
+	configPath := filepath.Join(configDir, "pit-fake.toml")
+	writeFile(t, configPath, `
+[workspace]
+root = ".."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want source path resolution failure")
+	}
+	if !strings.Contains(err.Error(), `workspace.root ".." resolves relative to config base`) {
+		t.Fatalf("Load() error = %q, want workspace.root resolution detail", err)
+	}
+	if !strings.Contains(err.Error(), `so source path "docs" resolves to`) {
+		t.Fatalf("Load() error = %q, want derived source path detail", err)
+	}
+}
+
 func TestLoadDefaultsBootstrapRuntimeContract(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/parse_toml.go
+++ b/internal/config/parse_toml.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -62,24 +63,190 @@ func undecodedKeyMessage(key toml.Key) string {
 
 	switch key[0] {
 	case "workspace":
-		return fmt.Sprintf("unsupported workspace field %q", strings.Join(key[1:], "."))
+		switch {
+		case len(key) == 2:
+			return unsupportedFieldMessage("workspace", key[1], []string{
+				"root",
+				"repo_id",
+				"index_path",
+				"infer_applies_to",
+				"repos",
+			})
+		case key[1] == "repos" && len(key) == 3:
+			return unsupportedFieldMessage("workspace.repos", key[2], []string{"id", "root"})
+		default:
+			return fmt.Sprintf("unsupported workspace field %q", strings.Join(key[1:], "."))
+		}
 	case "runtime":
 		switch len(key) {
 		case 2:
-			return fmt.Sprintf("unsupported runtime field %q", key[1])
+			return unsupportedFieldMessage("runtime", key[1], []string{"profiles", "embedder", "analysis"})
 		default:
-			return fmt.Sprintf("unsupported runtime.%s field %q", key[1], strings.Join(key[2:], "."))
+			switch key[1] {
+			case "embedder", "analysis":
+				return unsupportedFieldMessage(
+					"runtime."+key[1],
+					strings.Join(key[2:], "."),
+					runtimeProviderFields(),
+				)
+			case "profiles":
+				if len(key) >= 4 {
+					return unsupportedFieldMessage(
+						"runtime.profiles."+key[2],
+						strings.Join(key[3:], "."),
+						runtimeProviderFields(),
+					)
+				}
+				return fmt.Sprintf("unsupported runtime.profiles field %q", strings.Join(key[2:], "."))
+			default:
+				return fmt.Sprintf("unsupported runtime.%s field %q", key[1], strings.Join(key[2:], "."))
+			}
 		}
 	case "terminology":
 		switch len(key) {
 		case 2:
-			return fmt.Sprintf("unsupported terminology field %q", key[1])
+			return unsupportedFieldMessage("terminology", key[1], []string{"exclude_paths", "policies"})
 		default:
+			if key[1] == "policies" && len(key) == 3 {
+				return unsupportedFieldMessage("terminology.policies", key[2], []string{
+					"preferred",
+					"historical_aliases",
+					"deprecated_terms",
+					"forbidden_current",
+					"docs_severity",
+					"specs_severity",
+				})
+			}
 			return fmt.Sprintf("unsupported terminology.%s field %q", key[1], strings.Join(key[2:], "."))
 		}
 	case "sources":
-		return fmt.Sprintf("unsupported sources field %q", strings.Join(key[1:], "."))
+		return unsupportedFieldMessage("sources", strings.Join(key[1:], "."), []string{
+			"name",
+			"adapter",
+			"kind",
+			"role",
+			"repo",
+			"path",
+			"files",
+			"include",
+			"exclude",
+			"options",
+		})
 	default:
 		return fmt.Sprintf("unsupported section %q", key[0])
 	}
+}
+
+func runtimeProviderFields() []string {
+	return []string{
+		"profile",
+		"provider",
+		"model",
+		"endpoint",
+		"api_key_env",
+		"timeout_ms",
+		"max_retries",
+		"max_response_tokens",
+	}
+}
+
+func unsupportedFieldMessage(scope, field string, valid []string) string {
+	message := fmt.Sprintf("unsupported %s field %q", scope, field)
+	if strings.Contains(field, ".") || len(valid) == 0 {
+		return message
+	}
+	suggestions := rankedFieldSuggestions(field, valid)
+	if len(suggestions) == 0 {
+		return message
+	}
+	return fmt.Sprintf("%s; did you mean one of: %s", message, quotedList(suggestions))
+}
+
+func rankedFieldSuggestions(field string, valid []string) []string {
+	if len(valid) == 0 {
+		return nil
+	}
+	type suggestion struct {
+		field    string
+		distance int
+	}
+	ranked := make([]suggestion, 0, len(valid))
+	for _, candidate := range valid {
+		ranked = append(ranked, suggestion{
+			field:    candidate,
+			distance: levenshteinDistance(strings.ToLower(field), strings.ToLower(candidate)),
+		})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].distance != ranked[j].distance {
+			return ranked[i].distance < ranked[j].distance
+		}
+		if len(ranked[i].field) != len(ranked[j].field) {
+			return len(ranked[i].field) < len(ranked[j].field)
+		}
+		return ranked[i].field < ranked[j].field
+	})
+
+	limit := len(ranked)
+	if limit > 6 {
+		limit = 6
+	}
+	result := make([]string, 0, limit)
+	for _, item := range ranked[:limit] {
+		result = append(result, item.field)
+	}
+	return result
+}
+
+func quotedList(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, strconv.Quote(value))
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func levenshteinDistance(left, right string) int {
+	if left == right {
+		return 0
+	}
+	if left == "" {
+		return len([]rune(right))
+	}
+	if right == "" {
+		return len([]rune(left))
+	}
+
+	leftRunes := []rune(left)
+	rightRunes := []rune(right)
+	prev := make([]int, len(rightRunes)+1)
+	curr := make([]int, len(rightRunes)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i, leftRune := range leftRunes {
+		curr[0] = i + 1
+		for j, rightRune := range rightRunes {
+			cost := 0
+			if leftRune != rightRune {
+				cost = 1
+			}
+			insertion := curr[j] + 1
+			deletion := prev[j+1] + 1
+			substitution := prev[j] + cost
+			curr[j+1] = minInt(insertion, deletion, substitution)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rightRunes)]
+}
+
+func minInt(values ...int) int {
+	best := values[0]
+	for _, value := range values[1:] {
+		if value < best {
+			best = value
+		}
+	}
+	return best
 }

--- a/internal/index/freshness.go
+++ b/internal/index/freshness.go
@@ -38,6 +38,32 @@ type FreshnessStatus struct {
 	Issues    []FreshnessIssue `json:"issues,omitempty"`
 }
 
+type sourceManifest struct {
+	WorkspaceRepoID string                 `json:"workspace_repo_id,omitempty"`
+	Repos           []sourceManifestRepo   `json:"repos,omitempty"`
+	Sources         []sourceManifestSource `json:"sources,omitempty"`
+}
+
+type sourceManifestRepo struct {
+	ID           string `json:"id"`
+	Root         string `json:"root"`
+	ResolvedRoot string `json:"resolved_root,omitempty"`
+}
+
+type sourceManifestSource struct {
+	Name         string   `json:"name"`
+	Adapter      string   `json:"adapter"`
+	Kind         string   `json:"kind"`
+	Repo         string   `json:"repo,omitempty"`
+	ResolvedRepo string   `json:"resolved_repo,omitempty"`
+	RepoRoot     string   `json:"repo_root,omitempty"`
+	Path         string   `json:"path"`
+	ResolvedPath string   `json:"resolved_path,omitempty"`
+	Files        []string `json:"files,omitempty"`
+	Include      []string `json:"include,omitempty"`
+	Exclude      []string `json:"exclude,omitempty"`
+}
+
 // StaleIndexError reports that the configured index is present but not safe to reuse.
 type StaleIndexError struct {
 	Status *FreshnessStatus
@@ -112,6 +138,7 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 		"schema_version",
 		"embedder_fingerprint",
 		"source_fingerprint",
+		"source_manifest",
 		"content_fingerprint",
 	)
 	if err != nil {
@@ -157,9 +184,13 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 			Message: "index metadata is missing source_fingerprint",
 		})
 	case stored != currentSourceFingerprint:
+		message := fmt.Sprintf("index source fingerprint %q does not match current configured source fingerprint %q", stored, currentSourceFingerprint)
+		if diagnostic := sourceMismatchDiagnostic(strings.TrimSpace(metadata["source_manifest"]), cfg); diagnostic != "" {
+			message += "; " + diagnostic
+		}
 		issues = append(issues, FreshnessIssue{
 			Kind:    "source_fingerprint_mismatch",
-			Message: fmt.Sprintf("index source fingerprint %q does not match current configured source fingerprint %q", stored, currentSourceFingerprint),
+			Message: message,
 			Indexed: stored,
 			Current: currentSourceFingerprint,
 		})
@@ -309,6 +340,120 @@ func sourceFingerprint(cfg *config.Config) string {
 	}
 	sort.Strings(parts)
 	return fingerprint(parts)
+}
+
+func sourceManifestJSON(cfg *config.Config) string {
+	manifest := sourceManifestForConfig(cfg)
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func sourceManifestForConfig(cfg *config.Config) sourceManifest {
+	manifest := sourceManifest{
+		WorkspaceRepoID: config.PrimaryRepoID(cfg),
+		Repos:           make([]sourceManifestRepo, 0, len(cfg.Workspace.Repos)),
+		Sources:         make([]sourceManifestSource, 0, len(cfg.Sources)),
+	}
+	for _, repo := range cfg.Workspace.Repos {
+		manifest.Repos = append(manifest.Repos, sourceManifestRepo{
+			ID:           strings.TrimSpace(repo.ID),
+			Root:         filepath.ToSlash(strings.TrimSpace(repo.Root)),
+			ResolvedRoot: filepath.ToSlash(strings.TrimSpace(repo.RootPath)),
+		})
+	}
+	sort.Slice(manifest.Repos, func(i, j int) bool {
+		return manifest.Repos[i].ID < manifest.Repos[j].ID
+	})
+	for _, src := range cfg.Sources {
+		files := append([]string(nil), src.Files...)
+		include := append([]string(nil), src.Include...)
+		exclude := append([]string(nil), src.Exclude...)
+		sort.Strings(files)
+		sort.Strings(include)
+		sort.Strings(exclude)
+		manifest.Sources = append(manifest.Sources, sourceManifestSource{
+			Name:         src.Name,
+			Adapter:      src.Adapter,
+			Kind:         src.Kind,
+			Repo:         src.Repo,
+			ResolvedRepo: src.ResolvedRepo,
+			RepoRoot:     filepath.ToSlash(src.RepoRootPath),
+			Path:         filepath.ToSlash(src.Path),
+			ResolvedPath: filepath.ToSlash(src.ResolvedPath),
+			Files:        files,
+			Include:      include,
+			Exclude:      exclude,
+		})
+	}
+	sort.Slice(manifest.Sources, func(i, j int) bool {
+		return manifest.Sources[i].Name < manifest.Sources[j].Name
+	})
+	return manifest
+}
+
+func sourceMismatchDiagnostic(storedJSON string, cfg *config.Config) string {
+	if strings.TrimSpace(storedJSON) == "" || cfg == nil {
+		return ""
+	}
+
+	var stored sourceManifest
+	if err := json.Unmarshal([]byte(storedJSON), &stored); err != nil {
+		return ""
+	}
+	current := sourceManifestForConfig(cfg)
+
+	if len(stored.Sources) != len(current.Sources) {
+		return fmt.Sprintf("source list differs: expected %d source(s), got %d", len(stored.Sources), len(current.Sources))
+	}
+	if len(stored.Repos) != len(current.Repos) {
+		return fmt.Sprintf("workspace repo list differs: expected %d repo root(s), got %d", len(stored.Repos), len(current.Repos))
+	}
+
+	storedByName := make(map[string]sourceManifestSource, len(stored.Sources))
+	for _, src := range stored.Sources {
+		storedByName[src.Name] = src
+	}
+	for _, src := range current.Sources {
+		previous, ok := storedByName[src.Name]
+		if !ok {
+			return fmt.Sprintf("source names differ: indexed sources [%s], current sources [%s]", manifestSourceNames(stored.Sources), manifestSourceNames(current.Sources))
+		}
+		if previous.Adapter != src.Adapter {
+			return fmt.Sprintf("source %q adapter changed: indexed %q, current %q", src.Name, previous.Adapter, src.Adapter)
+		}
+		if previous.Kind != src.Kind {
+			return fmt.Sprintf("source %q kind changed: indexed %q, current %q", src.Name, previous.Kind, src.Kind)
+		}
+		if previous.Path != src.Path {
+			return fmt.Sprintf("source %q path changed: indexed %q, current %q", src.Name, previous.Path, src.Path)
+		}
+		if previous.RepoRoot != src.RepoRoot {
+			return fmt.Sprintf("source %q root changed: indexed %q, current %q", src.Name, previous.RepoRoot, src.RepoRoot)
+		}
+		if strings.Join(previous.Files, ",") != strings.Join(src.Files, ",") {
+			return fmt.Sprintf("source %q files selector changed: indexed [%s], current [%s]", src.Name, strings.Join(previous.Files, ", "), strings.Join(src.Files, ", "))
+		}
+		if strings.Join(previous.Include, ",") != strings.Join(src.Include, ",") {
+			return fmt.Sprintf("source %q include selector changed: indexed [%s], current [%s]", src.Name, strings.Join(previous.Include, ", "), strings.Join(src.Include, ", "))
+		}
+		if strings.Join(previous.Exclude, ",") != strings.Join(src.Exclude, ",") {
+			return fmt.Sprintf("source %q exclude selector changed: indexed [%s], current [%s]", src.Name, strings.Join(previous.Exclude, ", "), strings.Join(src.Exclude, ", "))
+		}
+	}
+
+	return ""
+}
+
+func manifestSourceNames(sources []sourceManifestSource) string {
+	names := make([]string, 0, len(sources))
+	for _, src := range sources {
+		names = append(names, src.Name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }
 
 func readMetadataContext(ctx context.Context, db *sql.DB, keys ...string) (map[string]string, error) {

--- a/internal/index/freshness_test.go
+++ b/internal/index/freshness_test.go
@@ -101,6 +101,32 @@ func TestInspectFreshnessReportsStaleWhenSourceConfigChanges(t *testing.T) {
 	}
 }
 
+func TestInspectFreshnessSourceMismatchExplainsSourceCountDifference(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFreshnessFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	cfg.Sources = cfg.Sources[:1]
+
+	status, err := InspectFreshnessContext(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("InspectFreshnessContext() error = %v", err)
+	}
+	if len(status.Issues) == 0 || status.Issues[0].Kind != "source_fingerprint_mismatch" {
+		t.Fatalf("freshness.issues = %+v, want source_fingerprint_mismatch", status.Issues)
+	}
+	if !strings.Contains(status.Issues[0].Message, "source list differs: expected 2 source(s), got 1") {
+		t.Fatalf("freshness issue = %+v, want source count diagnostic", status.Issues[0])
+	}
+}
+
 func TestInspectFreshnessIgnoresSourceOrderingChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -411,6 +411,11 @@ func buildStagingContext(ctx context.Context, db *sql.DB, cfg *config.Config, di
 	if err := insertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {
 		return nil, err
 	}
+	if manifest := sourceManifestJSON(cfg); manifest != "" {
+		if err := insertMetadataContext(ctx, tx, "source_manifest", manifest); err != nil {
+			return nil, err
+		}
+	}
 
 	chunkStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunks (artifact_ref, section, content) VALUES (?, ?, ?)`)
 	if err != nil {

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -55,9 +55,16 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 	assertCount(t, db, `SELECT COUNT(*) FROM chunks`, 17)
 	assertCount(t, db, `SELECT COUNT(*) FROM edges`, 9)
 	assertCount(t, db, `SELECT COUNT(*) FROM chunks_vec`, 17)
-	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 5)
+	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 6)
 	assertMetadataValue(t, db, "embedder_fingerprint", "fixture|fixture-8d|plain_v1")
 	assertMetadataValue(t, db, "source_fingerprint", sourceFingerprint(cfg))
+	var sourceManifest string
+	if err := db.QueryRow(`SELECT value FROM metadata WHERE key = 'source_manifest'`).Scan(&sourceManifest); err != nil {
+		t.Fatalf("query source_manifest: %v", err)
+	}
+	if strings.TrimSpace(sourceManifest) == "" {
+		t.Fatal("metadata.source_manifest = empty, want manifest detail")
+	}
 	assertSections(t, db, "SPEC-042", []string{
 		"Overview",
 		"Requirements",

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -344,6 +344,11 @@ func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Confi
 	if err := upsertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {
 		return nil, err
 	}
+	if manifest := sourceManifestJSON(cfg); manifest != "" {
+		if err := upsertMetadataContext(ctx, tx, "source_manifest", manifest); err != nil {
+			return nil, err
+		}
+	}
 	result.ContentFingerprint = contentFingerprint(records)
 	if err := upsertMetadataContext(ctx, tx, "content_fingerprint", result.ContentFingerprint); err != nil {
 		return nil, err

--- a/internal/resultmeta/timings.go
+++ b/internal/resultmeta/timings.go
@@ -1,0 +1,107 @@
+package resultmeta
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Timings reports optional command timing metadata for JSON CLI output.
+type Timings struct {
+	TotalMS        int64 `json:"total_ms"`
+	IndexingMS     int64 `json:"indexing_ms,omitempty"`
+	EmbeddingMS    int64 `json:"embedding_ms,omitempty"`
+	AnalysisMS     int64 `json:"analysis_ms,omitempty"`
+	AnalysisCalls  int   `json:"analysis_calls,omitempty"`
+	EmbeddingCalls int   `json:"embedding_calls,omitempty"`
+}
+
+// TimingTracker accumulates coarse command timing categories.
+type TimingTracker struct {
+	mu sync.Mutex
+
+	indexing       time.Duration
+	embedding      time.Duration
+	analysis       time.Duration
+	analysisCalls  int
+	embeddingCalls int
+}
+
+type timingTrackerKey struct{}
+
+func NewTimingTracker() *TimingTracker {
+	return &TimingTracker{}
+}
+
+func WithTimingTracker(ctx context.Context, tracker *TimingTracker) context.Context {
+	if tracker == nil {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, timingTrackerKey{}, tracker)
+}
+
+func TimingTrackerFromContext(ctx context.Context) *TimingTracker {
+	if ctx == nil {
+		return nil
+	}
+	tracker, _ := ctx.Value(timingTrackerKey{}).(*TimingTracker)
+	return tracker
+}
+
+func (t *TimingTracker) AddIndexing(duration time.Duration) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.indexing += duration
+}
+
+func (t *TimingTracker) AddEmbedding(duration time.Duration, calls int) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.embedding += duration
+	t.embeddingCalls += calls
+}
+
+func (t *TimingTracker) AddAnalysis(duration time.Duration, calls int) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.analysis += duration
+	t.analysisCalls += calls
+}
+
+func (t *TimingTracker) Snapshot(total time.Duration) *Timings {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return &Timings{
+		TotalMS:        durationMillis(total),
+		IndexingMS:     durationMillis(t.indexing),
+		EmbeddingMS:    durationMillis(t.embedding),
+		AnalysisMS:     durationMillis(t.analysis),
+		AnalysisCalls:  t.analysisCalls,
+		EmbeddingCalls: t.embeddingCalls,
+	}
+}
+
+func durationMillis(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+	if duration < time.Millisecond {
+		return 1
+	}
+	return duration.Milliseconds()
+}

--- a/internal/source/preview.go
+++ b/internal/source/preview.go
@@ -18,18 +18,18 @@ type PreviewResult struct {
 
 // SourcePreview describes one configured source and the paths it contributes.
 type SourcePreview struct {
-	Name          string                `json:"name"`
-	Adapter       string                `json:"adapter"`
-	Kind          string                `json:"kind"`
-	Path          string                `json:"path"`
-	ResolvedPath  string                `json:"resolved_path,omitempty"`
-	Files         []string              `json:"files,omitempty"`
-	Include       []string              `json:"include,omitempty"`
-	Exclude       []string              `json:"exclude,omitempty"`
-	CandidateCount int                  `json:"candidate_count,omitempty"`
-	ItemCount     int                   `json:"item_count"`
-	Items         []PreviewItem         `json:"items"`
-	RejectedItems []PreviewRejectedItem `json:"rejected_items,omitempty"`
+	Name           string                `json:"name"`
+	Adapter        string                `json:"adapter"`
+	Kind           string                `json:"kind"`
+	Path           string                `json:"path"`
+	ResolvedPath   string                `json:"resolved_path,omitempty"`
+	Files          []string              `json:"files,omitempty"`
+	Include        []string              `json:"include,omitempty"`
+	Exclude        []string              `json:"exclude,omitempty"`
+	CandidateCount int                   `json:"candidate_count,omitempty"`
+	ItemCount      int                   `json:"item_count"`
+	Items          []PreviewItem         `json:"items"`
+	RejectedItems  []PreviewRejectedItem `json:"rejected_items,omitempty"`
 }
 
 // PreviewItem describes one workspace-relative path that would be indexed.

--- a/internal/source/preview.go
+++ b/internal/source/preview.go
@@ -3,6 +3,7 @@ package source
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/dusk-network/pituitary/internal/config"
@@ -17,26 +18,41 @@ type PreviewResult struct {
 
 // SourcePreview describes one configured source and the paths it contributes.
 type SourcePreview struct {
-	Name      string        `json:"name"`
-	Adapter   string        `json:"adapter"`
-	Kind      string        `json:"kind"`
-	Path      string        `json:"path"`
-	Files     []string      `json:"files,omitempty"`
-	Include   []string      `json:"include,omitempty"`
-	Exclude   []string      `json:"exclude,omitempty"`
-	ItemCount int           `json:"item_count"`
-	Items     []PreviewItem `json:"items"`
+	Name          string                `json:"name"`
+	Adapter       string                `json:"adapter"`
+	Kind          string                `json:"kind"`
+	Path          string                `json:"path"`
+	ResolvedPath  string                `json:"resolved_path,omitempty"`
+	Files         []string              `json:"files,omitempty"`
+	Include       []string              `json:"include,omitempty"`
+	Exclude       []string              `json:"exclude,omitempty"`
+	CandidateCount int                  `json:"candidate_count,omitempty"`
+	ItemCount     int                   `json:"item_count"`
+	Items         []PreviewItem         `json:"items"`
+	RejectedItems []PreviewRejectedItem `json:"rejected_items,omitempty"`
 }
 
 // PreviewItem describes one workspace-relative path that would be indexed.
 type PreviewItem struct {
-	ArtifactKind string `json:"artifact_kind"`
-	Path         string `json:"path"`
+	ArtifactKind   string   `json:"artifact_kind"`
+	Path           string   `json:"path"`
+	FilesMatched   []string `json:"files_matched,omitempty"`
+	IncludeMatches []string `json:"include_matches,omitempty"`
+}
+
+// PreviewRejectedItem describes one candidate path that was skipped by source selectors.
+type PreviewRejectedItem struct {
+	Path           string   `json:"path"`
+	Reason         string   `json:"reason"`
+	FilesMatched   []string `json:"files_matched,omitempty"`
+	IncludeMatches []string `json:"include_matches,omitempty"`
+	ExcludeMatches []string `json:"exclude_matches,omitempty"`
 }
 
 // PreviewOptions controls diagnostic behavior during source previews.
 type PreviewOptions struct {
-	Logger *diag.Logger
+	Logger  *diag.Logger
+	Verbose bool
 }
 
 // PreviewFromConfig enumerates source items without rebuilding the index.
@@ -52,7 +68,7 @@ func PreviewFromConfigWithOptions(cfg *config.Config, options PreviewOptions) (*
 	}
 
 	for _, source := range cfg.Sources {
-		preview, err := previewSource(cfg.Workspace.RootPath, source)
+		preview, err := previewSource(cfg.Workspace.RootPath, source, options.Verbose)
 		if err != nil {
 			return nil, err
 		}
@@ -67,15 +83,16 @@ func PreviewFromConfigWithOptions(cfg *config.Config, options PreviewOptions) (*
 	return result, nil
 }
 
-func previewSource(workspaceRoot string, source config.Source) (SourcePreview, error) {
+func previewSource(workspaceRoot string, source config.Source, verbose bool) (SourcePreview, error) {
 	preview := SourcePreview{
-		Name:    source.Name,
-		Adapter: source.Adapter,
-		Kind:    source.Kind,
-		Path:    source.Path,
-		Files:   append([]string(nil), source.Files...),
-		Include: append([]string(nil), source.Include...),
-		Exclude: append([]string(nil), source.Exclude...),
+		Name:         source.Name,
+		Adapter:      source.Adapter,
+		Kind:         source.Kind,
+		Path:         source.Path,
+		ResolvedPath: filepath.ToSlash(source.ResolvedPath),
+		Files:        append([]string(nil), source.Files...),
+		Include:      append([]string(nil), source.Include...),
+		Exclude:      append([]string(nil), source.Exclude...),
 	}
 
 	if source.Adapter != config.AdapterFilesystem {
@@ -96,33 +113,94 @@ func previewSource(workspaceRoot string, source config.Source) (SourcePreview, e
 			})
 		}
 	case config.SourceKindMarkdownDocs:
-		matches, err := enumerateSelectedMarkdownPaths(workspaceRoot, source, "doc")
+		matches, candidateCount, rejected, err := previewMarkdownPaths(workspaceRoot, source, "doc", verbose)
 		if err != nil {
 			return SourcePreview{}, err
 		}
+		preview.CandidateCount = candidateCount
 		for _, match := range matches {
 			preview.Items = append(preview.Items, PreviewItem{
-				ArtifactKind: "doc",
-				Path:         workspaceRelative(workspaceRoot, match.AbsolutePath),
+				ArtifactKind:   "doc",
+				Path:           workspaceRelative(workspaceRoot, match.AbsolutePath),
+				FilesMatched:   append([]string(nil), match.Selection.FilesMatched...),
+				IncludeMatches: append([]string(nil), match.Selection.IncludeMatches...),
 			})
 		}
+		preview.RejectedItems = rejected
 	case config.SourceKindMarkdownContract:
-		matches, err := enumerateSelectedMarkdownPaths(workspaceRoot, source, "contract")
+		matches, candidateCount, rejected, err := previewMarkdownPaths(workspaceRoot, source, "contract", verbose)
 		if err != nil {
 			return SourcePreview{}, err
 		}
+		preview.CandidateCount = candidateCount
 		for _, match := range matches {
 			preview.Items = append(preview.Items, PreviewItem{
-				ArtifactKind: "spec",
-				Path:         workspaceRelative(workspaceRoot, match.AbsolutePath),
+				ArtifactKind:   "spec",
+				Path:           workspaceRelative(workspaceRoot, match.AbsolutePath),
+				FilesMatched:   append([]string(nil), match.Selection.FilesMatched...),
+				IncludeMatches: append([]string(nil), match.Selection.IncludeMatches...),
 			})
 		}
+		preview.RejectedItems = rejected
 	default:
 		return SourcePreview{}, fmt.Errorf("source %q: unsupported kind %q", source.Name, source.Kind)
 	}
 
 	preview.ItemCount = len(preview.Items)
 	return preview, nil
+}
+
+type previewMarkdownPath struct {
+	selectedMarkdownPath
+	Selection sourcePathSelection
+}
+
+func previewMarkdownPaths(workspaceRoot string, source config.Source, label string, verbose bool) ([]previewMarkdownPath, int, []PreviewRejectedItem, error) {
+	matches := make([]previewMarkdownPath, 0)
+	rejected := make([]PreviewRejectedItem, 0)
+	candidateCount := 0
+	err := filepath.WalkDir(source.ResolvedPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".md" {
+			return nil
+		}
+		candidateCount++
+		relPath, err := filepath.Rel(source.ResolvedPath, path)
+		if err != nil {
+			return fmt.Errorf("source %q %s %q: resolve relative path: %w", source.Name, label, workspaceRelative(workspaceRoot, path), err)
+		}
+		relPath = filepath.ToSlash(relPath)
+		selection, err := evaluateSourcePathSelection(source, relPath)
+		if err != nil {
+			return fmt.Errorf("source %q %s %q: %w", source.Name, label, workspaceRelative(workspaceRoot, path), err)
+		}
+		if !selection.Selected {
+			if verbose {
+				rejected = append(rejected, PreviewRejectedItem{
+					Path:           workspaceRelative(workspaceRoot, path),
+					Reason:         selection.Reason,
+					FilesMatched:   append([]string(nil), selection.FilesMatched...),
+					IncludeMatches: append([]string(nil), selection.IncludeMatches...),
+					ExcludeMatches: append([]string(nil), selection.ExcludeMatches...),
+				})
+			}
+			return nil
+		}
+		matches = append(matches, previewMarkdownPath{
+			selectedMarkdownPath: selectedMarkdownPath{
+				AbsolutePath: path,
+				RelativePath: relPath,
+			},
+			Selection: selection,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	return matches, candidateCount, rejected, nil
 }
 
 func previewViaAdapter(preview SourcePreview, source config.Source) (SourcePreview, error) {


### PR DESCRIPTION
## What changed

This follow-up PR tightens several low-level debugging and operator UX gaps that showed up in real use:

- documents and clarifies that `workspace.root` resolves relative to the config file base, and improves related path-resolution errors with resolved-path detail
- makes `preview-sources` useful for selector debugging with `--verbose`, resolved paths, candidate counts, include matches, and rejected candidates
- adds clearer index freshness mismatch diagnostics via stored source manifests, so source-list and selector drift are easier to identify
- promotes actionable compliance guidance into text summaries and `result.top_suggestions`
- adds optional JSON timing metadata for `check-compliance`, `check-doc-drift`, `check-terminology`, and `compile`
- documents the command/runtime matrix and gives `explain-file` much stronger billing in help and docs

## Why

These fixes are about trust and debuggability rather than new analysis features. The previous behavior was often technically correct but too opaque when:

- a scratch config lived outside the repo
- include/exclude selectors matched differently than expected
- the index fingerprint diverged without saying which source field changed
- the best remediation text existed only inside per-finding JSON
- operators formed the wrong mental model about which commands use `runtime.embedder` vs `runtime.analysis`

## Impact

Operators now get faster answers to "why did Pituitary think this?" without digging through raw JSON or trial-and-error edits. CI and local automation also get top-level timing and call-count metadata for regression tracking.

## Validation

- `go test ./cmd -count=1`
- `go test ./internal/config ./internal/index -count=1`
