### PR TITLE
feat(status): surface governance hotspots

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -396,6 +396,7 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 			fmt.Fprintf(w, "  %s %s\n", p.cross(), finding.Message)
 		}
 	}
+	renderStatusGovernanceHotspots(w, result.GovernanceHotspots)
 	if result.ArtifactLocations != nil {
 		fmt.Fprintf(w, "  %s %s\n", p.dim("artifact index dir:"), result.ArtifactLocations.IndexDir)
 		fmt.Fprintf(w, "  %s %s\n", p.dim("artifact discover --write default:"), result.ArtifactLocations.DiscoverConfigPath)
@@ -477,6 +478,78 @@ func renderCompactStatusDetails(w io.Writer, result *statusResult) {
 	for _, guidance := range result.Guidance {
 		fmt.Fprintf(w, "  %s %s\n", p.arrow(), guidance)
 	}
+}
+
+func renderStatusGovernanceHotspots(w io.Writer, hotspots *index.GovernanceHotspots) {
+	lines := statusGovernanceHotspotLines(hotspots)
+	if len(lines) == 0 {
+		return
+	}
+
+	p := presentationForWriter(w)
+	fmt.Fprintf(w, "  %s\n", p.white("GOVERNANCE HOTSPOTS"))
+	for i, line := range lines {
+		fmt.Fprintf(w, "  %s %s\n", p.treeItem(i == len(lines)-1), line)
+	}
+}
+
+func statusGovernanceHotspotLines(hotspots *index.GovernanceHotspots) []string {
+	if hotspots == nil {
+		return nil
+	}
+
+	lines := make([]string, 0, len(hotspots.HighFanOutSpecs)+len(hotspots.WeakLinkArtifacts)+len(hotspots.MultiGovernedArtifacts))
+	for _, hotspot := range hotspots.HighFanOutSpecs {
+		line := fmt.Sprintf("fan-out spec %s", hotspot.Ref)
+		if hotspot.Title != "" {
+			line += " · " + hotspot.Title
+		}
+		line += fmt.Sprintf(" | %d applies_to edges", hotspot.AppliesToCount)
+		if weakEdges := hotspot.InferredEdgeCount + hotspot.AmbiguousEdgeCount; weakEdges > 0 {
+			line += fmt.Sprintf(" | %d weak edges", weakEdges)
+		}
+		lines = append(lines, line)
+	}
+	for _, hotspot := range hotspots.WeakLinkArtifacts {
+		line := fmt.Sprintf("weak-link artifact %s | %d governing specs", hotspot.Ref, hotspot.GoverningSpecCount)
+		if hotspot.SourceRef != "" && hotspot.SourceRef != hotspot.Ref {
+			line += " | " + displaySourcePath(hotspot.SourceRef)
+		}
+		if hotspot.InferredEdgeCount > 0 {
+			line += fmt.Sprintf(" | %d inferred", hotspot.InferredEdgeCount)
+		}
+		if hotspot.AmbiguousEdgeCount > 0 {
+			line += fmt.Sprintf(" | %d ambiguous", hotspot.AmbiguousEdgeCount)
+		}
+		if specs := formatGovernanceHotspotSpecRefs(hotspot.GoverningSpecs, 3); specs != "" {
+			line += " | " + specs
+		}
+		lines = append(lines, line)
+	}
+	for _, hotspot := range hotspots.MultiGovernedArtifacts {
+		line := fmt.Sprintf("multi-governed artifact %s | %d governing specs", hotspot.Ref, hotspot.GoverningSpecCount)
+		if hotspot.SourceRef != "" && hotspot.SourceRef != hotspot.Ref {
+			line += " | " + displaySourcePath(hotspot.SourceRef)
+		}
+		if weakEdges := hotspot.InferredEdgeCount + hotspot.AmbiguousEdgeCount; weakEdges > 0 {
+			line += fmt.Sprintf(" | %d weak edges", weakEdges)
+		}
+		if specs := formatGovernanceHotspotSpecRefs(hotspot.GoverningSpecs, 3); specs != "" {
+			line += " | " + specs
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func formatGovernanceHotspotSpecRefs(refs []string, limit int) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	if limit <= 0 || len(refs) <= limit {
+		return strings.Join(refs, ", ")
+	}
+	return fmt.Sprintf("%s +%d more", strings.Join(refs[:limit], ", "), len(refs)-limit)
 }
 
 func renderSpecFamilies(w io.Writer, families *index.FamilyResult) {

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -213,6 +213,52 @@ func TestRenderStatusResultCompactSuppressesVerboseSections(t *testing.T) {
 	}
 }
 
+func TestRenderStatusResultIncludesGovernanceHotspots(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	renderStatusResult(&stdout, &statusResult{
+		EmbedderProvider: "fixture",
+		IndexExists:      true,
+		SpecCount:        3,
+		DocCount:         0,
+		ChunkCount:       9,
+		GovernanceHotspots: &index.GovernanceHotspots{
+			HighFanOutSpecs: []index.GovernanceSpecHotspot{
+				{Ref: "SPEC-300", Title: "Fanout Governance", AppliesToCount: 4},
+			},
+			WeakLinkArtifacts: []index.GovernanceArtifactHotspot{
+				{
+					Ref:                "code://src/service/weak.go",
+					GoverningSpecCount: 2,
+					InferredEdgeCount:  1,
+					AmbiguousEdgeCount: 1,
+					GoverningSpecs:     []string{"SPEC-100", "SPEC-200"},
+				},
+			},
+			MultiGovernedArtifacts: []index.GovernanceArtifactHotspot{
+				{
+					Ref:                "code://src/service/handler.go",
+					GoverningSpecCount: 2,
+					GoverningSpecs:     []string{"SPEC-100", "SPEC-200"},
+				},
+			},
+		},
+	})
+
+	output := stdout.String()
+	for _, want := range []string{
+		"GOVERNANCE HOTSPOTS",
+		"fan-out spec SPEC-300 · Fanout Governance | 4 applies_to edges",
+		"weak-link artifact code://src/service/weak.go | 2 governing specs | 1 inferred | 1 ambiguous | SPEC-100, SPEC-200",
+		"multi-governed artifact code://src/service/handler.go | 2 governing specs | SPEC-100, SPEC-200",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("renderStatusResult() output %q does not contain %q", output, want)
+		}
+	}
+}
+
 func TestRenderCommandTableSearchSpecs(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -19,25 +19,26 @@ type statusRequest struct {
 }
 
 type statusResult struct {
-	WorkspaceRoot     string                     `json:"workspace_root"`
-	ConfigPath        string                     `json:"config_path"`
-	EmbedderProvider  string                     `json:"embedder_provider,omitempty"`
-	AnalysisProvider  string                     `json:"analysis_provider,omitempty"`
-	RuntimeConfig     *statusRuntimeConfig       `json:"runtime_config,omitempty"`
-	ConfigResolution  *configResolution          `json:"config_resolution,omitempty"`
-	IndexPath         string                     `json:"index_path"`
-	IndexExists       bool                       `json:"index_exists"`
-	Freshness         *index.FreshnessStatus     `json:"freshness,omitempty"`
-	SpecCount         int                        `json:"spec_count"`
-	DocCount          int                        `json:"doc_count"`
-	ChunkCount        int                        `json:"chunk_count"`
-	Repos             []index.RepoCoverage       `json:"repo_coverage,omitempty"`
-	ArtifactLocations *statusArtifactLocation    `json:"artifact_locations,omitempty"`
-	RelationGraph     *index.RelationGraphStatus `json:"relation_graph,omitempty"`
-	Families          *index.FamilyResult        `json:"families,omitempty"`
-	Runtime           *runtimeprobe.Result       `json:"runtime,omitempty"`
-	Guidance          []string                   `json:"guidance,omitempty"`
-	Compact           bool                       `json:"-"`
+	WorkspaceRoot      string                     `json:"workspace_root"`
+	ConfigPath         string                     `json:"config_path"`
+	EmbedderProvider   string                     `json:"embedder_provider,omitempty"`
+	AnalysisProvider   string                     `json:"analysis_provider,omitempty"`
+	RuntimeConfig      *statusRuntimeConfig       `json:"runtime_config,omitempty"`
+	ConfigResolution   *configResolution          `json:"config_resolution,omitempty"`
+	IndexPath          string                     `json:"index_path"`
+	IndexExists        bool                       `json:"index_exists"`
+	Freshness          *index.FreshnessStatus     `json:"freshness,omitempty"`
+	SpecCount          int                        `json:"spec_count"`
+	DocCount           int                        `json:"doc_count"`
+	ChunkCount         int                        `json:"chunk_count"`
+	Repos              []index.RepoCoverage       `json:"repo_coverage,omitempty"`
+	GovernanceHotspots *index.GovernanceHotspots  `json:"governance_hotspots,omitempty"`
+	ArtifactLocations  *statusArtifactLocation    `json:"artifact_locations,omitempty"`
+	RelationGraph      *index.RelationGraphStatus `json:"relation_graph,omitempty"`
+	Families           *index.FamilyResult        `json:"families,omitempty"`
+	Runtime            *runtimeprobe.Result       `json:"runtime,omitempty"`
+	Guidance           []string                   `json:"guidance,omitempty"`
+	Compact            bool                       `json:"-"`
 }
 
 type statusRuntimeConfig struct {
@@ -164,23 +165,24 @@ func newStatusResult(result *app.StatusResult, resolution *configResolution) *st
 	guidance := append([]string(nil), result.Guidance...)
 	guidance = append(guidance, statusResolutionGuidance(result.ConfigPath, resolution)...)
 	return &statusResult{
-		WorkspaceRoot:     result.WorkspaceRoot,
-		ConfigPath:        result.ConfigPath,
-		EmbedderProvider:  result.EmbedderProvider,
-		AnalysisProvider:  result.AnalysisProvider,
-		RuntimeConfig:     newStatusRuntimeConfig(result.RuntimeConfig),
-		ConfigResolution:  resolution,
-		IndexPath:         result.Index.IndexPath,
-		IndexExists:       result.Index.Exists,
-		Freshness:         result.Freshness,
-		SpecCount:         result.Index.SpecCount,
-		DocCount:          result.Index.DocCount,
-		ChunkCount:        result.Index.ChunkCount,
-		Repos:             append([]index.RepoCoverage(nil), result.Index.Repos...),
-		ArtifactLocations: buildStatusArtifactLocations(result.WorkspaceRoot, result.ConfigPath, result.Index.IndexPath, resolution),
-		RelationGraph:     result.RelationGraph,
-		Runtime:           result.Runtime,
-		Guidance:          guidance,
+		WorkspaceRoot:      result.WorkspaceRoot,
+		ConfigPath:         result.ConfigPath,
+		EmbedderProvider:   result.EmbedderProvider,
+		AnalysisProvider:   result.AnalysisProvider,
+		RuntimeConfig:      newStatusRuntimeConfig(result.RuntimeConfig),
+		ConfigResolution:   resolution,
+		IndexPath:          result.Index.IndexPath,
+		IndexExists:        result.Index.Exists,
+		Freshness:          result.Freshness,
+		SpecCount:          result.Index.SpecCount,
+		DocCount:           result.Index.DocCount,
+		ChunkCount:         result.Index.ChunkCount,
+		Repos:              append([]index.RepoCoverage(nil), result.Index.Repos...),
+		GovernanceHotspots: result.Index.GovernanceHotspots,
+		ArtifactLocations:  buildStatusArtifactLocations(result.WorkspaceRoot, result.ConfigPath, result.Index.IndexPath, resolution),
+		RelationGraph:      result.RelationGraph,
+		Runtime:            result.Runtime,
+		Guidance:           guidance,
 	}
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/source"
 )
 
 func TestRunStatusReportsMissingIndex(t *testing.T) {
@@ -239,6 +244,84 @@ func TestRunStatusJSON(t *testing.T) {
 	}
 }
 
+func TestRunStatusJSONIncludesGovernanceHotspots(t *testing.T) {
+	repo := writeGovernanceHotspotStatusWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus([]string{"--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0 (stdout: %q, stderr: %q)", exitCode, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runStatus() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result struct {
+			GovernanceHotspots struct {
+				HighFanOutSpecs []struct {
+					Ref            string `json:"ref"`
+					AppliesToCount int    `json:"applies_to_count"`
+				} `json:"high_fan_out_specs"`
+				WeakLinkArtifacts []struct {
+					Ref                string `json:"ref"`
+					ExtractedEdgeCount int    `json:"extracted_edge_count"`
+					InferredEdgeCount  int    `json:"inferred_edge_count"`
+					AmbiguousEdgeCount int    `json:"ambiguous_edge_count"`
+				} `json:"weak_link_artifacts"`
+				MultiGovernedArtifacts []struct {
+					Ref                string   `json:"ref"`
+					GoverningSpecCount int      `json:"governing_spec_count"`
+					GoverningSpecs     []string `json:"governing_specs"`
+				} `json:"multi_governed_artifacts"`
+			} `json:"governance_hotspots"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if len(payload.Result.GovernanceHotspots.HighFanOutSpecs) == 0 {
+		t.Fatalf("high_fan_out_specs = %+v, want hotspot output", payload.Result.GovernanceHotspots)
+	}
+	if got, want := payload.Result.GovernanceHotspots.HighFanOutSpecs[0].Ref, "SPEC-300"; got != want {
+		t.Fatalf("high_fan_out_specs[0].ref = %q, want %q", got, want)
+	}
+	if got, want := payload.Result.GovernanceHotspots.HighFanOutSpecs[0].AppliesToCount, 4; got != want {
+		t.Fatalf("high_fan_out_specs[0].applies_to_count = %d, want %d", got, want)
+	}
+	if got, want := payload.Result.GovernanceHotspots.WeakLinkArtifacts[0].Ref, "code://src/service/weak.go"; got != want {
+		t.Fatalf("weak_link_artifacts[0].ref = %q, want %q", got, want)
+	}
+	if payload.Result.GovernanceHotspots.WeakLinkArtifacts[0].ExtractedEdgeCount != 0 {
+		t.Fatalf("weak_link_artifacts[0] = %+v, want zero extracted edges", payload.Result.GovernanceHotspots.WeakLinkArtifacts[0])
+	}
+	var handlerHotspot *struct {
+		Ref                string   `json:"ref"`
+		GoverningSpecCount int      `json:"governing_spec_count"`
+		GoverningSpecs     []string `json:"governing_specs"`
+	}
+	for i := range payload.Result.GovernanceHotspots.MultiGovernedArtifacts {
+		artifact := &payload.Result.GovernanceHotspots.MultiGovernedArtifacts[i]
+		if artifact.Ref == "code://src/service/handler.go" {
+			handlerHotspot = artifact
+			break
+		}
+	}
+	if handlerHotspot == nil {
+		t.Fatalf("multi_governed_artifacts = %+v, want handler hotspot", payload.Result.GovernanceHotspots.MultiGovernedArtifacts)
+	}
+	if got, want := handlerHotspot.GoverningSpecCount, 2; got != want {
+		t.Fatalf("multi_governed_artifacts[0].governing_spec_count = %d, want %d", got, want)
+	}
+}
+
 func TestRunStatusJSONIncludesRepoCoverage(t *testing.T) {
 	repo := writeMultiRepoSearchWorkspace(t)
 
@@ -396,6 +479,111 @@ func TestRunStatusJSONIncludesRuntimeProbeResults(t *testing.T) {
 	}
 	if got, want := payload.Result.Runtime.Checks[1].Status, "disabled"; got != want {
 		t.Fatalf("checks[1].status = %q, want %q", got, want)
+	}
+}
+
+func writeGovernanceHotspotStatusWorkspace(t *testing.T) string {
+	t.Helper()
+
+	repo := t.TempDir()
+	indexPath := filepath.Join(repo, ".pituitary", "pituitary.db")
+	configPath := filepath.Join(repo, "pituitary.toml")
+	mustWriteFileCmd(t, configPath, fmt.Sprintf(`
+[workspace]
+root = "."
+index_path = "%s"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`, filepath.ToSlash(indexPath)))
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "spec-100", "spec.toml"), `
+id = "SPEC-100"
+title = "Handler Governance"
+status = "accepted"
+domain = "api"
+body = "body.md"
+applies_to = [
+  "code://src/service/handler.go",
+  "code://src/service/shared.go",
+]
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "spec-100", "body.md"), `
+# Handler Governance
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "spec-200", "spec.toml"), `
+id = "SPEC-200"
+title = "Worker Governance"
+status = "accepted"
+domain = "api"
+body = "body.md"
+applies_to = [
+  "code://src/service/handler.go",
+  "code://src/service/worker.go",
+]
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "spec-200", "body.md"), `
+# Worker Governance
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "spec-300", "spec.toml"), `
+id = "SPEC-300"
+title = "Fanout Governance"
+status = "accepted"
+domain = "api"
+body = "body.md"
+applies_to = [
+  "code://src/service/fanout-a.go",
+  "code://src/service/fanout-b.go",
+  "code://src/service/fanout-c.go",
+  "code://src/service/fanout-d.go",
+]
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "spec-300", "body.md"), `
+# Fanout Governance
+`)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+	insertGovernanceHotspotStatusEdge(t, cfg.Workspace.ResolvedIndexPath, "SPEC-100", "code://src/service/weak.go", "inferred", "inferred", 0.7)
+	insertGovernanceHotspotStatusEdge(t, cfg.Workspace.ResolvedIndexPath, "SPEC-200", "code://src/service/weak.go", "inferred", "ambiguous", 0.5)
+	return repo
+}
+
+func insertGovernanceHotspotStatusEdge(t *testing.T, indexPath, fromRef, toRef, edgeSource, confidence string, confidenceScore float64) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", "file:"+filepath.ToSlash(indexPath)+"?mode=rw")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(
+		`INSERT OR REPLACE INTO edges (from_ref, to_ref, edge_type, edge_source, confidence, confidence_score) VALUES (?, ?, 'applies_to', ?, ?, ?)`,
+		fromRef,
+		toRef,
+		edgeSource,
+		confidence,
+		confidenceScore,
+	); err != nil {
+		t.Fatalf("insert hotspot edge %s -> %s: %v", fromRef, toRef, err)
 	}
 }
 

--- a/internal/index/status.go
+++ b/internal/index/status.go
@@ -262,8 +262,7 @@ SELECT
   COUNT(DISTINCT e.from_ref) AS governing_spec_count,
   %s AS extracted_edge_count,
   %s AS inferred_edge_count,
-  %s AS ambiguous_edge_count,
-  COALESCE(GROUP_CONCAT(DISTINCT e.from_ref), '') AS governing_specs
+  %s AS ambiguous_edge_count
 FROM edges e
 JOIN artifacts s ON s.ref = e.from_ref
 LEFT JOIN artifacts a ON a.ref = e.to_ref
@@ -283,8 +282,7 @@ SELECT
   governing_spec_count,
   extracted_edge_count,
   inferred_edge_count,
-  ambiguous_edge_count,
-  governing_specs
+  ambiguous_edge_count
 FROM (%s)
 WHERE %s
 ORDER BY %s
@@ -299,7 +297,6 @@ LIMIT 5`, aggregateQuery, filter, orderBy)
 	hotspots := []GovernanceArtifactHotspot{}
 	for rows.Next() {
 		var hotspot GovernanceArtifactHotspot
-		var rawGoverningSpecs string
 		if err := rows.Scan(
 			&hotspot.Ref,
 			&hotspot.Title,
@@ -308,17 +305,73 @@ LIMIT 5`, aggregateQuery, filter, orderBy)
 			&hotspot.ExtractedEdgeCount,
 			&hotspot.InferredEdgeCount,
 			&hotspot.AmbiguousEdgeCount,
-			&rawGoverningSpecs,
 		); err != nil {
 			return nil, err
 		}
-		hotspot.GoverningSpecs = splitGovernanceSpecRefs(rawGoverningSpecs)
 		hotspots = append(hotspots, hotspot)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+
+	refs := make([]string, 0, len(hotspots))
+	for _, hotspot := range hotspots {
+		refs = append(refs, hotspot.Ref)
+	}
+	specRefsByArtifact, err := loadGovernanceSpecRefsByArtifactContext(ctx, db, refs)
+	if err != nil {
+		return nil, err
+	}
+	for i := range hotspots {
+		hotspots[i].GoverningSpecs = specRefsByArtifact[hotspots[i].Ref]
+	}
 	return hotspots, nil
+}
+
+func loadGovernanceSpecRefsByArtifactContext(ctx context.Context, db *sql.DB, refs []string) (map[string][]string, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(refs)), ",")
+	query := fmt.Sprintf(`
+SELECT
+  e.to_ref,
+  e.from_ref
+FROM edges e
+JOIN artifacts s ON s.ref = e.from_ref
+WHERE e.edge_type = 'applies_to'
+  AND s.kind = ?
+  AND s.status = ?
+  AND e.to_ref IN (%s)
+GROUP BY e.to_ref, e.from_ref
+ORDER BY e.to_ref, e.from_ref`, placeholders)
+
+	args := make([]any, 0, 2+len(refs))
+	args = append(args, model.ArtifactKindSpec, model.StatusAccepted)
+	for _, ref := range refs {
+		args = append(args, ref)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	specRefsByArtifact := make(map[string][]string, len(refs))
+	for rows.Next() {
+		var artifactRef string
+		var specRef string
+		if err := rows.Scan(&artifactRef, &specRef); err != nil {
+			return nil, err
+		}
+		specRefsByArtifact[artifactRef] = append(specRefsByArtifact[artifactRef], specRef)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return specRefsByArtifact, nil
 }
 
 func governanceExtractedEdgeExpr(hasConfidence bool) string {

--- a/internal/index/status.go
+++ b/internal/index/status.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/dusk-network/pituitary/internal/model"
 )
@@ -18,6 +20,7 @@ type Status struct {
 	ChunkCount         int                 `json:"chunk_count"`
 	Repos              []RepoCoverage      `json:"repo_coverage,omitempty"`
 	GovernanceCoverage *GovernanceCoverage `json:"governance_coverage,omitempty"`
+	GovernanceHotspots *GovernanceHotspots `json:"governance_hotspots,omitempty"`
 }
 
 // GovernanceCoverage reports the percentage of indexed source files that have
@@ -30,6 +33,35 @@ type GovernanceCoverage struct {
 	InferredEdges  int     `json:"inferred_edges"`
 	ExtractedEdges int     `json:"extracted_edges,omitempty"`
 	AmbiguousEdges int     `json:"ambiguous_edges,omitempty"`
+}
+
+// GovernanceHotspots surfaces governance-maintenance hotspots from the indexed
+// applies_to graph so operators can distinguish weak traceability from direct
+// contradiction-oriented findings.
+type GovernanceHotspots struct {
+	HighFanOutSpecs        []GovernanceSpecHotspot     `json:"high_fan_out_specs,omitempty"`
+	WeakLinkArtifacts      []GovernanceArtifactHotspot `json:"weak_link_artifacts,omitempty"`
+	MultiGovernedArtifacts []GovernanceArtifactHotspot `json:"multi_governed_artifacts,omitempty"`
+}
+
+type GovernanceSpecHotspot struct {
+	Ref                string `json:"ref"`
+	Title              string `json:"title,omitempty"`
+	AppliesToCount     int    `json:"applies_to_count"`
+	ExtractedEdgeCount int    `json:"extracted_edge_count,omitempty"`
+	InferredEdgeCount  int    `json:"inferred_edge_count,omitempty"`
+	AmbiguousEdgeCount int    `json:"ambiguous_edge_count,omitempty"`
+}
+
+type GovernanceArtifactHotspot struct {
+	Ref                string   `json:"ref"`
+	Title              string   `json:"title,omitempty"`
+	SourceRef          string   `json:"source_ref,omitempty"`
+	GoverningSpecCount int      `json:"governing_spec_count"`
+	ExtractedEdgeCount int      `json:"extracted_edge_count,omitempty"`
+	InferredEdgeCount  int      `json:"inferred_edge_count,omitempty"`
+	AmbiguousEdgeCount int      `json:"ambiguous_edge_count,omitempty"`
+	GoverningSpecs     []string `json:"governing_specs,omitempty"`
 }
 
 // ReadStatus inspects the configured index path and returns basic counts.
@@ -77,6 +109,10 @@ func ReadStatusContext(ctx context.Context, path string) (*Status, error) {
 		coverage, coverageErr := queryGovernanceCoverageContext(ctx, db)
 		if coverageErr == nil {
 			status.GovernanceCoverage = coverage
+		}
+		hotspots, hotspotErr := queryGovernanceHotspotsContext(ctx, db)
+		if hotspotErr == nil {
+			status.GovernanceHotspots = hotspots
 		}
 	}
 
@@ -128,4 +164,202 @@ func queryGovernanceCoverageContext(ctx context.Context, db *sql.DB) (*Governanc
 	}
 
 	return &coverage, nil
+}
+
+func queryGovernanceHotspotsContext(ctx context.Context, db *sql.DB) (*GovernanceHotspots, error) {
+	hasConfidence := hasEdgeConfidenceColumn(ctx, db)
+
+	highFanOutSpecs, err := queryGovernanceSpecHotspotsContext(ctx, db, hasConfidence)
+	if err != nil {
+		return nil, err
+	}
+	weakLinkArtifacts, err := queryGovernanceArtifactHotspotsContext(
+		ctx,
+		db,
+		hasConfidence,
+		`extracted_edge_count = 0 AND (inferred_edge_count > 0 OR ambiguous_edge_count > 0)`,
+		`ambiguous_edge_count DESC, inferred_edge_count DESC, governing_spec_count DESC, ref`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	multiGovernedArtifacts, err := queryGovernanceArtifactHotspotsContext(
+		ctx,
+		db,
+		hasConfidence,
+		`governing_spec_count > 1`,
+		`governing_spec_count DESC, ambiguous_edge_count DESC, inferred_edge_count DESC, ref`,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(highFanOutSpecs) == 0 && len(weakLinkArtifacts) == 0 && len(multiGovernedArtifacts) == 0 {
+		return nil, nil
+	}
+	return &GovernanceHotspots{
+		HighFanOutSpecs:        highFanOutSpecs,
+		WeakLinkArtifacts:      weakLinkArtifacts,
+		MultiGovernedArtifacts: multiGovernedArtifacts,
+	}, nil
+}
+
+func queryGovernanceSpecHotspotsContext(ctx context.Context, db *sql.DB, hasConfidence bool) ([]GovernanceSpecHotspot, error) {
+	query := fmt.Sprintf(`
+SELECT
+  s.ref,
+  COALESCE(s.title, ''),
+  COUNT(*) AS applies_to_count,
+  %s AS extracted_edge_count,
+  %s AS inferred_edge_count,
+  %s AS ambiguous_edge_count
+FROM edges e
+JOIN artifacts s ON s.ref = e.from_ref
+WHERE e.edge_type = 'applies_to'
+  AND s.kind = ?
+  AND s.status = ?
+GROUP BY s.ref, s.title
+ORDER BY applies_to_count DESC, s.ref
+LIMIT 5`,
+		governanceExtractedEdgeExpr(hasConfidence),
+		governanceInferredEdgeExpr(hasConfidence),
+		governanceAmbiguousEdgeExpr(hasConfidence),
+	)
+
+	rows, err := db.QueryContext(ctx, query, model.ArtifactKindSpec, model.StatusAccepted)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	hotspots := []GovernanceSpecHotspot{}
+	for rows.Next() {
+		var hotspot GovernanceSpecHotspot
+		if err := rows.Scan(
+			&hotspot.Ref,
+			&hotspot.Title,
+			&hotspot.AppliesToCount,
+			&hotspot.ExtractedEdgeCount,
+			&hotspot.InferredEdgeCount,
+			&hotspot.AmbiguousEdgeCount,
+		); err != nil {
+			return nil, err
+		}
+		hotspots = append(hotspots, hotspot)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return hotspots, nil
+}
+
+func queryGovernanceArtifactHotspotsContext(ctx context.Context, db *sql.DB, hasConfidence bool, filter string, orderBy string) ([]GovernanceArtifactHotspot, error) {
+	aggregateQuery := fmt.Sprintf(`
+SELECT
+  e.to_ref AS ref,
+  COALESCE(a.title, '') AS title,
+  COALESCE(a.source_ref, '') AS source_ref,
+  COUNT(DISTINCT e.from_ref) AS governing_spec_count,
+  %s AS extracted_edge_count,
+  %s AS inferred_edge_count,
+  %s AS ambiguous_edge_count,
+  COALESCE(GROUP_CONCAT(DISTINCT e.from_ref), '') AS governing_specs
+FROM edges e
+JOIN artifacts s ON s.ref = e.from_ref
+LEFT JOIN artifacts a ON a.ref = e.to_ref
+WHERE e.edge_type = 'applies_to'
+  AND s.kind = ?
+  AND s.status = ?
+GROUP BY e.to_ref, a.title, a.source_ref`,
+		governanceExtractedEdgeExpr(hasConfidence),
+		governanceInferredEdgeExpr(hasConfidence),
+		governanceAmbiguousEdgeExpr(hasConfidence),
+	)
+	query := fmt.Sprintf(`
+SELECT
+  ref,
+  title,
+  source_ref,
+  governing_spec_count,
+  extracted_edge_count,
+  inferred_edge_count,
+  ambiguous_edge_count,
+  governing_specs
+FROM (%s)
+WHERE %s
+ORDER BY %s
+LIMIT 5`, aggregateQuery, filter, orderBy)
+
+	rows, err := db.QueryContext(ctx, query, model.ArtifactKindSpec, model.StatusAccepted)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	hotspots := []GovernanceArtifactHotspot{}
+	for rows.Next() {
+		var hotspot GovernanceArtifactHotspot
+		var rawGoverningSpecs string
+		if err := rows.Scan(
+			&hotspot.Ref,
+			&hotspot.Title,
+			&hotspot.SourceRef,
+			&hotspot.GoverningSpecCount,
+			&hotspot.ExtractedEdgeCount,
+			&hotspot.InferredEdgeCount,
+			&hotspot.AmbiguousEdgeCount,
+			&rawGoverningSpecs,
+		); err != nil {
+			return nil, err
+		}
+		hotspot.GoverningSpecs = splitGovernanceSpecRefs(rawGoverningSpecs)
+		hotspots = append(hotspots, hotspot)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return hotspots, nil
+}
+
+func governanceExtractedEdgeExpr(hasConfidence bool) string {
+	if hasConfidence {
+		return `SUM(CASE WHEN e.confidence = 'extracted' THEN 1 ELSE 0 END)`
+	}
+	return `SUM(CASE WHEN e.edge_source = 'manual' THEN 1 ELSE 0 END)`
+}
+
+func governanceInferredEdgeExpr(hasConfidence bool) string {
+	if hasConfidence {
+		return `SUM(CASE WHEN e.confidence = 'inferred' THEN 1 ELSE 0 END)`
+	}
+	return `SUM(CASE WHEN e.edge_source = 'inferred' THEN 1 ELSE 0 END)`
+}
+
+func governanceAmbiguousEdgeExpr(hasConfidence bool) string {
+	if hasConfidence {
+		return `SUM(CASE WHEN e.confidence = 'ambiguous' THEN 1 ELSE 0 END)`
+	}
+	return `0`
+}
+
+func splitGovernanceSpecRefs(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	values := strings.Split(raw, ",")
+	refs := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		ref := strings.TrimSpace(value)
+		if ref == "" {
+			continue
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	return refs
 }

--- a/internal/index/status_test.go
+++ b/internal/index/status_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -90,6 +91,56 @@ func TestReadStatusReportsRepoCoverage(t *testing.T) {
 		if got, want := repo.DocCount, 1; got != want {
 			t.Fatalf("repo %q doc_count = %d, want %d", repoID, got, want)
 		}
+	}
+}
+
+func TestReadStatusReportsGovernanceHotspots(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadGovernanceHotspotFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+	insertStatusEdge(t, cfg.Workspace.ResolvedIndexPath, "SPEC-100", "code://src/service/weak.go", "inferred", "inferred", 0.7)
+	insertStatusEdge(t, cfg.Workspace.ResolvedIndexPath, "SPEC-200", "code://src/service/weak.go", "inferred", "ambiguous", 0.5)
+
+	status, err := ReadStatus(cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("ReadStatus() error = %v", err)
+	}
+	if status.GovernanceHotspots == nil {
+		t.Fatal("status.GovernanceHotspots = nil, want hotspot summary")
+	}
+
+	fanOut, ok := findGovernanceSpecHotspot(status.GovernanceHotspots.HighFanOutSpecs, "SPEC-300")
+	if !ok {
+		t.Fatalf("high fan-out specs = %+v, want SPEC-300", status.GovernanceHotspots.HighFanOutSpecs)
+	}
+	if got, want := fanOut.AppliesToCount, 4; got != want {
+		t.Fatalf("SPEC-300 applies_to_count = %d, want %d", got, want)
+	}
+
+	weakLink, ok := findGovernanceArtifactHotspot(status.GovernanceHotspots.WeakLinkArtifacts, "code://src/service/weak.go")
+	if !ok {
+		t.Fatalf("weak link artifacts = %+v, want weak.go", status.GovernanceHotspots.WeakLinkArtifacts)
+	}
+	if weakLink.ExtractedEdgeCount != 0 || weakLink.InferredEdgeCount != 1 || weakLink.AmbiguousEdgeCount != 1 {
+		t.Fatalf("weak link hotspot = %+v, want 0 extracted / 1 inferred / 1 ambiguous", weakLink)
+	}
+
+	multiGoverned, ok := findGovernanceArtifactHotspot(status.GovernanceHotspots.MultiGovernedArtifacts, "code://src/service/handler.go")
+	if !ok {
+		t.Fatalf("multi-governed artifacts = %+v, want handler.go", status.GovernanceHotspots.MultiGovernedArtifacts)
+	}
+	if got, want := multiGoverned.GoverningSpecCount, 2; got != want {
+		t.Fatalf("handler.go governing_spec_count = %d, want %d", got, want)
+	}
+	if got, want := multiGoverned.GoverningSpecs, []string{"SPEC-100", "SPEC-200"}; !equalStrings(got, want) {
+		t.Fatalf("handler.go governing_specs = %#v, want %#v", got, want)
 	}
 }
 
@@ -198,4 +249,137 @@ The default rate limit is 100 requests per minute.
 		tb.Fatalf("config.Load() error = %v", err)
 	}
 	return cfg
+}
+
+func loadGovernanceHotspotFixtureConfig(tb testing.TB) *config.Config {
+	tb.Helper()
+
+	root := tb.TempDir()
+	indexPath := filepath.Join(root, "pituitary.db")
+	configPath := filepath.Join(root, "pituitary.toml")
+	mustWriteFile(tb, configPath, fmt.Sprintf(`
+[workspace]
+root = "%s"
+index_path = "%s"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`, filepath.ToSlash(root), filepath.ToSlash(indexPath)))
+	mustWriteFile(tb, filepath.Join(root, "specs", "spec-100", "spec.toml"), `
+id = "SPEC-100"
+title = "Handler Governance"
+status = "accepted"
+domain = "api"
+body = "body.md"
+applies_to = [
+  "code://src/service/handler.go",
+  "code://src/service/shared.go",
+]
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "spec-100", "body.md"), `
+# Handler Governance
+
+Shared handler behavior is explicitly governed.
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "spec-200", "spec.toml"), `
+id = "SPEC-200"
+title = "Worker Governance"
+status = "accepted"
+domain = "api"
+body = "body.md"
+applies_to = [
+  "code://src/service/handler.go",
+  "code://src/service/worker.go",
+]
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "spec-200", "body.md"), `
+# Worker Governance
+
+Worker behavior overlaps on the shared handler path.
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "spec-300", "spec.toml"), `
+id = "SPEC-300"
+title = "Fanout Governance"
+status = "accepted"
+domain = "api"
+body = "body.md"
+applies_to = [
+  "code://src/service/fanout-a.go",
+  "code://src/service/fanout-b.go",
+  "code://src/service/fanout-c.go",
+  "code://src/service/fanout-d.go",
+]
+`)
+	mustWriteFile(tb, filepath.Join(root, "specs", "spec-300", "body.md"), `
+# Fanout Governance
+
+This spec governs a broader surface.
+`)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
+}
+
+func insertStatusEdge(tb testing.TB, indexPath, fromRef, toRef, edgeSource, confidence string, confidenceScore float64) {
+	tb.Helper()
+
+	db, err := openReadWriteContext(context.Background(), indexPath)
+	if err != nil {
+		tb.Fatalf("openReadWriteContext() error = %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(
+		context.Background(),
+		`INSERT OR REPLACE INTO edges (from_ref, to_ref, edge_type, edge_source, confidence, confidence_score) VALUES (?, ?, 'applies_to', ?, ?, ?)`,
+		fromRef,
+		toRef,
+		edgeSource,
+		confidence,
+		confidenceScore,
+	); err != nil {
+		tb.Fatalf("insert hotspot edge %s -> %s: %v", fromRef, toRef, err)
+	}
+}
+
+func findGovernanceSpecHotspot(items []GovernanceSpecHotspot, ref string) (GovernanceSpecHotspot, bool) {
+	for _, item := range items {
+		if item.Ref == ref {
+			return item, true
+		}
+	}
+	return GovernanceSpecHotspot{}, false
+}
+
+func findGovernanceArtifactHotspot(items []GovernanceArtifactHotspot, ref string) (GovernanceArtifactHotspot, bool) {
+	for _, item := range items {
+		if item.Ref == ref {
+			return item, true
+		}
+	}
+	return GovernanceArtifactHotspot{}, false
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- add status governance hotspot JSON for high fan-out specs, weak-link artifacts, and multi-governed artifacts
- render hotspot summaries in status text output
- cover hotspot query and CLI JSON output in tests

## Testing
- go test ./internal/index -run 'Status|Governance'
- go test ./cmd -run 'Status|RenderStatus'
- go test ./internal/index ./cmd

Closes #305