### PR TITLE
[codex] Fix doc applies_to lookups in compliance

### DIFF
--- a/cmd/check_compliance_test.go
+++ b/cmd/check_compliance_test.go
@@ -86,6 +86,106 @@ func buildLimiter() {}
 	}
 }
 
+func TestRunCheckComplianceDocAppliesToUsesIndexedDocRef(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	writeComplianceSourceFile(t, repo, "specs/rate-limit-v2/spec.toml", `
+id = "SPEC-042"
+title = "Per-Tenant Rate Limiting for Public API Endpoints"
+status = "accepted"
+domain = "api"
+authors = ["emanuele"]
+tags = ["rate-limiting", "api", "multi-tenant", "security"]
+body = "body.md"
+
+supersedes = ["SPEC-008"]
+applies_to = [
+  "code://src/api/middleware/ratelimiter.go",
+  "config://src/api/config/limits.yaml",
+  "doc://guides/reference-adapter",
+]
+`)
+	writeComplianceSourceFile(t, repo, "docs/guides/reference-adapter.md", `
+# Reference Adapter
+
+## Requirements
+
+Apply limits per tenant rather than per API key.
+Enforce a default limit of 200 requests per minute.
+Allow tenant-specific overrides through configuration.
+
+## Design
+
+Use a sliding-window limiter.
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		rebuildSearchWorkspaceIndex(t)
+		return runCheckCompliance([]string{
+			"--path", "docs/guides/reference-adapter.md",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCheckCompliance() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckCompliance() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			RelevantSpecs []struct {
+				SpecRef string   `json:"spec_ref"`
+				Basis   []string `json:"basis"`
+			} `json:"relevant_specs"`
+			Compliant []struct {
+				Path    string `json:"path"`
+				SpecRef string `json:"spec_ref"`
+			} `json:"compliant"`
+			Conflicts   []any `json:"conflicts"`
+			Unspecified []any `json:"unspecified"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal compliance payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("payload errors = %+v, want none", payload.Errors)
+	}
+	if len(payload.Result.Compliant) == 0 {
+		t.Fatalf("result.compliant = %+v, want compliant findings", payload.Result.Compliant)
+	}
+	if len(payload.Result.Conflicts) != 0 {
+		t.Fatalf("result.conflicts = %+v, want none", payload.Result.Conflicts)
+	}
+	if len(payload.Result.Unspecified) != 0 {
+		t.Fatalf("result.unspecified = %+v, want none", payload.Result.Unspecified)
+	}
+
+	var relevantBasis []string
+	found := false
+	for _, item := range payload.Result.RelevantSpecs {
+		if item.SpecRef == "SPEC-042" {
+			relevantBasis = append([]string(nil), item.Basis...)
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("relevant_specs = %+v, want SPEC-042", payload.Result.RelevantSpecs)
+	}
+	if len(relevantBasis) != 1 || relevantBasis[0] != "applies_to" {
+		t.Fatalf("SPEC-042 basis = %v, want [applies_to]", relevantBasis)
+	}
+	if payload.Result.Compliant[0].Path != "docs/guides/reference-adapter.md" || payload.Result.Compliant[0].SpecRef != "SPEC-042" {
+		t.Fatalf("top compliant finding = %+v, want explicit doc applies_to match", payload.Result.Compliant[0])
+	}
+}
+
 func TestRunCheckCompliancePathJSONConflict(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 	writeComplianceSourceFile(t, repo, "src/api/middleware/ratelimiter.go", `

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -140,12 +140,11 @@ type ComplianceResult struct {
 }
 
 type complianceTarget struct {
-	Path          string
-	RefCandidates []string
-	Content       string
-	Embedding     []float64
-	DuplicateKey  string
-	RemovedOnly   bool
+	Path         string
+	Content      string
+	Embedding    []float64
+	DuplicateKey string
+	RemovedOnly  bool
 }
 
 type complianceEvaluationTarget struct {
@@ -492,10 +491,9 @@ func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, p
 		}
 
 		targets = append(targets, complianceTarget{
-			Path:          relPath,
-			RefCandidates: governedRefsForPath(relPath),
-			Content:       string(data),
-			DuplicateKey:  complianceContentDigest(string(data)),
+			Path:         relPath,
+			Content:      string(data),
+			DuplicateKey: complianceContentDigest(string(data)),
 		})
 	}
 	return targets, nil
@@ -517,11 +515,10 @@ func loadParsedDiffComplianceTargetsContext(ctx context.Context, cfg *config.Con
 			continue
 		}
 		targets = append(targets, complianceTarget{
-			Path:          item.Path,
-			RefCandidates: governedRefsForPath(item.Path),
-			Content:       content,
-			DuplicateKey:  complianceDuplicateKey(cfg.Workspace.RootPath, item.Path, content),
-			RemovedOnly:   removedOnly,
+			Path:         item.Path,
+			Content:      content,
+			DuplicateKey: complianceDuplicateKey(cfg.Workspace.RootPath, item.Path, content),
+			RemovedOnly:  removedOnly,
 		})
 	}
 	if len(targets) == 0 {
@@ -534,7 +531,11 @@ func prepareComplianceEvaluationTargetsContext(ctx context.Context, repo *analys
 	prepared := make([]complianceEvaluationTarget, 0, len(targets))
 	fallbackIndexes := make([]int, 0, len(targets))
 	for _, target := range targets {
-		explicitRefs, err := repo.specRefsForGovernedRefs(target.RefCandidates)
+		governedRefs, err := index.ResolveGovernedRefsForPathContext(ctx, repo.db, target.Path)
+		if err != nil {
+			return nil, err
+		}
+		explicitRefs, err := repo.specRefsForGovernedRefs(governedRefs)
 		if err != nil {
 			return nil, err
 		}
@@ -740,14 +741,6 @@ func resolveWorkspaceFilePath(rootPath, rawPath string) (string, string, error) 
 
 func normalizeCompliancePath(path string) string {
 	return pathpkg.Clean(filepath.ToSlash(stringsTrimSpace(path)))
-}
-
-func governedRefsForPath(path string) []string {
-	path = normalizeCompliancePath(path)
-	return uniqueStrings([]string{
-		"code://" + path,
-		"config://" + path,
-	})
 }
 
 func parseDiffTargets(diffText string) ([]parsedDiffTarget, error) {

--- a/internal/index/governed_by.go
+++ b/internal/index/governed_by.go
@@ -33,13 +33,17 @@ func GovernedByContext(ctx context.Context, dbPath string, path string, atDate s
 	if normalized == "" || normalized == "." {
 		return nil, fmt.Errorf("governed_by requires a non-empty file path")
 	}
-	refs := governedRefsForPath(normalized)
 
 	db, err := OpenReadOnlyContext(ctx, dbPath)
 	if err != nil {
 		return nil, err
 	}
 	defer db.Close()
+
+	refs, err := ResolveGovernedRefsForPathContext(ctx, db, normalized)
+	if err != nil {
+		return nil, err
+	}
 
 	hasSource := hasEdgeSourceColumn(ctx, db)
 	hasConfidence := hasEdgeConfidenceColumn(ctx, db)
@@ -132,6 +136,20 @@ WHERE a.kind = 'spec'
 	}, nil
 }
 
+// ResolveGovernedRefsForPathContext expands a workspace-relative path into the
+// applies_to refs that may govern it. This preserves the historical code/config
+// candidates and adds any indexed artifact refs normalized from the same
+// workspace path, such as doc:// refs for markdown docs.
+func ResolveGovernedRefsForPathContext(ctx context.Context, db *sql.DB, path string) ([]string, error) {
+	path = normalizePath(path)
+	refs := governedRefsForPath(path)
+	artifactRefs, err := indexedArtifactRefsForPathContext(ctx, db, path)
+	if err != nil {
+		return nil, err
+	}
+	return uniqueGovernedRefs(append(refs, artifactRefs...)), nil
+}
+
 // appendTemporalClause adds a temporal validity filter to the SQL query when
 // atDate is non-empty. It filters for edges active at the given date using:
 // valid_from <= atDate AND (valid_to IS NULL OR valid_to >= atDate).
@@ -160,6 +178,51 @@ func governedRefsForPath(path string) []string {
 	default:
 		return []string{"code://" + path, "config://" + path}
 	}
+}
+
+func indexedArtifactRefsForPathContext(ctx context.Context, db *sql.DB, path string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT ref
+FROM artifacts
+WHERE json_extract(metadata_json, '$.path') = ?
+ORDER BY ref`, path)
+	if err != nil {
+		return nil, fmt.Errorf("query indexed artifact refs: %w", err)
+	}
+	defer rows.Close()
+
+	var refs []string
+	for rows.Next() {
+		var ref string
+		if err := rows.Scan(&ref); err != nil {
+			return nil, fmt.Errorf("scan indexed artifact ref: %w", err)
+		}
+		refs = append(refs, ref)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate indexed artifact refs: %w", err)
+	}
+	return refs, nil
+}
+
+func uniqueGovernedRefs(refs []string) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			continue
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		result = append(result, ref)
+	}
+	return result
 }
 
 func hasEdgeSourceColumn(ctx context.Context, db *sql.DB) bool {
@@ -209,5 +272,6 @@ func normalizePath(path string) string {
 	path = strings.TrimSpace(path)
 	path = strings.TrimPrefix(path, "code://")
 	path = strings.TrimPrefix(path, "config://")
+	path = strings.TrimPrefix(path, "doc://")
 	return filepath.ToSlash(filepath.Clean(path))
 }

--- a/internal/index/governed_by_test.go
+++ b/internal/index/governed_by_test.go
@@ -1,0 +1,96 @@
+package index
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+func TestGovernedByContextResolvesIndexedDocAppliesToRefs(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "pituitary.toml")
+	indexPath := filepath.Join(t.TempDir(), "pituitary.db")
+
+	mustWriteFile(t, filepath.Join(repo, "specs", "reference-adapter", "spec.toml"), `
+id = "SPEC-DOC"
+title = "Reference Adapter"
+status = "accepted"
+domain = "docs"
+body = "body.md"
+applies_to = ["doc://guides/reference-adapter"]
+`)
+	mustWriteFile(t, filepath.Join(repo, "specs", "reference-adapter", "body.md"), `
+## Requirements
+
+Reference adapter documentation is governed explicitly.
+`)
+	mustWriteFile(t, filepath.Join(repo, "docs", "guides", "reference-adapter.md"), `
+# Reference Adapter
+
+This guide is governed explicitly.
+`)
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repo)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	result, err := GovernedByContext(context.Background(), cfg.Workspace.ResolvedIndexPath, "docs/guides/reference-adapter.md", "", "")
+	if err != nil {
+		t.Fatalf("GovernedByContext() error = %v", err)
+	}
+	if result.Path != "docs/guides/reference-adapter.md" {
+		t.Fatalf("result.Path = %q, want normalized doc path", result.Path)
+	}
+	if !containsGovernedRef(result.Refs, "doc://guides/reference-adapter") {
+		t.Fatalf("result.Refs = %v, want indexed doc ref candidate", result.Refs)
+	}
+	if len(result.Specs) != 1 || result.Specs[0].Ref != "SPEC-DOC" {
+		t.Fatalf("result.Specs = %+v, want SPEC-DOC", result.Specs)
+	}
+}
+
+func containsGovernedRef(refs []string, want string) bool {
+	for _, ref := range refs {
+		if ref == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- resolve applies_to candidates from indexed artifact paths as well as code/config path heuristics
- make check-compliance and governed_by honor explicit doc:// applies_to edges
- add regressions for compliance and governed_by doc path lookups

Fixes #297