### PR TITLE
docs: clarify shipped slice and dogfood contract scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="#what-it-catches">What It Catches</a> · <a href="#quick-start">Quick Start</a> · <a href="#stop-your-agent-from-building-on-stale-decisions">Agent</a> · <a href="#use-it-in-ci">CI</a> · <a href="docs/cheatsheet.md">Cheatsheet</a> · <a href="docs/reference.md">Reference</a>
+  <a href="#what-it-catches">What It Catches</a> · <a href="#quick-start">Quick Start</a> · <a href="#stop-your-agent-from-building-on-stale-decisions">Agent</a> · <a href="#optional-ci-wiring">CI</a> · <a href="docs/cheatsheet.md">Cheatsheet</a> · <a href="docs/reference.md">Reference</a>
 </p>
 
 ---
@@ -29,6 +29,8 @@
 [Watch on asciinema](https://asciinema.org/a/4NBiD3tUyuwMWooT) for the interactive version.
 
 Single binary. No Docker. No API keys required. One SQLite file.
+
+The core shipped slice is local and CLI-first. The MCP server, CI wiring, and provider-backed semantic runtimes are optional wrappers around that same deterministic core.
 
 ## What It Catches
 
@@ -62,7 +64,7 @@ Pituitary starts as a drift detector. As your intent corpus grows, it becomes th
 
 **Spec families.** Community detection on the dependency graph discovers natural governance clusters. Coverage gaps between families are the highest-risk ungoverned areas.
 
-**Governance protocol for AI.** The MCP server teaches your AI assistant *when* to check governance — before modifying files, before committing, after accepting specs, when writing docs — not just how.
+**Governance protocol for AI.** The optional MCP wrapper teaches your AI assistant *when* to check governance — before modifying files, before committing, after accepting specs, when writing docs — not just how.
 
 ## Quick Start
 
@@ -131,7 +133,7 @@ sudo install pituitary /usr/local/bin/
 
 Your agent writes specs, reviews PRs, and proposes changes — but it doesn't know what's already been decided. Pituitary gives it that context. The governance protocol teaches it when to check, not just how.
 
-### MCP Server (Claude Code, Cursor, Windsurf, or any MCP client)
+### Optional MCP Server (Claude Code, Cursor, Windsurf, or any MCP client)
 
 ```json
 {
@@ -168,9 +170,9 @@ The repo's [AGENTS.md](AGENTS.md) is the canonical project policy. Tools that re
 
 See [skills/pituitary-cli/README.md](skills/pituitary-cli/README.md) for the full install guide, request templates, and security notes.
 
-## Use It in CI
+## Optional CI Wiring
 
-For pull requests that change specs, use the shipped GitHub Action to run `review-spec` and post the report as a PR comment:
+If you already use GitHub Actions, you can wrap the same local CLI workflow in the checked-in action and post `review-spec` output as a PR comment:
 
 ```yaml
 permissions:

--- a/docs/development/architecture-guide.md
+++ b/docs/development/architecture-guide.md
@@ -2,13 +2,14 @@
 
 This guide is the contributor-friendly version of [ARCHITECTURE.md](../../ARCHITECTURE.md). It focuses on how the current codebase is actually organized and how data moves through it.
 
-For product boundaries and full contract details, read `ARCHITECTURE.md`. Use this file when you want to understand where code should go.
+For canonical product boundaries and full contract details, read `ARCHITECTURE.md`. This guide keeps a short summary of the current shipped slice because contributors still need that context when deciding where code should go.
 
 ## What Pituitary Does
 
 Pituitary indexes a local workspace of:
 
 - spec bundles: `spec.toml` plus `body.md`
+- inferred Markdown contracts
 - Markdown docs
 
 It then answers questions over that indexed corpus:
@@ -100,6 +101,7 @@ Loads configured sources from disk and normalizes them into canonical records.
 Responsibilities:
 
 - discover `spec.toml` bundles
+- discover Markdown contracts
 - discover Markdown docs
 - validate malformed bundles
 - derive canonical refs and `source_ref` values
@@ -173,6 +175,8 @@ The repo includes a small fixture workspace:
 - `docs/`
 - `pituitary.toml`
 - `testdata/bootstrap_expectations.json`
+
+The repo also includes a self-dogfood contract slice under `dogfood/contracts/` that governs the README and contributor docs.
 
 That workspace is used across tests and benchmarks. When changing behavior, prefer extending the existing fixtures and expectations instead of inventing parallel test-only worlds unless the case is truly isolated.
 

--- a/dogfood/contracts/contributor-workflow.md
+++ b/dogfood/contracts/contributor-workflow.md
@@ -1,6 +1,11 @@
 Ref: DOG-002
 Status: accepted
 Domain: developer-experience
+Applies To:
+- doc://docs/development/adding-a-command
+- doc://docs/development/architecture-guide
+- doc://docs/development/prerequisites
+- doc://docs/development/testing-guide
 
 # Pituitary Contributor Workflow Contract
 

--- a/dogfood/contracts/product-scope.md
+++ b/dogfood/contracts/product-scope.md
@@ -1,6 +1,10 @@
 Ref: DOG-001
 Status: accepted
 Domain: product
+Applies To:
+- doc://README
+- doc://ARCHITECTURE
+- doc://docs/development/architecture-guide
 
 # Pituitary Product Scope Contract
 


### PR DESCRIPTION
## Summary\n- clarify the README around the shipped local CLI-first slice and optional wrappers\n- tighten the contributor architecture guide around inferred markdown contracts and dogfood coverage\n- declare applies_to coverage for the product and contributor workflow dogfood contracts\n\n## Validation\n- git diff --check\n- rebase onto github/main