### PR TITLE
[codex] Add additive relation-status output for check-compliance

### DIFF
--- a/cmd/check_compliance_test.go
+++ b/cmd/check_compliance_test.go
@@ -54,6 +54,21 @@ func buildLimiter() {}
 			} `json:"compliant"`
 			Conflicts   []any `json:"conflicts"`
 			Unspecified []any `json:"unspecified"`
+			Relations   []struct {
+				Path       string `json:"path"`
+				Type       string `json:"type"`
+				State      string `json:"state"`
+				DeclaredBy string `json:"declared_by"`
+			} `json:"relations"`
+			RelationSummary struct {
+				Total               int `json:"total"`
+				Verified            int `json:"verified"`
+				Drifted             int `json:"drifted"`
+				UnverifiableInScope int `json:"unverifiable_in_scope"`
+			} `json:"relation_summary"`
+			Discovery struct {
+				FilesWithZeroRelations []any `json:"files_with_zero_relations"`
+			} `json:"discovery"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
 	}
@@ -80,6 +95,24 @@ func buildLimiter() {}
 	}
 	if len(payload.Result.Unspecified) != 0 {
 		t.Fatalf("result.unspecified = %+v, want none", payload.Result.Unspecified)
+	}
+	if got, want := payload.Result.RelationSummary.Total, len(payload.Result.RelevantSpecs); got != want {
+		t.Fatalf("relation_summary.total = %d, want %d", got, want)
+	}
+	if got, want := payload.Result.RelationSummary.Verified, payload.Result.RelationSummary.Total; got != want {
+		t.Fatalf("relation_summary.verified = %d, want %d", got, want)
+	}
+	if payload.Result.RelationSummary.Drifted != 0 || payload.Result.RelationSummary.UnverifiableInScope != 0 {
+		t.Fatalf("relation_summary = %+v, want only verified relations", payload.Result.RelationSummary)
+	}
+	if len(payload.Result.Relations) != payload.Result.RelationSummary.Total {
+		t.Fatalf("relations = %+v, want one entry per explicit governing relation", payload.Result.Relations)
+	}
+	if len(payload.Result.Discovery.FilesWithZeroRelations) != 0 {
+		t.Fatalf("discovery = %+v, want no zero-relation files", payload.Result.Discovery)
+	}
+	if payload.Result.Relations[0].Path == "" || payload.Result.Relations[0].DeclaredBy == "" || payload.Result.Relations[0].State != "verified" {
+		t.Fatalf("top relation = %+v, want verified explicit relation metadata", payload.Result.Relations[0])
 	}
 	if payload.Result.Compliant[0].SpecRef == "" || payload.Result.Compliant[0].SectionHeading == "" {
 		t.Fatalf("top compliant finding = %+v, want spec ref and section heading", payload.Result.Compliant[0])
@@ -147,6 +180,14 @@ Use a sliding-window limiter.
 			} `json:"compliant"`
 			Conflicts   []any `json:"conflicts"`
 			Unspecified []any `json:"unspecified"`
+			Relations   []struct {
+				Type      string `json:"type"`
+				State     string `json:"state"`
+				Endpoints []struct {
+					NodeKind string `json:"node_kind"`
+					Ref      string `json:"ref"`
+				} `json:"endpoints"`
+			} `json:"relations"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
 	}
@@ -183,6 +224,15 @@ Use a sliding-window limiter.
 	}
 	if payload.Result.Compliant[0].Path != "docs/guides/reference-adapter.md" || payload.Result.Compliant[0].SpecRef != "SPEC-042" {
 		t.Fatalf("top compliant finding = %+v, want explicit doc applies_to match", payload.Result.Compliant[0])
+	}
+	if len(payload.Result.Relations) == 0 {
+		t.Fatalf("relations = %+v, want explicit doc relation", payload.Result.Relations)
+	}
+	if payload.Result.Relations[0].Type != "doc_reflects_spec" || payload.Result.Relations[0].State != "verified" {
+		t.Fatalf("top relation = %+v, want verified doc_reflects_spec", payload.Result.Relations[0])
+	}
+	if len(payload.Result.Relations[0].Endpoints) != 2 || payload.Result.Relations[0].Endpoints[1].Ref != "doc://guides/reference-adapter" {
+		t.Fatalf("top relation endpoints = %+v, want indexed doc ref endpoint", payload.Result.Relations[0].Endpoints)
 	}
 }
 
@@ -224,6 +274,11 @@ func buildLimiter() {}
 				Expected       string `json:"expected"`
 				Observed       string `json:"observed"`
 			} `json:"conflicts"`
+			Relations []struct {
+				Path       string `json:"path"`
+				State      string `json:"state"`
+				DeclaredBy string `json:"declared_by"`
+			} `json:"relations"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
 	}
@@ -247,6 +302,16 @@ func buildLimiter() {}
 	}
 	if payload.Result.Conflicts[0].Code == "" {
 		t.Fatalf("top conflict = %+v, want stable code", payload.Result.Conflicts[0])
+	}
+	foundDrifted := false
+	for _, relation := range payload.Result.Relations {
+		if relation.Path == "src/api/middleware/ratelimiter.go" && relation.DeclaredBy == "SPEC-042#applies_to" && relation.State == "drifted" {
+			foundDrifted = true
+			break
+		}
+	}
+	if !foundDrifted {
+		t.Fatalf("relations = %+v, want drifted relation for SPEC-042", payload.Result.Relations)
 	}
 }
 
@@ -286,6 +351,17 @@ plinth ember quartz
 				LimitingFactor string `json:"limiting_factor"`
 				Suggestion     string `json:"suggestion"`
 			} `json:"unspecified"`
+			Relations       []any `json:"relations"`
+			RelationSummary struct {
+				Total int `json:"total"`
+			} `json:"relation_summary"`
+			Discovery struct {
+				FilesWithZeroRelations []struct {
+					Path         string `json:"path"`
+					Code         string `json:"code"`
+					Traceability string `json:"traceability"`
+				} `json:"files_with_zero_relations"`
+			} `json:"discovery"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
 	}
@@ -315,6 +391,15 @@ plinth ember quartz
 	}
 	if !strings.Contains(payload.Result.Unspecified[0].Suggestion, `applies_to = ["code://notes/ungoverned.txt"]`) {
 		t.Fatalf("unspecified finding = %+v, want applies_to suggestion", payload.Result.Unspecified[0])
+	}
+	if len(payload.Result.Relations) != 0 || payload.Result.RelationSummary.Total != 0 {
+		t.Fatalf("relations = %+v summary=%+v, want no explicit relations", payload.Result.Relations, payload.Result.RelationSummary)
+	}
+	if len(payload.Result.Discovery.FilesWithZeroRelations) != 1 {
+		t.Fatalf("discovery = %+v, want one zero-relation discovery item", payload.Result.Discovery)
+	}
+	if payload.Result.Discovery.FilesWithZeroRelations[0].Path != "notes/ungoverned.txt" || payload.Result.Discovery.FilesWithZeroRelations[0].Code != "weak_traceability" {
+		t.Fatalf("discovery item = %+v, want ungoverned weak_traceability path", payload.Result.Discovery.FilesWithZeroRelations[0])
 	}
 }
 
@@ -505,6 +590,20 @@ func buildLimiter() {}
 				LimitingFactor string `json:"limiting_factor"`
 				Suggestion     string `json:"suggestion"`
 			} `json:"unspecified"`
+			Relations []struct {
+				State      string `json:"state"`
+				DeclaredBy string `json:"declared_by"`
+				Code       string `json:"code"`
+			} `json:"relations"`
+			RelationSummary struct {
+				Total               int `json:"total"`
+				Verified            int `json:"verified"`
+				Drifted             int `json:"drifted"`
+				UnverifiableInScope int `json:"unverifiable_in_scope"`
+			} `json:"relation_summary"`
+			Discovery struct {
+				FilesWithZeroRelations []any `json:"files_with_zero_relations"`
+			} `json:"discovery"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
 	}
@@ -530,6 +629,21 @@ func buildLimiter() {}
 		if !strings.Contains(item.Suggestion, "already governs") {
 			t.Fatalf("unspecified finding = %+v, want explicit guidance", item)
 		}
+	}
+	if got, want := payload.Result.RelationSummary.Total, len(payload.Result.Relations); got != want {
+		t.Fatalf("relation_summary.total = %d, want %d", got, want)
+	}
+	if payload.Result.RelationSummary.Verified != 0 || payload.Result.RelationSummary.Drifted != 0 {
+		t.Fatalf("relation_summary = %+v, want only unverifiable relations", payload.Result.RelationSummary)
+	}
+	if payload.Result.RelationSummary.UnverifiableInScope != len(payload.Result.Relations) {
+		t.Fatalf("relation_summary = %+v relations=%+v, want all relations unverifiable_in_scope", payload.Result.RelationSummary, payload.Result.Relations)
+	}
+	if len(payload.Result.Discovery.FilesWithZeroRelations) != 0 {
+		t.Fatalf("discovery = %+v, want no zero-relation discovery items", payload.Result.Discovery)
+	}
+	if len(payload.Result.Relations) == 0 || payload.Result.Relations[0].State != "unverifiable_in_scope" {
+		t.Fatalf("relations = %+v, want explicit relations marked unverifiable_in_scope", payload.Result.Relations)
 	}
 }
 
@@ -574,6 +688,21 @@ plinth ember quartz
 				MissingGovernanceEdge     int `json:"missing_governance_edge"`
 				ExplicitButUnderexercised int `json:"explicit_but_underexercised"`
 			} `json:"unspecified_summary"`
+			Relations []struct {
+				State string `json:"state"`
+				Path  string `json:"path"`
+			} `json:"relations"`
+			RelationSummary struct {
+				Total               int `json:"total"`
+				Verified            int `json:"verified"`
+				Drifted             int `json:"drifted"`
+				UnverifiableInScope int `json:"unverifiable_in_scope"`
+			} `json:"relation_summary"`
+			Discovery struct {
+				FilesWithZeroRelations []struct {
+					Path string `json:"path"`
+				} `json:"files_with_zero_relations"`
+			} `json:"discovery"`
 		} `json:"result"`
 		Errors []cliIssue `json:"errors"`
 	}
@@ -591,6 +720,18 @@ plinth ember quartz
 	}
 	if got, want := payload.Result.UnspecifiedSummary.ExplicitButUnderexercised, 2; got != want {
 		t.Fatalf("explicit_but_underexercised = %d, want %d", got, want)
+	}
+	if got, want := payload.Result.RelationSummary.Total, len(payload.Result.Relations); got != want {
+		t.Fatalf("relation_summary.total = %d, want %d", got, want)
+	}
+	if payload.Result.RelationSummary.UnverifiableInScope != len(payload.Result.Relations) {
+		t.Fatalf("relation_summary = %+v, want all explicit relations marked unverifiable_in_scope", payload.Result.RelationSummary)
+	}
+	if payload.Result.RelationSummary.Verified != 0 || payload.Result.RelationSummary.Drifted != 0 {
+		t.Fatalf("relation_summary = %+v, want no verified or drifted relations in this mixed test", payload.Result.RelationSummary)
+	}
+	if len(payload.Result.Discovery.FilesWithZeroRelations) != 1 || payload.Result.Discovery.FilesWithZeroRelations[0].Path != "notes/ungoverned.txt" {
+		t.Fatalf("discovery = %+v, want notes/ungoverned.txt only", payload.Result.Discovery)
 	}
 }
 

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -109,6 +109,46 @@ func TestRunSchemaCommandJSON(t *testing.T) {
 	}
 }
 
+func TestRunSchemaCheckComplianceIncludesRelationOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runSchema([]string{"check-compliance", "--format", "json"}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("runSchema(check-compliance) exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runSchema(check-compliance) wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			Name         string         `json:"name"`
+			OutputSchema map[string]any `json:"output_schema"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal check-compliance schema payload: %v", err)
+	}
+	if payload.Result.Name != "check-compliance" {
+		t.Fatalf("result.name = %q, want check-compliance", payload.Result.Name)
+	}
+	outputProps, _ := payload.Result.OutputSchema["properties"].(map[string]any)
+	if _, ok := outputProps["relations"]; !ok {
+		t.Fatalf("output schema properties = %#v, want relations", outputProps)
+	}
+	if _, ok := outputProps["relation_summary"]; !ok {
+		t.Fatalf("output schema properties = %#v, want relation_summary", outputProps)
+	}
+	if _, ok := outputProps["discovery"]; !ok {
+		t.Fatalf("output schema properties = %#v, want discovery", outputProps)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
 func TestRunVersionUsesPituitaryFormatEnv(t *testing.T) {
 	t.Setenv(formatEnvVar, "json")
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -20,6 +20,14 @@ When a changed path has no explicit governance, findings include a `limiting_fac
 
 The JSON result also carries `unspecified_summary`, which splits `unspecified` findings into `missing_governance_edge` versus `explicit_but_underexercised` so CI and operators do not treat those remediations as the same class of problem.
 
+For additive machine-readable status, `check-compliance --format json` also emits:
+
+- `result.relations[]` for explicit accepted spec-to-target relations already present in the index
+- `result.relation_summary` counting `verified`, `drifted`, and `unverifiable_in_scope`
+- `result.discovery.files_with_zero_relations[]` for changed paths that still lack any explicit accepted relation
+
+That keeps explicit relation failure separate from governance discovery without changing the legacy `compliant / conflicts / unspecified` shape.
+
 Text output now also promotes the strongest per-finding guidance into a short `TOP SUGGESTIONS` block, and JSON mirrors that guidance in `result.top_suggestions`, so operators do not need to dig through every individual finding to see the best next action.
 
 ## Commands

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -134,6 +134,9 @@ type ComplianceResult struct {
 	Conflicts          []ComplianceFinding           `json:"conflicts"`
 	Unspecified        []ComplianceFinding           `json:"unspecified"`
 	UnspecifiedSummary *ComplianceUnspecifiedSummary `json:"unspecified_summary,omitempty"`
+	Relations          []ComplianceRelation          `json:"relations"`
+	RelationSummary    ComplianceRelationSummary     `json:"relation_summary"`
+	Discovery          ComplianceDiscovery           `json:"discovery"`
 	TopSuggestions     []string                      `json:"top_suggestions,omitempty"`
 	Runtime            *CommandRuntime               `json:"runtime,omitempty"`
 	ContentTrust       *resultmeta.ContentTrust      `json:"content_trust,omitempty"`
@@ -148,8 +151,9 @@ type complianceTarget struct {
 }
 
 type complianceEvaluationTarget struct {
-	Target       complianceTarget
-	ExplicitRefs []string
+	Target             complianceTarget
+	ExplicitRefs       []string
+	ExplicitTargetRefs map[string]string
 }
 
 type complianceAssessment struct {
@@ -177,6 +181,66 @@ type ComplianceUnspecifiedSummary struct {
 	Total                     int `json:"total"`
 	MissingGovernanceEdge     int `json:"missing_governance_edge"`
 	ExplicitButUnderexercised int `json:"explicit_but_underexercised"`
+}
+
+// ComplianceRelationEndpoint identifies one endpoint in an explicit
+// spec-to-target compliance relation.
+type ComplianceRelationEndpoint struct {
+	NodeKind string `json:"node_kind"`
+	Ref      string `json:"ref"`
+}
+
+// ComplianceRelation reports the state of one explicit accepted spec relation
+// already present in the index.
+type ComplianceRelation struct {
+	ID              string                       `json:"id"`
+	Type            string                       `json:"type"`
+	DeclaredBy      string                       `json:"declared_by"`
+	Verifier        string                       `json:"verifier"`
+	State           string                       `json:"state"`
+	Endpoints       []ComplianceRelationEndpoint `json:"endpoints"`
+	Path            string                       `json:"path"`
+	SectionHeading  string                       `json:"section_heading,omitempty"`
+	Code            string                       `json:"code,omitempty"`
+	Message         string                       `json:"message,omitempty"`
+	Traceability    string                       `json:"traceability,omitempty"`
+	LimitingFactor  string                       `json:"limiting_factor,omitempty"`
+	Suggestion      string                       `json:"suggestion,omitempty"`
+	Expected        string                       `json:"expected,omitempty"`
+	Observed        string                       `json:"observed,omitempty"`
+	Provenance      string                       `json:"provenance,omitempty"`
+	Confidence      float64                      `json:"confidence,omitempty"`
+	Classification  string                       `json:"classification,omitempty"`
+	RationaleText   string                       `json:"rationale_text,omitempty"`
+	RationaleKind   string                       `json:"rationale_kind,omitempty"`
+	RationaleSymbol string                       `json:"rationale_symbol,omitempty"`
+}
+
+// ComplianceRelationSummary counts explicit relations by status.
+type ComplianceRelationSummary struct {
+	Total               int `json:"total"`
+	Verified            int `json:"verified"`
+	Drifted             int `json:"drifted"`
+	UnverifiableInScope int `json:"unverifiable_in_scope"`
+}
+
+// ComplianceDiscovery reports changed paths that lack any explicit accepted
+// spec relation and therefore need governance authoring attention.
+type ComplianceDiscovery struct {
+	FilesWithZeroRelations []ComplianceDiscoveryItem `json:"files_with_zero_relations"`
+}
+
+// ComplianceDiscoveryItem preserves the existing operator guidance for paths
+// that have no explicit accepted governing relation.
+type ComplianceDiscoveryItem struct {
+	Path           string `json:"path"`
+	SpecRef        string `json:"spec_ref,omitempty"`
+	Title          string `json:"title,omitempty"`
+	Code           string `json:"code"`
+	Message        string `json:"message"`
+	Traceability   string `json:"traceability,omitempty"`
+	LimitingFactor string `json:"limiting_factor,omitempty"`
+	Suggestion     string `json:"suggestion,omitempty"`
 }
 
 type complianceAdjudicationCandidate struct {
@@ -229,6 +293,8 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 		Compliant:    []ComplianceFinding{},
 		Conflicts:    []ComplianceFinding{},
 		Unspecified:  []ComplianceFinding{},
+		Relations:    []ComplianceRelation{},
+		Discovery:    ComplianceDiscovery{FilesWithZeroRelations: []ComplianceDiscoveryItem{}},
 		Runtime:      runtime,
 		ContentTrust: resultmeta.UntrustedWorkspaceText(),
 	}
@@ -322,6 +388,10 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	sortComplianceFindings(result.Conflicts)
 	sortComplianceFindings(result.Unspecified)
 	result.UnspecifiedSummary = buildComplianceUnspecifiedSummary(result.Unspecified)
+	explicitRelationTargets := complianceExplicitRelationTargets(evaluationTargets)
+	result.Relations = buildComplianceRelations(result, explicitRelationTargets)
+	result.RelationSummary = buildComplianceRelationSummary(result.Relations)
+	result.Discovery = buildComplianceDiscovery(result.Unspecified, explicitRelationTargets)
 	result.TopSuggestions = buildComplianceTopSuggestions(result)
 	return result, nil
 }
@@ -535,13 +605,15 @@ func prepareComplianceEvaluationTargetsContext(ctx context.Context, repo *analys
 		if err != nil {
 			return nil, err
 		}
-		explicitRefs, err := repo.specRefsForGovernedRefs(governedRefs)
+		explicitTargetRefs, err := repo.explicitTargetRefsForGovernedRefs(target.Path, governedRefs)
 		if err != nil {
 			return nil, err
 		}
+		explicitRefs := sortedComplianceExplicitRefs(explicitTargetRefs)
 		prepared = append(prepared, complianceEvaluationTarget{
-			Target:       target,
-			ExplicitRefs: explicitRefs,
+			Target:             target,
+			ExplicitRefs:       explicitRefs,
+			ExplicitTargetRefs: explicitTargetRefs,
 		})
 		if len(explicitRefs) == 0 {
 			fallbackIndexes = append(fallbackIndexes, len(prepared)-1)
@@ -855,16 +927,16 @@ func complianceTargetPaths(targets []complianceTarget) []string {
 	return uniqueStrings(paths)
 }
 
-func (r *analysisRepository) specRefsForGovernedRefs(refs []string) ([]string, error) {
+func (r *analysisRepository) explicitTargetRefsForGovernedRefs(path string, refs []string) (map[string]string, error) {
 	refs = uniqueStrings(refs)
 	if len(refs) == 0 {
-		return nil, nil
+		return map[string]string{}, nil
 	}
 
 	var builder strings.Builder
 	args := make([]any, 0, 2+len(refs))
 	builder.WriteString(`
-SELECT DISTINCT a.ref
+SELECT DISTINCT a.ref, e.to_ref
 FROM edges e
 JOIN artifacts a ON a.ref = e.from_ref
 WHERE a.kind = ?
@@ -879,26 +951,100 @@ WHERE a.kind = ?
 		builder.WriteString("?")
 		args = append(args, ref)
 	}
-	builder.WriteString(")\nORDER BY a.ref")
+	builder.WriteString(")\nORDER BY a.ref, e.to_ref")
 
 	rows, err := r.db.QueryContext(r.ctx, builder.String(), args...)
 	if err != nil {
-		return nil, fmt.Errorf("query governing specs: %w", err)
+		return nil, fmt.Errorf("query governing spec relations: %w", err)
 	}
 	defer rows.Close()
 
-	var result []string
+	result := make(map[string]string)
 	for rows.Next() {
-		var ref string
-		if err := rows.Scan(&ref); err != nil {
-			return nil, fmt.Errorf("scan governing spec: %w", err)
+		var (
+			specRef   string
+			targetRef string
+		)
+		if err := rows.Scan(&specRef, &targetRef); err != nil {
+			return nil, fmt.Errorf("scan governing spec relation: %w", err)
 		}
-		result = append(result, ref)
+		current, ok := result[specRef]
+		if !ok || complianceRelationTargetLess(path, targetRef, current) {
+			result[specRef] = targetRef
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate governing specs: %w", err)
+		return nil, fmt.Errorf("iterate governing spec relations: %w", err)
 	}
 	return result, nil
+}
+
+func sortedComplianceExplicitRefs(refs map[string]string) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(refs))
+	for ref := range refs {
+		result = append(result, ref)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func complianceExplicitRelationTargets(targets []complianceEvaluationTarget) map[string]string {
+	result := make(map[string]string)
+	for _, target := range targets {
+		for specRef, targetRef := range target.ExplicitTargetRefs {
+			key := complianceRelationKey(target.Target.Path, specRef)
+			current, ok := result[key]
+			if !ok || complianceRelationTargetLess(target.Target.Path, targetRef, current) {
+				result[key] = targetRef
+			}
+		}
+	}
+	return result
+}
+
+func complianceRelationKey(path, specRef string) string {
+	return normalizeCompliancePath(path) + "\x00" + stringsTrimSpace(specRef)
+}
+
+func complianceRelationTargetLess(path, left, right string) bool {
+	leftRank := complianceRelationTargetRank(path, left)
+	rightRank := complianceRelationTargetRank(path, right)
+	switch {
+	case leftRank != rightRank:
+		return leftRank < rightRank
+	case len(left) != len(right):
+		return len(left) < len(right)
+	default:
+		return left < right
+	}
+}
+
+func complianceRelationTargetRank(path, ref string) int {
+	ref = strings.TrimSpace(ref)
+	switch {
+	case stringsHasPrefix(ref, "doc://"):
+		return 0
+	case compliancePathLooksConfig(path) && stringsHasPrefix(ref, "config://"):
+		return 1
+	case stringsHasPrefix(ref, "code://"):
+		return 2
+	case stringsHasPrefix(ref, "config://"):
+		return 3
+	default:
+		return 4
+	}
+}
+
+func compliancePathLooksConfig(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml", ".json", ".toml", ".ini", ".cfg", ".conf":
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *analysisRepository) complianceSemanticSuggestions(embedding []float64) ([]scoredArtifactRef, error) {
@@ -1246,6 +1392,168 @@ func buildComplianceUnspecifiedSummary(findings []ComplianceFinding) *Compliance
 		summary.MissingGovernanceEdge++
 	}
 	return summary
+}
+
+func buildComplianceRelations(result *ComplianceResult, explicitTargetRefs map[string]string) []ComplianceRelation {
+	if result == nil || len(explicitTargetRefs) == 0 {
+		return []ComplianceRelation{}
+	}
+
+	type candidate struct {
+		relation ComplianceRelation
+		rank     int
+	}
+
+	relations := make(map[string]candidate)
+	add := func(findings []ComplianceFinding, state string, rank int) {
+		for _, finding := range findings {
+			if stringsTrimSpace(finding.SpecRef) == "" {
+				continue
+			}
+			targetRef, ok := explicitTargetRefs[complianceRelationKey(finding.Path, finding.SpecRef)]
+			if !ok {
+				continue
+			}
+			relation := complianceRelationFromFinding(finding, targetRef, state)
+			key := complianceRelationKey(finding.Path, finding.SpecRef)
+			current, exists := relations[key]
+			if !exists || rank > current.rank {
+				relations[key] = candidate{relation: relation, rank: rank}
+			}
+		}
+	}
+
+	add(result.Unspecified, "unverifiable_in_scope", 1)
+	add(result.Compliant, "verified", 2)
+	add(result.Conflicts, "drifted", 3)
+
+	if len(relations) == 0 {
+		return []ComplianceRelation{}
+	}
+
+	items := make([]ComplianceRelation, 0, len(relations))
+	for _, item := range relations {
+		items = append(items, item.relation)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		switch {
+		case items[i].Path != items[j].Path:
+			return items[i].Path < items[j].Path
+		case items[i].Endpoints[0].Ref != items[j].Endpoints[0].Ref:
+			return items[i].Endpoints[0].Ref < items[j].Endpoints[0].Ref
+		default:
+			return items[i].ID < items[j].ID
+		}
+	})
+	return items
+}
+
+func complianceRelationFromFinding(finding ComplianceFinding, targetRef, state string) ComplianceRelation {
+	relationType, nodeKind := complianceRelationTypeAndNodeKind(targetRef)
+	traceability := finding.Traceability
+	if traceability == "" {
+		traceability = "explicit_applies_to"
+	}
+	return ComplianceRelation{
+		ID:         fmt.Sprintf("rel:%s:%s->%s", relationType, finding.SpecRef, targetRef),
+		Type:       relationType,
+		DeclaredBy: finding.SpecRef + "#applies_to",
+		Verifier:   complianceRelationVerifier(finding),
+		State:      state,
+		Endpoints: []ComplianceRelationEndpoint{
+			{NodeKind: "spec", Ref: finding.SpecRef},
+			{NodeKind: nodeKind, Ref: targetRef},
+		},
+		Path:            finding.Path,
+		SectionHeading:  finding.SectionHeading,
+		Code:            finding.Code,
+		Message:         finding.Message,
+		Traceability:    traceability,
+		LimitingFactor:  finding.LimitingFactor,
+		Suggestion:      finding.Suggestion,
+		Expected:        finding.Expected,
+		Observed:        finding.Observed,
+		Provenance:      finding.Provenance,
+		Confidence:      finding.Confidence,
+		Classification:  finding.Classification,
+		RationaleText:   finding.RationaleText,
+		RationaleKind:   finding.RationaleKind,
+		RationaleSymbol: finding.RationaleSymbol,
+	}
+}
+
+func complianceRelationTypeAndNodeKind(targetRef string) (string, string) {
+	switch {
+	case stringsHasPrefix(targetRef, "doc://"):
+		return "doc_reflects_spec", "doc"
+	case stringsHasPrefix(targetRef, "config://"):
+		return "config_reflects_spec", "config"
+	case stringsHasPrefix(targetRef, "code://"):
+		return "code_reflects_spec", "code"
+	default:
+		return "artifact_reflects_spec", "artifact"
+	}
+}
+
+func complianceRelationVerifier(finding ComplianceFinding) string {
+	switch finding.Provenance {
+	case ProvenanceModelAdjudication:
+		return "semantic_adjudication"
+	default:
+		return "deterministic_traceability"
+	}
+}
+
+func buildComplianceRelationSummary(relations []ComplianceRelation) ComplianceRelationSummary {
+	summary := ComplianceRelationSummary{Total: len(relations)}
+	for _, relation := range relations {
+		switch relation.State {
+		case "verified":
+			summary.Verified++
+		case "drifted":
+			summary.Drifted++
+		case "unverifiable_in_scope":
+			summary.UnverifiableInScope++
+		}
+	}
+	return summary
+}
+
+func buildComplianceDiscovery(findings []ComplianceFinding, explicitTargetRefs map[string]string) ComplianceDiscovery {
+	items := make([]ComplianceDiscoveryItem, 0)
+	seen := make(map[string]struct{})
+	for _, finding := range findings {
+		if stringsTrimSpace(finding.SpecRef) != "" {
+			if _, ok := explicitTargetRefs[complianceRelationKey(finding.Path, finding.SpecRef)]; ok {
+				continue
+			}
+		}
+		if _, ok := seen[finding.Path]; ok {
+			continue
+		}
+		seen[finding.Path] = struct{}{}
+		items = append(items, ComplianceDiscoveryItem{
+			Path:           finding.Path,
+			SpecRef:        finding.SpecRef,
+			Title:          finding.Title,
+			Code:           finding.Code,
+			Message:        finding.Message,
+			Traceability:   finding.Traceability,
+			LimitingFactor: finding.LimitingFactor,
+			Suggestion:     finding.Suggestion,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		switch {
+		case items[i].Path != items[j].Path:
+			return items[i].Path < items[j].Path
+		case items[i].SpecRef != items[j].SpecRef:
+			return items[i].SpecRef < items[j].SpecRef
+		default:
+			return items[i].Code < items[j].Code
+		}
+	})
+	return ComplianceDiscovery{FilesWithZeroRelations: items}
 }
 
 func buildComplianceTopSuggestions(result *ComplianceResult) []string {


### PR DESCRIPTION
## Summary

Adds an additive relation-status view to `check-compliance --format json` without changing the legacy `compliant / conflicts / unspecified` shape.

- emit `result.relations` for explicit accepted spec-to-target relations already present in the index
- emit `result.relation_summary` and `result.discovery.files_with_zero_relations`
- keep the implementation spec-anchored and update schema/tests/docs accordingly

Closes #299.

## Testing

- `go test ./cmd -run 'CheckCompliance|Schema'`
- `go test ./internal/analysis -run Compliance`
