### PR TITLE
refactor(analysis): stage drift and compliance pipelines

### DIFF
--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -375,13 +375,17 @@ func appendComplianceFinding(result *ComplianceResult, finding ComplianceFinding
 }
 
 func refineComplianceSemantically(ctx context.Context, cfg *config.Config, repo *analysisRepository, adjudicationCandidates map[string]*complianceAdjudicationCandidate, result *ComplianceResult) error {
+	if len(adjudicationCandidates) == 0 {
+		return nil
+	}
+
 	analyzer, err := newQualitativeAnalyzer(cfg.Runtime.Analysis)
 	if err != nil {
 		return err
 	}
 	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
 	adjudicator, ok := analyzer.(complianceAdjudicator)
-	if !ok || len(adjudicationCandidates) == 0 {
+	if !ok {
 		return nil
 	}
 

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -282,13 +282,30 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	}
 	evaluationTargets = collapseComplianceDuplicateEvaluationTargets(evaluationTargets)
 
+	result := newComplianceResult(cfg, targets)
+	relevant := map[string]*complianceRelevantAccumulator{}
+
+	adjudicationCandidates, err := evaluateComplianceDeterministically(repo, evaluationTargets, result, relevant)
+	if err != nil {
+		return nil, err
+	}
+	if err := refineComplianceSemantically(ctx, cfg, repo, adjudicationCandidates, result); err != nil {
+		return nil, err
+	}
+	if err := finalizeComplianceResult(ctx, cfg, repo, evaluationTargets, relevant, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func newComplianceResult(cfg *config.Config, targets []complianceTarget) *ComplianceResult {
 	analysisRuntime := newAnalysisRuntimeUsage(cfg.Runtime.Analysis)
 	var runtime *CommandRuntime
 	if analysisRuntime != nil {
 		runtime = &CommandRuntime{Analysis: analysisRuntime}
 	}
 
-	result := &ComplianceResult{
+	return &ComplianceResult{
 		Paths:        complianceTargetPaths(targets),
 		Compliant:    []ComplianceFinding{},
 		Conflicts:    []ComplianceFinding{},
@@ -298,8 +315,9 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 		Runtime:      runtime,
 		ContentTrust: resultmeta.UntrustedWorkspaceText(),
 	}
-	relevant := map[string]*complianceRelevantAccumulator{}
+}
 
+func evaluateComplianceDeterministically(repo *analysisRepository, evaluationTargets []complianceEvaluationTarget, result *ComplianceResult, relevant map[string]*complianceRelevantAccumulator) (map[string]*complianceAdjudicationCandidate, error) {
 	adjudicationCandidates := map[string]*complianceAdjudicationCandidate{}
 
 	for _, item := range evaluationTargets {
@@ -309,13 +327,13 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 			if err != nil {
 				return nil, err
 			}
-			item, specRef, title, basis := complianceNoSpecFinding(repo, target, suggestions)
+			finding, specRef, title, basis := complianceNoSpecFinding(repo, target, suggestions)
 			if specRef != "" {
 				addComplianceRelevantSpec(relevant, specRef, target.Path, basis)
-				item.SpecRef = specRef
-				item.Title = title
+				finding.SpecRef = specRef
+				finding.Title = title
 			}
-			result.Unspecified = append(result.Unspecified, item)
+			result.Unspecified = append(result.Unspecified, finding)
 			continue
 		}
 
@@ -331,59 +349,65 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 			addComplianceRelevantSpec(relevant, ref, target.Path, "applies_to")
 			assessment := assessComplianceSpec(spec, target)
 			assessment.Finding.Provenance = ProvenanceLiteral
-			switch assessment.Kind {
-			case "conflict":
-				result.Conflicts = append(result.Conflicts, assessment.Finding)
-			case "compliant":
-				result.Compliant = append(result.Compliant, assessment.Finding)
-			default:
-				result.Unspecified = append(result.Unspecified, assessment.Finding)
+			appendComplianceFinding(result, assessment.Finding, assessment.Kind)
+			if assessment.Kind == "compliant" {
+				continue
 			}
-
-			// Collect non-compliant targets for adjudication — targets already
-			// deterministically resolved as compliant are low-value for the
-			// model and would consume the per-request target budget.
-			if assessment.Kind != "compliant" {
-				if _, ok := adjudicationCandidates[ref]; !ok {
-					adjudicationCandidates[ref] = &complianceAdjudicationCandidate{spec: spec}
-				}
-				adjudicationCandidates[ref].targets = append(adjudicationCandidates[ref].targets, target)
+			if _, ok := adjudicationCandidates[ref]; !ok {
+				adjudicationCandidates[ref] = &complianceAdjudicationCandidate{spec: spec}
 			}
+			adjudicationCandidates[ref].targets = append(adjudicationCandidates[ref].targets, target)
 		}
 	}
 
-	// Semantic adjudication: if the analysis runtime is configured, use the
-	// model to find compliance violations that deterministic matching missed.
+	return adjudicationCandidates, nil
+}
+
+func appendComplianceFinding(result *ComplianceResult, finding ComplianceFinding, kind string) {
+	switch kind {
+	case "conflict":
+		result.Conflicts = append(result.Conflicts, finding)
+	case "compliant":
+		result.Compliant = append(result.Compliant, finding)
+	default:
+		result.Unspecified = append(result.Unspecified, finding)
+	}
+}
+
+func refineComplianceSemantically(ctx context.Context, cfg *config.Config, repo *analysisRepository, adjudicationCandidates map[string]*complianceAdjudicationCandidate, result *ComplianceResult) error {
 	analyzer, err := newQualitativeAnalyzer(cfg.Runtime.Analysis)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
-	if adjudicator, ok := analyzer.(complianceAdjudicator); ok && len(adjudicationCandidates) > 0 {
-		adjudicator = complianceAdjudicatorWithTimings(ctx, adjudicator)
-		if result.Runtime != nil && result.Runtime.Analysis != nil {
-			result.Runtime.Analysis.Used = true
-		}
-		adjFindings, err := runComplianceAdjudication(ctx, adjudicator, repo, adjudicationCandidates, result)
-		if err != nil {
-			return nil, err
-		}
-		result.Conflicts = append(result.Conflicts, adjFindings...)
+	adjudicator, ok := analyzer.(complianceAdjudicator)
+	if !ok || len(adjudicationCandidates) == 0 {
+		return nil
 	}
 
+	adjudicator = complianceAdjudicatorWithTimings(ctx, adjudicator)
+	if result.Runtime != nil && result.Runtime.Analysis != nil {
+		result.Runtime.Analysis.Used = true
+	}
+	adjFindings, err := runComplianceAdjudication(ctx, adjudicator, repo, adjudicationCandidates, result)
+	if err != nil {
+		return err
+	}
+	result.Conflicts = append(result.Conflicts, adjFindings...)
+	return nil
+}
+
+func finalizeComplianceResult(ctx context.Context, cfg *config.Config, repo *analysisRepository, evaluationTargets []complianceEvaluationTarget, relevant map[string]*complianceRelevantAccumulator, result *ComplianceResult) error {
 	allSpecRefs := complianceRelevantSpecRefs(relevant)
 	if len(allSpecRefs) > 0 {
 		specs, err := repo.loadSelectedSpecs(allSpecRefs)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		result.RelevantSpecs = buildComplianceRelevantSpecs(specs, relevant)
 	}
 
-	// Classify conflicts as deliberate_deviation or unintentional_drift
-	// based on rationale comments found in the source files.
 	classifyComplianceConflicts(ctx, cfg, result)
-
 	sortComplianceFindings(result.Compliant)
 	sortComplianceFindings(result.Conflicts)
 	sortComplianceFindings(result.Unspecified)
@@ -393,7 +417,7 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	result.RelationSummary = buildComplianceRelationSummary(result.Relations)
 	result.Discovery = buildComplianceDiscovery(result.Unspecified, explicitRelationTargets)
 	result.TopSuggestions = buildComplianceTopSuggestions(result)
-	return result, nil
+	return nil
 }
 
 // runComplianceAdjudication sends narrowed targets to the analysis model for

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -281,174 +281,17 @@ func CheckDocDriftContext(ctx context.Context, cfg *config.Config, request DocDr
 }
 
 func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, analysisRuntime *RuntimeUsage, scope DocDriftScope, selectedDocs map[string]docDocument, specs map[string]specDocument, loadAllSpecs func() (map[string]specDocument, error)) (*DocDriftResult, error) {
-	driftItems := make([]DriftItem, 0, len(selectedDocs))
-	assessments := make([]DocDriftAssessment, 0, len(selectedDocs))
-	remediationItems := make([]DocRemediationItem, 0, len(selectedDocs))
-	relevantSpecRefs := make([]string, 0, len(specs))
-	warningSpecs := make([]specDocument, 0, len(specs))
-	inferenceSpecs := specs
-	var allSpecs map[string]specDocument
-	ensureAllSpecs := func() (map[string]specDocument, error) {
-		if allSpecs != nil || loadAllSpecs == nil {
-			return allSpecs, nil
-		}
-		loaded, err := loadAllSpecs()
-		if err != nil {
-			return nil, err
-		}
-		allSpecs = loaded
-		inferenceSpecs = loaded
-		return allSpecs, nil
+	loader := newDocDriftSpecLoader(specs, loadAllSpecs)
+	state, pending, err := collectDocDriftDeterministicResults(analyzer, selectedDocs, specs, loader)
+	if err != nil {
+		return nil, err
 	}
-	// Phase 1: deterministic evaluation — collect items that need LLM refinement.
-	type pendingRefinement struct {
-		ref         string
-		doc         docDocument
-		relevant    []specDocument
-		item        *DriftItem
-		remediation *DocRemediationItem
+	refined, err := refinePendingDocDriftResults(ctx, analyzer, analysisRuntime, pending)
+	if err != nil {
+		return nil, err
 	}
-	var pending []pendingRefinement
-
-	for _, ref := range sortedDocRefs(selectedDocs) {
-		doc := selectedDocs[ref]
-		relevant := relevantAcceptedSpecs(doc, specs)
-		if roleToleratesHistoricalDrift(doc) {
-			if assessment := historicalDocAssessment(doc, relevant); assessment != nil {
-				assessments = append(assessments, *assessment)
-				relevantSpecRefs = append(relevantSpecRefs, assessment.SpecRefs...)
-				for _, specRef := range assessment.SpecRefs {
-					if spec, ok := specs[specRef]; ok {
-						warningSpecs = append(warningSpecs, spec)
-					}
-				}
-			}
-			continue
-		}
-		item, remediation := driftAgainstAcceptedSpecs(doc, relevant)
-		if item != nil && analyzer != nil {
-			pending = append(pending, pendingRefinement{
-				ref: ref, doc: doc, relevant: relevant,
-				item: item, remediation: remediation,
-			})
-			continue
-		}
-		// No LLM refinement needed — process deterministically.
-		if assessment := assessDocDrift(doc, relevant, item); assessment != nil {
-			assessments = append(assessments, *assessment)
-			relevantSpecRefs = append(relevantSpecRefs, assessment.SpecRefs...)
-			for _, specRef := range assessment.SpecRefs {
-				if spec, ok := specs[specRef]; ok {
-					warningSpecs = append(warningSpecs, spec)
-				}
-			}
-		} else if item == nil {
-			allSpecs, err := ensureAllSpecs()
-			if err != nil {
-				return nil, err
-			}
-			if assessment := possibleDriftAssessment(doc, allSpecs); assessment != nil {
-				assessments = append(assessments, *assessment)
-				relevantSpecRefs = append(relevantSpecRefs, assessment.SpecRefs...)
-				for _, specRef := range assessment.SpecRefs {
-					if spec, ok := allSpecs[specRef]; ok {
-						warningSpecs = append(warningSpecs, spec)
-					}
-				}
-			}
-		}
-		if item == nil {
-			continue
-		}
-		driftItems = append(driftItems, *item)
-		if remediation != nil {
-			remediationItems = append(remediationItems, *remediation)
-		}
-		for _, specRef := range item.SpecRefs {
-			if spec, ok := specs[specRef]; ok {
-				relevantSpecRefs = append(relevantSpecRefs, specRef)
-				warningSpecs = append(warningSpecs, spec)
-			}
-		}
-	}
-
-	// Phase 2: parallel LLM refinement for docs that need it.
-	type refinedResult struct {
-		idx         int
-		item        *DriftItem
-		remediation *DocRemediationItem
-	}
-	refined := make([]refinedResult, len(pending))
-
-	if len(pending) > 0 {
-		if analysisRuntime != nil && analyzer != nil {
-			analysisRuntime.Used = true
-		}
-
-		var mu sync.Mutex
-		g, gctx := errgroup.WithContext(ctx)
-		g.SetLimit(adjudicationConcurrency)
-
-		for i, p := range pending {
-			g.Go(func() error {
-				shortlist := p.relevant
-				if len(shortlist) > docDriftRelevantSpecLimit {
-					shortlist = shortlist[:docDriftRelevantSpecLimit]
-				}
-				relevantByRef := make(map[string]specDocument, len(shortlist))
-				for _, spec := range shortlist {
-					relevantByRef[spec.Record.Ref] = spec
-				}
-				rItem, rRemediation, err := analyzer.RefineDocDrift(gctx, p.doc, relevantByRef, *p.item, p.remediation)
-				if err != nil {
-					return err
-				}
-				mu.Lock()
-				refined[i] = refinedResult{idx: i, item: rItem, remediation: rRemediation}
-				mu.Unlock()
-				return nil
-			})
-		}
-
-		if err := g.Wait(); err != nil {
-			return nil, err
-		}
-	}
-
-	// Phase 3: merge refined results back.
-	for i, p := range pending {
-		item := p.item
-		remediation := p.remediation
-		if refined[i].item != nil {
-			item = refined[i].item
-		}
-		if refined[i].remediation != nil {
-			remediation = refined[i].remediation
-		}
-		if assessment := assessDocDrift(p.doc, p.relevant, item); assessment != nil {
-			assessments = append(assessments, *assessment)
-			relevantSpecRefs = append(relevantSpecRefs, assessment.SpecRefs...)
-			for _, specRef := range assessment.SpecRefs {
-				if spec, ok := specs[specRef]; ok {
-					warningSpecs = append(warningSpecs, spec)
-				}
-			}
-		}
-		if item == nil {
-			continue
-		}
-		driftItems = append(driftItems, *item)
-		if remediation != nil {
-			remediationItems = append(remediationItems, *remediation)
-		}
-		for _, specRef := range item.SpecRefs {
-			if spec, ok := specs[specRef]; ok {
-				relevantSpecRefs = append(relevantSpecRefs, specRef)
-				warningSpecs = append(warningSpecs, spec)
-			}
-		}
-	}
-	relevantSpecRefs = uniqueStrings(relevantSpecRefs)
+	mergeRefinedDocDriftResults(&state, pending, refined, specs)
+	relevantSpecRefs := uniqueStrings(state.relevantSpecRefs)
 
 	var runtime *CommandRuntime
 	if analysisRuntime != nil {
@@ -457,16 +300,204 @@ func buildDocDriftResult(ctx context.Context, analyzer qualitativeAnalyzer, anal
 
 	return &DocDriftResult{
 		Scope:          scope,
-		DriftItems:     driftItems,
-		Assessments:    assessments,
-		SpecInferences: buildSpecInferences(inferenceSpecs, relevantSpecRefs),
+		DriftItems:     state.driftItems,
+		Assessments:    state.assessments,
+		SpecInferences: buildSpecInferences(loader.inferenceSpecs(), relevantSpecRefs),
 		Remediation: &DocRemediationResult{
-			Items: remediationItems,
+			Items: state.remediationItems,
 		},
 		Runtime:      runtime,
-		Warnings:     buildSpecInferenceWarnings("doc-drift analysis", warningSpecs...),
+		Warnings:     buildSpecInferenceWarnings("doc-drift analysis", state.warningSpecs...),
 		ContentTrust: resultmeta.UntrustedWorkspaceText(),
 	}, nil
+}
+
+type pendingDocDriftRefinement struct {
+	ref         string
+	doc         docDocument
+	relevant    []specDocument
+	item        *DriftItem
+	remediation *DocRemediationItem
+}
+
+type refinedDocDriftResult struct {
+	item        *DriftItem
+	remediation *DocRemediationItem
+}
+
+type docDriftBuildState struct {
+	driftItems       []DriftItem
+	assessments      []DocDriftAssessment
+	remediationItems []DocRemediationItem
+	relevantSpecRefs []string
+	warningSpecs     []specDocument
+}
+
+type docDriftSpecLoader struct {
+	baseSpecs    map[string]specDocument
+	loadAllSpecs func() (map[string]specDocument, error)
+	allSpecs     map[string]specDocument
+}
+
+func newDocDriftSpecLoader(specs map[string]specDocument, loadAllSpecs func() (map[string]specDocument, error)) *docDriftSpecLoader {
+	return &docDriftSpecLoader{
+		baseSpecs:    specs,
+		loadAllSpecs: loadAllSpecs,
+	}
+}
+
+func (l *docDriftSpecLoader) ensureAllSpecs() (map[string]specDocument, error) {
+	if l.allSpecs != nil || l.loadAllSpecs == nil {
+		return l.allSpecs, nil
+	}
+	loaded, err := l.loadAllSpecs()
+	if err != nil {
+		return nil, err
+	}
+	l.allSpecs = loaded
+	return l.allSpecs, nil
+}
+
+func (l *docDriftSpecLoader) inferenceSpecs() map[string]specDocument {
+	if l.allSpecs != nil {
+		return l.allSpecs
+	}
+	return l.baseSpecs
+}
+
+func newDocDriftBuildState(selectedDocCount, specCount int) docDriftBuildState {
+	return docDriftBuildState{
+		driftItems:       make([]DriftItem, 0, selectedDocCount),
+		assessments:      make([]DocDriftAssessment, 0, selectedDocCount),
+		remediationItems: make([]DocRemediationItem, 0, selectedDocCount),
+		relevantSpecRefs: make([]string, 0, specCount),
+		warningSpecs:     make([]specDocument, 0, specCount),
+	}
+}
+
+func (s *docDriftBuildState) appendAssessment(assessment *DocDriftAssessment, specs map[string]specDocument) {
+	if assessment == nil {
+		return
+	}
+	s.assessments = append(s.assessments, *assessment)
+	s.relevantSpecRefs = append(s.relevantSpecRefs, assessment.SpecRefs...)
+	for _, specRef := range assessment.SpecRefs {
+		if spec, ok := specs[specRef]; ok {
+			s.warningSpecs = append(s.warningSpecs, spec)
+		}
+	}
+}
+
+func (s *docDriftBuildState) appendItem(item *DriftItem, remediation *DocRemediationItem, specs map[string]specDocument) {
+	if item == nil {
+		return
+	}
+	s.driftItems = append(s.driftItems, *item)
+	if remediation != nil {
+		s.remediationItems = append(s.remediationItems, *remediation)
+	}
+	for _, specRef := range item.SpecRefs {
+		if spec, ok := specs[specRef]; ok {
+			s.relevantSpecRefs = append(s.relevantSpecRefs, specRef)
+			s.warningSpecs = append(s.warningSpecs, spec)
+		}
+	}
+}
+
+func collectDocDriftDeterministicResults(analyzer qualitativeAnalyzer, selectedDocs map[string]docDocument, specs map[string]specDocument, loader *docDriftSpecLoader) (docDriftBuildState, []pendingDocDriftRefinement, error) {
+	state := newDocDriftBuildState(len(selectedDocs), len(specs))
+	pending := make([]pendingDocDriftRefinement, 0, len(selectedDocs))
+
+	for _, ref := range sortedDocRefs(selectedDocs) {
+		doc := selectedDocs[ref]
+		relevant := relevantAcceptedSpecs(doc, specs)
+		if roleToleratesHistoricalDrift(doc) {
+			state.appendAssessment(historicalDocAssessment(doc, relevant), specs)
+			continue
+		}
+
+		item, remediation := driftAgainstAcceptedSpecs(doc, relevant)
+		if item != nil && analyzer != nil {
+			pending = append(pending, pendingDocDriftRefinement{
+				ref:         ref,
+				doc:         doc,
+				relevant:    relevant,
+				item:        item,
+				remediation: remediation,
+			})
+			continue
+		}
+
+		if assessment := assessDocDrift(doc, relevant, item); assessment != nil {
+			state.appendAssessment(assessment, specs)
+		} else if item == nil {
+			allSpecs, err := loader.ensureAllSpecs()
+			if err != nil {
+				return docDriftBuildState{}, nil, err
+			}
+			state.appendAssessment(possibleDriftAssessment(doc, allSpecs), allSpecs)
+		}
+		state.appendItem(item, remediation, specs)
+	}
+
+	return state, pending, nil
+}
+
+func refinePendingDocDriftResults(ctx context.Context, analyzer qualitativeAnalyzer, analysisRuntime *RuntimeUsage, pending []pendingDocDriftRefinement) ([]refinedDocDriftResult, error) {
+	refined := make([]refinedDocDriftResult, len(pending))
+	if len(pending) == 0 || analyzer == nil {
+		return refined, nil
+	}
+	if analysisRuntime != nil {
+		analysisRuntime.Used = true
+	}
+
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(adjudicationConcurrency)
+
+	for i, pendingItem := range pending {
+		i := i
+		pendingItem := pendingItem
+		g.Go(func() error {
+			shortlist := pendingItem.relevant
+			if len(shortlist) > docDriftRelevantSpecLimit {
+				shortlist = shortlist[:docDriftRelevantSpecLimit]
+			}
+			relevantByRef := make(map[string]specDocument, len(shortlist))
+			for _, spec := range shortlist {
+				relevantByRef[spec.Record.Ref] = spec
+			}
+			item, remediation, err := analyzer.RefineDocDrift(gctx, pendingItem.doc, relevantByRef, *pendingItem.item, pendingItem.remediation)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			refined[i] = refinedDocDriftResult{item: item, remediation: remediation}
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return refined, nil
+}
+
+func mergeRefinedDocDriftResults(state *docDriftBuildState, pending []pendingDocDriftRefinement, refined []refinedDocDriftResult, specs map[string]specDocument) {
+	for i, pendingItem := range pending {
+		item := pendingItem.item
+		remediation := pendingItem.remediation
+		if refined[i].item != nil {
+			item = refined[i].item
+		}
+		if refined[i].remediation != nil {
+			remediation = refined[i].remediation
+		}
+		state.appendAssessment(assessDocDrift(pendingItem.doc, pendingItem.relevant, item), specs)
+		state.appendItem(item, remediation, specs)
+	}
 }
 
 func normalizeDocDriftScope(request DocDriftRequest) (DocDriftScope, error) {


### PR DESCRIPTION
## Summary
- split doc drift into deterministic collection, refinement, and merge stages
- split compliance into deterministic evaluation, semantic adjudication, and final assembly helpers
- preserve existing JSON contracts and runtime bookkeeping

## Testing
- go test ./internal/analysis -run 'Compliance|DocDrift'
- go test ./cmd -run 'CheckCompliance|CheckDocDrift'
- go test ./internal/analysis ./cmd

Closes #304