### PR TITLE
refactor(index): rebuild on Stroma schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.9
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6
+	github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196
 	github.com/google/go-github/v79 v79.0.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196 h1:1TULfQD0OA8zpd7+4QaXpNcoosAkytPKkI+Xld2cTZs=
+github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/chunk/markdown.go
+++ b/internal/chunk/markdown.go
@@ -1,112 +1,11 @@
 package chunk
 
-import (
-	"strings"
-)
+import stchunk "github.com/dusk-network/stroma/chunk"
 
 // Section is one heading-aware Markdown chunk.
-type Section struct {
-	Heading string
-	Body    string
-}
-
-type heading struct {
-	Level int
-	Text  string
-}
+type Section = stchunk.Section
 
 // Markdown splits Markdown into heading-aware sections.
 func Markdown(title, body string) []Section {
-	body = strings.ReplaceAll(body, "\r\n", "\n")
-	lines := strings.Split(body, "\n")
-
-	var (
-		sections      []Section
-		stack         []heading
-		currentLines  []string
-		currentHeader string
-	)
-
-	flush := func() {
-		text := strings.TrimSpace(strings.Join(currentLines, "\n"))
-		currentLines = nil
-		if text == "" {
-			return
-		}
-
-		headingText := strings.TrimSpace(currentHeader)
-		if headingText == "" {
-			headingText = strings.TrimSpace(title)
-		}
-
-		sections = append(sections, Section{
-			Heading: headingText,
-			Body:    text,
-		})
-	}
-
-	for _, line := range lines {
-		level, text, ok := parseHeading(line)
-		if ok {
-			flush()
-			for len(stack) > 0 && stack[len(stack)-1].Level >= level {
-				stack = stack[:len(stack)-1]
-			}
-			stack = append(stack, heading{Level: level, Text: text})
-			currentHeader = joinHeadings(stack)
-			continue
-		}
-
-		currentLines = append(currentLines, line)
-	}
-
-	flush()
-
-	if len(sections) == 0 {
-		text := strings.TrimSpace(body)
-		if text == "" {
-			return nil
-		}
-		return []Section{{
-			Heading: strings.TrimSpace(title),
-			Body:    text,
-		}}
-	}
-
-	return sections
-}
-
-func parseHeading(line string) (int, string, bool) {
-	trimmed := strings.TrimSpace(line)
-	if trimmed == "" {
-		return 0, "", false
-	}
-
-	level := 0
-	for level < len(trimmed) && trimmed[level] == '#' {
-		level++
-	}
-	if level == 0 || level > 6 {
-		return 0, "", false
-	}
-	if len(trimmed) == level || trimmed[level] != ' ' {
-		return 0, "", false
-	}
-
-	text := strings.TrimSpace(trimmed[level+1:])
-	if text == "" {
-		return 0, "", false
-	}
-	return level, text, true
-}
-
-func joinHeadings(stack []heading) string {
-	parts := make([]string, 0, len(stack))
-	for _, item := range stack {
-		if item.Text == "" {
-			continue
-		}
-		parts = append(parts, item.Text)
-	}
-	return strings.Join(parts, " / ")
+	return stchunk.Markdown(title, body)
 }

--- a/internal/index/embedder.go
+++ b/internal/index/embedder.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/fnv"
-	"math"
 	"strings"
-	"unicode"
 
 	"github.com/dusk-network/pituitary/internal/config"
+	stembed "github.com/dusk-network/stroma/embed"
 )
 
 // DependencyUnavailableError indicates that a required runtime dependency
@@ -81,12 +79,7 @@ func DependencyUnavailableDetails(err error) map[string]any {
 }
 
 // Embedder generates embeddings for rebuild and query-time retrieval.
-type Embedder interface {
-	Fingerprint() string
-	Dimension(ctx context.Context) (int, error)
-	EmbedDocuments(ctx context.Context, texts []string) ([][]float64, error)
-	EmbedQueries(ctx context.Context, texts []string) ([][]float64, error)
-}
+type Embedder = stembed.Embedder
 
 // NewEmbedder resolves the configured embedder runtime.
 func NewEmbedder(provider config.RuntimeProvider) (Embedder, error) {
@@ -96,7 +89,11 @@ func NewEmbedder(provider config.RuntimeProvider) (Embedder, error) {
 		if err != nil {
 			return nil, err
 		}
-		return fixtureEmbedder{dimension: dimension, model: provider.Model}, nil
+		base, err := stembed.NewFixture(provider.Model, dimension)
+		if err != nil {
+			return nil, err
+		}
+		return &fixtureEmbedder{base: base, model: provider.Model}, nil
 	case config.RuntimeProviderOpenAI:
 		return newOpenAICompatibleEmbedder(provider)
 	default:
@@ -114,96 +111,26 @@ func newEmbedder(provider config.RuntimeProvider) (Embedder, error) {
 }
 
 type fixtureEmbedder struct {
-	dimension int
-	model     string
+	base  *stembed.Fixture
+	model string
 }
 
-func (e fixtureEmbedder) Fingerprint() string {
+func (e *fixtureEmbedder) Fingerprint() string {
 	return embedderFingerprint(config.RuntimeProviderFixture, e.model, "plain_v1")
 }
 
-func (e fixtureEmbedder) Dimension(ctx context.Context) (int, error) {
-	return e.dimension, nil
+func (e *fixtureEmbedder) Dimension(ctx context.Context) (int, error) {
+	return e.base.Dimension(ctx)
 }
 
-func (e fixtureEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float64, error) {
-	return e.embedTexts(ctx, texts)
+func (e *fixtureEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float64, error) {
+	return e.base.EmbedDocuments(ctx, texts)
 }
 
-func (e fixtureEmbedder) EmbedQueries(ctx context.Context, texts []string) ([][]float64, error) {
-	return e.embedTexts(ctx, texts)
-}
-
-func (e fixtureEmbedder) embedTexts(ctx context.Context, texts []string) ([][]float64, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	vectors := make([][]float64, 0, len(texts))
-	for _, text := range texts {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		vectors = append(vectors, fixtureVector(text, e.dimension))
-	}
-	return vectors, nil
+func (e *fixtureEmbedder) EmbedQueries(ctx context.Context, texts []string) ([][]float64, error) {
+	return e.base.EmbedQueries(ctx, texts)
 }
 
 func embedderFingerprint(provider, model, strategy string) string {
 	return fmt.Sprintf("%s|%s|%s", strings.TrimSpace(provider), strings.TrimSpace(model), strings.TrimSpace(strategy))
-}
-
-func fixtureVector(text string, dimension int) []float64 {
-	vector := make([]float64, dimension)
-	if dimension <= 0 {
-		return vector
-	}
-
-	tokens := tokenize(text)
-	if len(tokens) == 0 {
-		return vector
-	}
-
-	for i, token := range tokens {
-		vector[tokenBucket(token, dimension)] += 1.0
-		if i > 0 {
-			bigram := tokens[i-1] + "_" + token
-			vector[tokenBucket(bigram, dimension)] += 1.5
-		}
-	}
-
-	return normalize(vector)
-}
-
-func tokenize(text string) []string {
-	var builder strings.Builder
-	builder.Grow(len(text))
-	for _, r := range strings.ToLower(text) {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			builder.WriteRune(r)
-			continue
-		}
-		builder.WriteByte(' ')
-	}
-	return strings.Fields(builder.String())
-}
-
-func tokenBucket(token string, dimension int) int {
-	hasher := fnv.New32a()
-	_, _ = hasher.Write([]byte(token))
-	return int(int64(hasher.Sum32()) % int64(dimension))
-}
-
-func normalize(vector []float64) []float64 {
-	var norm float64
-	for _, value := range vector {
-		norm += value * value
-	}
-	if norm == 0 {
-		return vector
-	}
-	norm = math.Sqrt(norm)
-	for i := range vector {
-		vector[i] /= norm
-	}
-	return vector
 }

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -713,197 +713,60 @@ func probeStagingDatabaseContext(ctx context.Context, stagePath string, dimensio
 	return nil
 }
 
-func buildStagingContext(ctx context.Context, db *sql.DB, cfg *config.Config, dimension int, embedder Embedder, records *source.LoadResult, state *reuseState, options RebuildOptions, reporter RebuildProgressReporter) (*RebuildResult, error) {
-	if err := createSchemaContext(ctx, db, dimension); err != nil {
-		return nil, fmt.Errorf("create schema: %w", err)
-	}
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("begin rebuild transaction: %w", err)
-	}
-	defer func() {
-		if tx != nil {
-			_ = tx.Rollback()
-		}
-	}()
-
-	result := &RebuildResult{
-		EmbedderDimension: dimension,
-		FullRebuild:       options.Full,
-		Repos:             repoCoverageFromRecords(records),
-		Sources:           append([]source.LoadSourceSummary(nil), records.Sources...),
-	}
-	totalArtifacts := len(records.Specs) + len(records.Docs)
-	currentArtifact := 0
-
-	if err := insertMetadataContext(ctx, tx, "schema_version", strconv.Itoa(schemaVersion)); err != nil {
-		return nil, err
-	}
-	if err := insertMetadataContext(ctx, tx, "embedder_dimension", strconv.Itoa(dimension)); err != nil {
-		return nil, err
-	}
-	if err := insertMetadataContext(ctx, tx, "embedder_fingerprint", embedder.Fingerprint()); err != nil {
-		return nil, err
-	}
-	if err := insertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {
-		return nil, err
-	}
-	if manifest := sourceManifestJSON(cfg); manifest != "" {
-		if err := insertMetadataContext(ctx, tx, "source_manifest", manifest); err != nil {
-			return nil, err
-		}
-	}
-
-	chunkStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunks (artifact_ref, section, content) VALUES (?, ?, ?)`)
-	if err != nil {
-		return nil, fmt.Errorf("prepare chunk insert: %w", err)
-	}
-	defer chunkStmt.Close()
-
-	vectorStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunks_vec (chunk_id, embedding) VALUES (?, ?)`)
-	if err != nil {
-		return nil, fmt.Errorf("prepare chunk vector insert: %w", err)
-	}
-	defer vectorStmt.Close()
-
-	edgeStmt, err := tx.PrepareContext(ctx, `INSERT OR IGNORE INTO edges (from_ref, to_ref, edge_type, edge_source, valid_from, valid_to, confidence, confidence_score) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return nil, fmt.Errorf("prepare edge insert: %w", err)
-	}
-	defer edgeStmt.Close()
-
-	rebuildTime := time.Now().UTC().Format("2006-01-02")
-	rebuildTimePtr := &rebuildTime
-
-	for _, spec := range records.Specs {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		currentArtifact++
-		if err := insertSpecArtifactContext(ctx, tx, spec); err != nil {
-			return nil, err
-		}
-		result.ArtifactCount++
-		result.SpecCount++
-
-		plan := planArtifactReuse(spec.Title, spec.ContentHash, spec.BodyText, storedArtifactForRecord(state, spec.Ref))
-		chunkCount, reusedCount, embeddedCount, err := insertArtifactChunksContext(ctx, chunkStmt, vectorStmt, embedder, spec.Ref, spec.Title, plan, RebuildProgressEvent{
-			ArtifactKind: model.ArtifactKindSpec,
-			ArtifactRef:  spec.Ref,
-			Current:      currentArtifact,
-			Total:        totalArtifacts,
-		}, reporter)
-		if err != nil {
-			return nil, err
-		}
-		result.ChunkCount += chunkCount
-		result.ReusedChunkCount += reusedCount
-		result.EmbeddedChunkCount += embeddedCount
-		if plan.artifactUnchanged {
-			result.ReusedArtifactCount++
-		}
-
-		// Superseded or deprecated specs get valid_to set to close their edges.
-		var edgeValidTo *string
-		if spec.Status == "superseded" || spec.Status == "deprecated" {
-			edgeValidTo = rebuildTimePtr
-		}
-
-		for _, relation := range spec.Relations {
-			if err := insertEdgeContext(ctx, edgeStmt, spec.Ref, relation.Ref, string(relation.Type), "manual", rebuildTimePtr, edgeValidTo, ConfidenceExtracted); err != nil {
-				return nil, err
-			}
-			result.EdgeCount++
-		}
-		for _, appliesTo := range spec.AppliesTo {
-			if err := insertEdgeContext(ctx, edgeStmt, spec.Ref, appliesTo, "applies_to", "manual", rebuildTimePtr, edgeValidTo, ConfidenceExtracted); err != nil {
-				return nil, err
-			}
-			result.EdgeCount++
-		}
-	}
-
-	for _, doc := range records.Docs {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		currentArtifact++
-		if err := insertDocArtifactContext(ctx, tx, doc); err != nil {
-			return nil, err
-		}
-		result.ArtifactCount++
-		result.DocCount++
-
-		plan := planArtifactReuse(doc.Title, doc.ContentHash, doc.BodyText, storedArtifactForRecord(state, doc.Ref))
-		chunkCount, reusedCount, embeddedCount, err := insertArtifactChunksContext(ctx, chunkStmt, vectorStmt, embedder, doc.Ref, doc.Title, plan, RebuildProgressEvent{
-			ArtifactKind: model.ArtifactKindDoc,
-			ArtifactRef:  doc.Ref,
-			Current:      currentArtifact,
-			Total:        totalArtifacts,
-		}, reporter)
-		if err != nil {
-			return nil, err
-		}
-		result.ChunkCount += chunkCount
-		result.ReusedChunkCount += reusedCount
-		result.EmbeddedChunkCount += embeddedCount
-		if plan.artifactUnchanged {
-			result.ReusedArtifactCount++
-		}
-	}
-
-	// Infer AST-based applies_to edges from code file symbols.
-	inferredCount, inferErr := inferASTEdgesContext(ctx, tx, edgeStmt, cfg, records.Specs, rebuildTimePtr)
-	if inferErr != nil {
-		return nil, fmt.Errorf("infer AST edges: %w", inferErr)
-	}
-	result.EdgeCount += inferredCount
-	result.InferredEdgeCount = inferredCount
-
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit rebuild transaction: %w", err)
-	}
-	tx = nil
-
-	if err := runIntegrityChecksContext(ctx, db); err != nil {
-		return nil, err
-	}
-
-	result.ContentFingerprint = contentFingerprint(records)
-	if err := insertContentFingerprintContext(ctx, db, result.ContentFingerprint); err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
 func createSchemaContext(ctx context.Context, db *sql.DB, dimension int) error {
 	statements := []string{
-		`CREATE TABLE artifacts (
+		`CREATE TABLE records (
 			ref           TEXT PRIMARY KEY,
 			kind          TEXT NOT NULL,
 			title         TEXT,
-			status        TEXT,
-			domain        TEXT,
 			source_ref    TEXT NOT NULL,
-			adapter       TEXT NOT NULL,
 			body_format   TEXT NOT NULL,
+			body_text     TEXT NOT NULL,
 			content_hash  TEXT NOT NULL,
 			metadata_json TEXT NOT NULL,
+			status        TEXT,
+			domain        TEXT,
+			adapter       TEXT NOT NULL DEFAULT 'filesystem',
 			valid_from    TEXT,
 			valid_to      TEXT
 		)`,
-		`CREATE TABLE chunks (
+		`CREATE TABLE chunk_records (
 			id            INTEGER PRIMARY KEY AUTOINCREMENT,
-			artifact_ref  TEXT NOT NULL,
-			section       TEXT,
+			record_ref    TEXT NOT NULL,
+			chunk_index   INTEGER NOT NULL,
+			heading       TEXT,
 			content       TEXT NOT NULL,
-			FOREIGN KEY (artifact_ref) REFERENCES artifacts(ref)
+			FOREIGN KEY (record_ref) REFERENCES records(ref)
 		)`,
 		fmt.Sprintf(`CREATE VIRTUAL TABLE chunks_vec USING vec0(
 			chunk_id INTEGER PRIMARY KEY,
 			embedding float[%d] distance_metric=cosine
 		)`, dimension),
+		`CREATE VIEW artifacts AS
+			SELECT
+				ref,
+				kind,
+				title,
+				status,
+				domain,
+				source_ref,
+				adapter,
+				body_format,
+				content_hash,
+				metadata_json,
+				valid_from,
+				valid_to
+			FROM records`,
+		`CREATE VIEW chunks AS
+			SELECT
+				id,
+				record_ref,
+				chunk_index,
+				heading,
+				content,
+				record_ref AS artifact_ref,
+				heading AS section
+			FROM chunk_records`,
 		`CREATE TABLE edges (
 			from_ref         TEXT NOT NULL,
 			to_ref           TEXT NOT NULL,
@@ -926,9 +789,9 @@ func createSchemaContext(ctx context.Context, db *sql.DB, dimension int) error {
 			value         TEXT NOT NULL
 		)`,
 		`CREATE INDEX idx_artifacts_kind_status_domain
-			ON artifacts(kind, status, domain)`,
+			ON records(kind, status, domain)`,
 		`CREATE INDEX idx_chunks_artifact_ref
-			ON chunks(artifact_ref)`,
+			ON chunk_records(record_ref)`,
 		`CREATE INDEX idx_edges_from_ref_type
 			ON edges(from_ref, edge_type)`,
 		`CREATE INDEX idx_edges_to_ref_type
@@ -1137,20 +1000,6 @@ var (
 func insertEdgeContext(ctx context.Context, stmt *sql.Stmt, fromRef, toRef, edgeType, edgeSource string, validFrom, validTo *string, conf EdgeConfidence) error {
 	if _, err := stmt.ExecContext(ctx, fromRef, toRef, edgeType, edgeSource, validFrom, validTo, conf.Tier, conf.Score); err != nil {
 		return fmt.Errorf("insert edge %s -> %s (%s, %s): %w", fromRef, toRef, edgeType, edgeSource, err)
-	}
-	return nil
-}
-
-func insertMetadataContext(ctx context.Context, tx *sql.Tx, key, value string) error {
-	if _, err := tx.ExecContext(ctx, `INSERT INTO metadata (key, value) VALUES (?, ?)`, key, value); err != nil {
-		return fmt.Errorf("insert metadata %s: %w", key, err)
-	}
-	return nil
-}
-
-func insertContentFingerprintContext(ctx context.Context, db *sql.DB, value string) error {
-	if _, err := db.ExecContext(ctx, `INSERT INTO metadata (key, value) VALUES (?, ?)`, "content_fingerprint", value); err != nil {
-		return fmt.Errorf("insert content fingerprint: %w", err)
 	}
 	return nil
 }

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -19,9 +19,11 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
+	stcorpus "github.com/dusk-network/stroma/corpus"
+	stindex "github.com/dusk-network/stroma/index"
 )
 
-const schemaVersion = 7
+const schemaVersion = 8
 
 // RebuildResult reports the staged rebuild outcome.
 // When Update is true, the result describes an incremental update instead of a full rebuild.
@@ -169,23 +171,38 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 		return nil, err
 	}
 
-	db, err := openReadWriteContext(ctx, stagePath)
+	corpusRecords, err := corpusRecordsFromLoadResult(records)
 	if err != nil {
-		return nil, fmt.Errorf("open staging database: %w", err)
+		return nil, err
 	}
+	emitPlannedRebuildProgress(records, reuseState, reporter)
+
 	success := false
 	defer func() {
-		_ = db.Close()
 		if !success {
 			_ = os.Remove(stagePath)
 		}
 	}()
 
-	result, err := buildStagingContext(ctx, db, cfg, dimension, embedder, records, reuseState, options, reporter)
+	if _, err := stindex.Rebuild(ctx, corpusRecords, stindex.BuildOptions{
+		Path:     stagePath,
+		Embedder: embedder,
+	}); err != nil {
+		return nil, fmt.Errorf("build stroma staging database: %w", err)
+	}
+
+	db, err := openReadWriteContext(ctx, stagePath)
 	if err != nil {
+		return nil, fmt.Errorf("open staging database: %w", err)
+	}
+
+	result := summarizeRebuild(records, dimension, reuseState, options)
+	result.IndexPath = indexPath
+
+	if err := finalizeStromaIndexContext(ctx, db, cfg, records, result); err != nil {
+		_ = db.Close()
 		return nil, err
 	}
-	result.IndexPath = indexPath
 
 	if err := db.Close(); err != nil {
 		return nil, fmt.Errorf("close staging database: %w", err)
@@ -198,6 +215,327 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 	}
 	success = true
 	return result, nil
+}
+
+func corpusRecordsFromLoadResult(records *source.LoadResult) ([]stcorpus.Record, error) {
+	if records == nil {
+		return nil, fmt.Errorf("records are required")
+	}
+
+	corpusRecords := make([]stcorpus.Record, 0, len(records.Specs)+len(records.Docs))
+	for _, spec := range records.Specs {
+		record, err := corpusRecordFromSpec(spec)
+		if err != nil {
+			return nil, err
+		}
+		corpusRecords = append(corpusRecords, record)
+	}
+	for _, doc := range records.Docs {
+		record, err := corpusRecordFromDoc(doc)
+		if err != nil {
+			return nil, err
+		}
+		corpusRecords = append(corpusRecords, record)
+	}
+	return corpusRecords, nil
+}
+
+func corpusRecordFromSpec(spec model.SpecRecord) (stcorpus.Record, error) {
+	metadata := cloneMetadata(spec.Metadata)
+	if status := strings.TrimSpace(spec.Status); status != "" {
+		metadata["pituitary_status"] = status
+	}
+	if domain := strings.TrimSpace(spec.Domain); domain != "" {
+		metadata["pituitary_domain"] = domain
+	}
+	metadata["pituitary_adapter"] = adapterFromMetadata(metadata)
+
+	return stcorpus.Record{
+		Ref:         spec.Ref,
+		Kind:        spec.Kind,
+		Title:       spec.Title,
+		SourceRef:   spec.SourceRef,
+		BodyFormat:  spec.BodyFormat,
+		BodyText:    spec.BodyText,
+		ContentHash: spec.ContentHash,
+		Metadata:    metadata,
+	}.Normalized()
+}
+
+func corpusRecordFromDoc(doc model.DocRecord) (stcorpus.Record, error) {
+	metadata := cloneMetadata(doc.Metadata)
+	metadata["pituitary_adapter"] = adapterFromMetadata(metadata)
+
+	return stcorpus.Record{
+		Ref:         doc.Ref,
+		Kind:        doc.Kind,
+		Title:       doc.Title,
+		SourceRef:   doc.SourceRef,
+		BodyFormat:  doc.BodyFormat,
+		BodyText:    doc.BodyText,
+		ContentHash: doc.ContentHash,
+		Metadata:    metadata,
+	}.Normalized()
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func finalizeStromaIndexContext(ctx context.Context, db *sql.DB, cfg *config.Config, records *source.LoadResult, result *RebuildResult) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin stroma augmentation transaction: %w", err)
+	}
+	defer func() {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := extendStromaSchemaContext(ctx, tx); err != nil {
+		return err
+	}
+	if err := populatePituitaryRecordFieldsContext(ctx, tx, records); err != nil {
+		return err
+	}
+
+	edgeStmt, err := tx.PrepareContext(ctx, `INSERT OR IGNORE INTO edges (from_ref, to_ref, edge_type, edge_source, valid_from, valid_to, confidence, confidence_score) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare edge insert: %w", err)
+	}
+	defer edgeStmt.Close()
+
+	rebuildTime := time.Now().UTC().Format("2006-01-02")
+	rebuildTimePtr := &rebuildTime
+	edgeCount := 0
+
+	for _, spec := range records.Specs {
+		var edgeValidTo *string
+		if spec.Status == model.StatusSuperseded || spec.Status == model.StatusDeprecated {
+			edgeValidTo = rebuildTimePtr
+		}
+		for _, relation := range spec.Relations {
+			if err := insertEdgeContext(ctx, edgeStmt, spec.Ref, relation.Ref, string(relation.Type), "manual", rebuildTimePtr, edgeValidTo, ConfidenceExtracted); err != nil {
+				return err
+			}
+			edgeCount++
+		}
+		for _, appliesTo := range spec.AppliesTo {
+			if err := insertEdgeContext(ctx, edgeStmt, spec.Ref, appliesTo, "applies_to", "manual", rebuildTimePtr, edgeValidTo, ConfidenceExtracted); err != nil {
+				return err
+			}
+			edgeCount++
+		}
+	}
+
+	inferredCount, err := inferASTEdgesContext(ctx, tx, edgeStmt, cfg, records.Specs, rebuildTimePtr)
+	if err != nil {
+		return fmt.Errorf("infer AST edges: %w", err)
+	}
+	edgeCount += inferredCount
+
+	if err := upsertMetadataContext(ctx, tx, "schema_version", strconv.Itoa(schemaVersion)); err != nil {
+		return err
+	}
+	if err := upsertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {
+		return err
+	}
+	if manifest := sourceManifestJSON(cfg); manifest != "" {
+		if err := upsertMetadataContext(ctx, tx, "source_manifest", manifest); err != nil {
+			return err
+		}
+	}
+
+	result.ContentFingerprint = contentFingerprint(records)
+	if err := upsertMetadataContext(ctx, tx, "content_fingerprint", result.ContentFingerprint); err != nil {
+		return err
+	}
+
+	if err := runTransactionIntegrityChecks(ctx, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit stroma augmentation transaction: %w", err)
+	}
+	tx = nil
+
+	if err := runIntegrityChecksContext(ctx, db); err != nil {
+		return err
+	}
+
+	result.EdgeCount = edgeCount
+	result.InferredEdgeCount = inferredCount
+	return nil
+}
+
+func extendStromaSchemaContext(ctx context.Context, tx *sql.Tx) error {
+	statements := []string{
+		`ALTER TABLE records ADD COLUMN status TEXT`,
+		`ALTER TABLE records ADD COLUMN domain TEXT`,
+		`ALTER TABLE records ADD COLUMN adapter TEXT NOT NULL DEFAULT 'filesystem'`,
+		`ALTER TABLE records ADD COLUMN valid_from TEXT`,
+		`ALTER TABLE records ADD COLUMN valid_to TEXT`,
+		`ALTER TABLE chunks RENAME TO chunk_records`,
+		`CREATE VIEW artifacts AS
+			SELECT
+				ref,
+				kind,
+				title,
+				status,
+				domain,
+				source_ref,
+				adapter,
+				body_format,
+				content_hash,
+				metadata_json,
+				valid_from,
+				valid_to
+			FROM records`,
+		`CREATE VIEW chunks AS
+			SELECT
+				id,
+				record_ref,
+				chunk_index,
+				heading,
+				content,
+				record_ref AS artifact_ref,
+				heading AS section
+			FROM chunk_records`,
+		`CREATE TABLE edges (
+			from_ref         TEXT NOT NULL,
+			to_ref           TEXT NOT NULL,
+			edge_type        TEXT NOT NULL,
+			edge_source      TEXT NOT NULL DEFAULT 'manual',
+			valid_from       TEXT,
+			valid_to         TEXT,
+			confidence       TEXT NOT NULL DEFAULT 'extracted',
+			confidence_score REAL NOT NULL DEFAULT 1.0,
+			PRIMARY KEY (from_ref, to_ref, edge_type)
+		)`,
+		`CREATE TABLE ast_cache (
+			content_hash   TEXT PRIMARY KEY,
+			path           TEXT NOT NULL,
+			symbols_json   TEXT NOT NULL,
+			rationale_json TEXT NOT NULL DEFAULT '[]'
+		)`,
+		`CREATE INDEX idx_artifacts_kind_status_domain ON records(kind, status, domain)`,
+		`CREATE INDEX idx_chunks_artifact_ref ON chunk_records(record_ref)`,
+		`CREATE INDEX idx_edges_from_ref_type ON edges(from_ref, edge_type)`,
+		`CREATE INDEX idx_edges_to_ref_type ON edges(to_ref, edge_type)`,
+	}
+
+	for _, statement := range statements {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("augment stroma schema: %w", err)
+		}
+	}
+	return nil
+}
+
+func populatePituitaryRecordFieldsContext(ctx context.Context, tx *sql.Tx, records *source.LoadResult) error {
+	stmt, err := tx.PrepareContext(ctx, `UPDATE records SET status = ?, domain = ?, adapter = ?, valid_from = ?, valid_to = ? WHERE ref = ?`)
+	if err != nil {
+		return fmt.Errorf("prepare record augmentation: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, spec := range records.Specs {
+		if _, err := stmt.ExecContext(
+			ctx,
+			nullableString(strings.TrimSpace(spec.Status)),
+			nullableString(strings.TrimSpace(spec.Domain)),
+			adapterFromMetadata(spec.Metadata),
+			nil,
+			nil,
+			spec.Ref,
+		); err != nil {
+			return fmt.Errorf("augment spec record %s: %w", spec.Ref, err)
+		}
+	}
+	for _, doc := range records.Docs {
+		if _, err := stmt.ExecContext(
+			ctx,
+			nil,
+			nil,
+			adapterFromMetadata(doc.Metadata),
+			nil,
+			nil,
+			doc.Ref,
+		); err != nil {
+			return fmt.Errorf("augment doc record %s: %w", doc.Ref, err)
+		}
+	}
+	return nil
+}
+
+func nullableString(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func emitPlannedRebuildProgress(records *source.LoadResult, state *reuseState, reporter RebuildProgressReporter) {
+	if reporter == nil || records == nil {
+		return
+	}
+
+	totalArtifacts := len(records.Specs) + len(records.Docs)
+	currentArtifact := 0
+
+	for _, spec := range records.Specs {
+		currentArtifact++
+		plan := planArtifactReuse(spec.Title, spec.ContentHash, spec.BodyText, storedArtifactForRecord(state, spec.Ref))
+		reportRebuildProgress(reporter, RebuildProgressEvent{
+			Phase:        "chunking",
+			ArtifactKind: model.ArtifactKindSpec,
+			ArtifactRef:  spec.Ref,
+			Current:      currentArtifact,
+			Total:        totalArtifacts,
+			ChunkCount:   len(plan.sections),
+		})
+		if plan.embeddedChunkCount > 0 {
+			reportRebuildProgress(reporter, RebuildProgressEvent{
+				Phase:        "embedding",
+				ArtifactKind: model.ArtifactKindSpec,
+				ArtifactRef:  spec.Ref,
+				Current:      currentArtifact,
+				Total:        totalArtifacts,
+				ChunkCount:   plan.embeddedChunkCount,
+			})
+		}
+	}
+
+	for _, doc := range records.Docs {
+		currentArtifact++
+		plan := planArtifactReuse(doc.Title, doc.ContentHash, doc.BodyText, storedArtifactForRecord(state, doc.Ref))
+		reportRebuildProgress(reporter, RebuildProgressEvent{
+			Phase:        "chunking",
+			ArtifactKind: model.ArtifactKindDoc,
+			ArtifactRef:  doc.Ref,
+			Current:      currentArtifact,
+			Total:        totalArtifacts,
+			ChunkCount:   len(plan.sections),
+		})
+		if plan.embeddedChunkCount > 0 {
+			reportRebuildProgress(reporter, RebuildProgressEvent{
+				Phase:        "embedding",
+				ArtifactKind: model.ArtifactKindDoc,
+				ArtifactRef:  doc.Ref,
+				Current:      currentArtifact,
+				Total:        totalArtifacts,
+				ChunkCount:   plan.embeddedChunkCount,
+			})
+		}
+	}
 }
 
 func prepareRebuildContext(ctx context.Context, cfg *config.Config, records *source.LoadResult) (Embedder, error) {
@@ -612,18 +950,19 @@ func insertSpecArtifactContext(ctx context.Context, tx *sql.Tx, spec model.SpecR
 	}
 	_, err = tx.ExecContext(
 		ctx,
-		`INSERT INTO artifacts (ref, kind, title, status, domain, source_ref, adapter, body_format, content_hash, metadata_json)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO records (ref, kind, title, source_ref, body_format, body_text, content_hash, metadata_json, status, domain, adapter)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		spec.Ref,
 		spec.Kind,
 		spec.Title,
-		spec.Status,
-		spec.Domain,
 		spec.SourceRef,
-		adapterFromMetadata(spec.Metadata),
 		spec.BodyFormat,
+		spec.BodyText,
 		spec.ContentHash,
 		string(metadataJSON),
+		nullableString(strings.TrimSpace(spec.Status)),
+		nullableString(strings.TrimSpace(spec.Domain)),
+		adapterFromMetadata(spec.Metadata),
 	)
 	if err != nil {
 		return fmt.Errorf("insert spec artifact %s: %w", spec.Ref, err)
@@ -638,18 +977,19 @@ func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocReco
 	}
 	_, err = tx.ExecContext(
 		ctx,
-		`INSERT INTO artifacts (ref, kind, title, status, domain, source_ref, adapter, body_format, content_hash, metadata_json)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO records (ref, kind, title, source_ref, body_format, body_text, content_hash, metadata_json, status, domain, adapter)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		doc.Ref,
 		doc.Kind,
 		doc.Title,
-		nil,
-		nil,
 		doc.SourceRef,
-		adapterFromMetadata(doc.Metadata),
 		doc.BodyFormat,
+		doc.BodyText,
 		doc.ContentHash,
 		string(metadataJSON),
+		nil,
+		nil,
+		adapterFromMetadata(doc.Metadata),
 	)
 	if err != nil {
 		return fmt.Errorf("insert doc artifact %s: %w", doc.Ref, err)
@@ -712,7 +1052,7 @@ func insertArtifactChunksContext(ctx context.Context, chunkStmt, vectorStmt *sql
 		if err := ctx.Err(); err != nil {
 			return 0, 0, 0, err
 		}
-		chunkID, err := insertChunkContext(ctx, chunkStmt, artifactRef, section.Heading, section.Body)
+		chunkID, err := insertChunkContext(ctx, chunkStmt, artifactRef, i, section.Heading, section.Body)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -741,8 +1081,8 @@ func reportRebuildProgress(reporter RebuildProgressReporter, event RebuildProgre
 	reporter(event)
 }
 
-func insertChunkContext(ctx context.Context, stmt *sql.Stmt, artifactRef, section, content string) (int64, error) {
-	result, err := stmt.ExecContext(ctx, artifactRef, section, content)
+func insertChunkContext(ctx context.Context, stmt *sql.Stmt, artifactRef string, chunkIndex int, section, content string) (int64, error) {
+	result, err := stmt.ExecContext(ctx, artifactRef, chunkIndex, section, content)
 	if err != nil {
 		return 0, fmt.Errorf("insert chunk for %s: %w", artifactRef, err)
 	}

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -55,7 +55,7 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 	assertCount(t, db, `SELECT COUNT(*) FROM chunks`, 17)
 	assertCount(t, db, `SELECT COUNT(*) FROM edges`, 9)
 	assertCount(t, db, `SELECT COUNT(*) FROM chunks_vec`, 17)
-	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 6)
+	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 7)
 	assertMetadataValue(t, db, "embedder_fingerprint", "fixture|fixture-8d|plain_v1")
 	assertMetadataValue(t, db, "source_fingerprint", sourceFingerprint(cfg))
 	var sourceManifest string
@@ -77,8 +77,10 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 		"Public API Rate Limits / Operational Notes",
 	})
 
-	assertSchemaObject(t, db, "table", "artifacts")
-	assertSchemaObject(t, db, "table", "chunks")
+	assertSchemaObject(t, db, "view", "artifacts")
+	assertSchemaObject(t, db, "view", "chunks")
+	assertSchemaObject(t, db, "table", "records")
+	assertSchemaObject(t, db, "table", "chunk_records")
 	assertSchemaObject(t, db, "table", "chunks_vec")
 	assertSchemaObject(t, db, "table", "edges")
 	assertSchemaObject(t, db, "index", "idx_artifacts_kind_status_domain")
@@ -711,13 +713,13 @@ func TestRebuildSetsTemporalValidityOnEdges(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Verify schema version is 5.
+	// Verify schema version matches the Stroma-backed compatibility schema.
 	var version string
 	if err := db.QueryRow(`SELECT value FROM metadata WHERE key = 'schema_version'`).Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != "7" {
-		t.Errorf("schema_version = %q, want 7", version)
+	if version != "8" {
+		t.Errorf("schema_version = %q, want 8", version)
 	}
 
 	// Verify that manual edges have valid_from set to today (YYYY-MM-DD).

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -3,37 +3,12 @@ package index
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
 
-	_ "github.com/asg017/sqlite-vec-go-bindings/ncruces"
-	_ "github.com/ncruces/go-sqlite3/driver"
+	ststore "github.com/dusk-network/stroma/store"
 )
 
-var sqliteReadyMu sync.Mutex
-var sqliteReady bool
-var sqliteReadinessProbe = probeSQLiteReadyContext
-
-const sqliteReadinessDSN = "file:pituitary-sqlite-ready?mode=memory&cache=shared"
-
 func openReadWriteContext(ctx context.Context, path string) (*sql.DB, error) {
-	if err := CheckSQLiteReadyContext(ctx); err != nil {
-		return nil, err
-	}
-	dsn := sqliteURI(path, "")
-	db, err := sql.Open("sqlite3", dsn)
-	if err != nil {
-		return nil, err
-	}
-	if err := configureDB(ctx, db); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	return db, nil
+	return ststore.OpenReadWriteContext(ctx, path)
 }
 
 // OpenReadOnly opens a fresh read-only SQLite handle for query paths.
@@ -43,58 +18,11 @@ func OpenReadOnly(path string) (*sql.DB, error) {
 
 // OpenReadOnlyContext opens a fresh read-only SQLite handle for query paths.
 func OpenReadOnlyContext(ctx context.Context, path string) (*sql.DB, error) {
-	info, err := os.Stat(path)
-	switch {
-	case os.IsNotExist(err):
-		return nil, &MissingIndexError{Path: path}
-	case err != nil:
-		return nil, fmt.Errorf("stat index %s: %w", path, err)
-	case info.IsDir():
-		return nil, fmt.Errorf("index path %s is a directory", path)
-	}
-
-	if err := CheckSQLiteReadyContext(ctx); err != nil {
-		return nil, err
-	}
-	dsn := sqliteURI(path, "ro")
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := ststore.OpenReadOnlyContext(ctx, path)
 	if err != nil {
-		return nil, err
-	}
-	if err := configureDB(ctx, db); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	if _, err := db.ExecContext(ctx, `PRAGMA query_only = ON`); err != nil {
-		_ = db.Close()
-		return nil, err
+		return nil, normalizeStoreError(err)
 	}
 	return db, nil
-}
-
-func sqliteURI(path, mode string) string {
-	normalizedPath := filepath.ToSlash(path)
-	if hasWindowsDrivePrefix(normalizedPath) && !strings.HasPrefix(normalizedPath, "/") {
-		normalizedPath = "/" + normalizedPath
-	}
-	u := url.URL{
-		Scheme: "file",
-		Path:   normalizedPath,
-	}
-	query := url.Values{}
-	if mode != "" {
-		query.Set("mode", mode)
-	}
-	u.RawQuery = query.Encode()
-	return u.String()
-}
-
-func hasWindowsDrivePrefix(path string) bool {
-	if len(path) < 2 || path[1] != ':' {
-		return false
-	}
-	drive := path[0]
-	return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
 }
 
 // CheckSQLiteReady validates that the SQLite driver and sqlite-vec extension are usable.
@@ -104,48 +32,12 @@ func CheckSQLiteReady() error {
 
 // CheckSQLiteReadyContext validates that the SQLite driver and sqlite-vec extension are usable.
 func CheckSQLiteReadyContext(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	sqliteReadyMu.Lock()
-	defer sqliteReadyMu.Unlock()
-
-	if sqliteReady {
-		return ctx.Err()
-	}
-	if err := sqliteReadinessProbe(ctx); err != nil {
-		return err
-	}
-	sqliteReady = true
-	return ctx.Err()
+	return ststore.CheckSQLiteReadyContext(ctx)
 }
 
-func configureDB(ctx context.Context, db *sql.DB) error {
-	if _, err := db.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
-		return fmt.Errorf("enable foreign keys: %w", err)
+func normalizeStoreError(err error) error {
+	if !ststore.IsMissingIndex(err) {
+		return err
 	}
-	return nil
-}
-
-func probeSQLiteReadyContext(ctx context.Context) error {
-	db, err := sql.Open("sqlite3", sqliteReadinessDSN)
-	if err != nil {
-		return fmt.Errorf("open sqlite readiness probe: %w", err)
-	}
-	defer db.Close()
-
-	if err := configureDB(ctx, db); err != nil {
-		return fmt.Errorf("configure sqlite readiness probe: %w", err)
-	}
-	if _, err := db.ExecContext(ctx, `CREATE VIRTUAL TABLE pituitary_vec_probe USING vec0(
-chunk_id integer primary key,
-embedding float[8] distance_metric=cosine
-)`); err != nil {
-		return fmt.Errorf("initialize sqlite-vec extension: %w", err)
-	}
-	if _, err := db.ExecContext(ctx, `DROP TABLE pituitary_vec_probe`); err != nil {
-		return fmt.Errorf("drop sqlite-vec readiness probe: %w", err)
-	}
-	return nil
+	return &MissingIndexError{Path: ststore.MissingIndexPath(err)}
 }

--- a/internal/index/store_test.go
+++ b/internal/index/store_test.go
@@ -2,103 +2,52 @@ package index
 
 import (
 	"context"
-	"errors"
+	"path/filepath"
 	"testing"
 )
 
-func TestSQLiteURIUsesWindowsSafeDriveLetterForm(t *testing.T) {
-	t.Parallel()
-
-	got := sqliteURI("C:/Users/alice/pituitary.db", "")
-	want := "file:///C:/Users/alice/pituitary.db"
-	if got != want {
-		t.Fatalf("sqliteURI() = %q, want %q", got, want)
-	}
-}
-
-func TestSQLiteURIPreservesModeForWindowsDriveLetterPaths(t *testing.T) {
-	t.Parallel()
-
-	got := sqliteURI("C:/Users/alice/pituitary.db.new", "ro")
-	want := "file:///C:/Users/alice/pituitary.db.new?mode=ro"
-	if got != want {
-		t.Fatalf("sqliteURI() = %q, want %q", got, want)
-	}
-}
-
 func TestCheckSQLiteReadyPasses(t *testing.T) {
-	resetSQLiteReadyForTest(t)
+	t.Parallel()
 
 	if err := CheckSQLiteReady(); err != nil {
 		t.Fatalf("CheckSQLiteReady() error = %v", err)
 	}
 }
 
-func TestCheckSQLiteReadyRetriesAfterFailure(t *testing.T) {
-	resetSQLiteReadyForTest(t)
+func TestOpenReadOnlyContextWrapsMissingIndexErrors(t *testing.T) {
+	t.Parallel()
 
-	transient := errors.New("transient sqlite readiness failure")
-	callCount := 0
-
-	sqliteReadyMu.Lock()
-	sqliteReadinessProbe = func(context.Context) error {
-		callCount++
-		if callCount == 1 {
-			return transient
-		}
-		return nil
+	path := filepath.Join(t.TempDir(), "missing.db")
+	_, err := OpenReadOnlyContext(context.Background(), path)
+	if err == nil {
+		t.Fatal("OpenReadOnlyContext() error = nil, want missing index failure")
 	}
-	sqliteReadyMu.Unlock()
-
-	if err := CheckSQLiteReady(); !errors.Is(err, transient) {
-		t.Fatalf("first CheckSQLiteReady() error = %v, want %v", err, transient)
+	if !IsMissingIndex(err) {
+		t.Fatalf("OpenReadOnlyContext() error = %T (%v), want MissingIndexError", err, err)
 	}
-	if err := CheckSQLiteReady(); err != nil {
-		t.Fatalf("second CheckSQLiteReady() error = %v", err)
+	if got, want := MissingIndexPath(err), path; got != want {
+		t.Fatalf("MissingIndexPath() = %q, want %q", got, want)
 	}
-	if callCount != 2 {
-		t.Fatalf("probe call count = %d, want 2", callCount)
-	}
-	if !sqliteReady {
-		t.Fatal("sqliteReady = false, want true after successful retry")
+	if got, want := err.Error(), "index "+path+" does not exist; run `pituitary index --rebuild`"; got != want {
+		t.Fatalf("OpenReadOnlyContext() error = %q, want %q", got, want)
 	}
 }
 
-func TestCheckSQLiteReadyCachesSuccess(t *testing.T) {
-	resetSQLiteReadyForTest(t)
+func TestOpenReadOnlyContextOpensExistingIndex(t *testing.T) {
+	t.Parallel()
 
-	callCount := 0
-
-	sqliteReadyMu.Lock()
-	sqliteReadinessProbe = func(context.Context) error {
-		callCount++
-		return nil
+	path := filepath.Join(t.TempDir(), "pituitary.db")
+	writer, err := openReadWriteContext(context.Background(), path)
+	if err != nil {
+		t.Fatalf("openReadWriteContext() error = %v", err)
 	}
-	sqliteReadyMu.Unlock()
-
-	if err := CheckSQLiteReady(); err != nil {
-		t.Fatalf("first CheckSQLiteReady() error = %v", err)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close() error = %v", err)
 	}
-	if err := CheckSQLiteReady(); err != nil {
-		t.Fatalf("second CheckSQLiteReady() error = %v", err)
+
+	db, err := OpenReadOnlyContext(context.Background(), path)
+	if err != nil {
+		t.Fatalf("OpenReadOnlyContext() error = %v", err)
 	}
-	if callCount != 1 {
-		t.Fatalf("probe call count = %d, want 1", callCount)
-	}
-}
-
-func resetSQLiteReadyForTest(t *testing.T) {
-	t.Helper()
-
-	sqliteReadyMu.Lock()
-	sqliteReady = false
-	sqliteReadinessProbe = probeSQLiteReadyContext
-	sqliteReadyMu.Unlock()
-
-	t.Cleanup(func() {
-		sqliteReadyMu.Lock()
-		sqliteReady = false
-		sqliteReadinessProbe = probeSQLiteReadyContext
-		sqliteReadyMu.Unlock()
-	})
+	defer db.Close()
 }

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -217,7 +217,7 @@ func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Confi
 	}
 
 	// Prepare insert statements.
-	chunkStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunks (artifact_ref, section, content) VALUES (?, ?, ?)`)
+	chunkStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunk_records (record_ref, chunk_index, heading, content) VALUES (?, ?, ?, ?)`)
 	if err != nil {
 		return nil, fmt.Errorf("prepare chunk insert: %w", err)
 	}
@@ -540,15 +540,15 @@ ORDER BY c.id`, ref)
 // vectors from the database within a transaction.
 func deleteArtifactDataContext(ctx context.Context, tx *sql.Tx, ref string) error {
 	// Delete vectors (vec0 virtual table) via subquery on chunks.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks_vec WHERE chunk_id IN (SELECT id FROM chunks WHERE artifact_ref = ?)`, ref); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks_vec WHERE chunk_id IN (SELECT id FROM chunk_records WHERE record_ref = ?)`, ref); err != nil {
 		return fmt.Errorf("delete vectors for %s: %w", ref, err)
 	}
 	// Delete chunks.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks WHERE artifact_ref = ?`, ref); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM chunk_records WHERE record_ref = ?`, ref); err != nil {
 		return fmt.Errorf("delete chunks for %s: %w", ref, err)
 	}
 	// Delete artifact.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM artifacts WHERE ref = ?`, ref); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM records WHERE ref = ?`, ref); err != nil {
 		return fmt.Errorf("delete artifact %s: %w", ref, err)
 	}
 	return nil
@@ -586,7 +586,7 @@ func countChunksForRefsContext(ctx context.Context, db *sql.DB, refs []string) (
 	if len(refs) == 0 {
 		return 0, nil
 	}
-	query := `SELECT COUNT(*) FROM chunks WHERE artifact_ref IN (` + placeholders(len(refs)) + `)`
+	query := `SELECT COUNT(*) FROM chunk_records WHERE record_ref IN (` + placeholders(len(refs)) + `)`
 	args := make([]any, 0, len(refs))
 	for _, ref := range refs {
 		args = append(args, ref)

--- a/internal/index/vector_blob.go
+++ b/internal/index/vector_blob.go
@@ -1,53 +1,25 @@
 package index
 
-import (
-	"bytes"
-	"encoding/binary"
-	"fmt"
-	"math"
-)
+import ststore "github.com/dusk-network/stroma/store"
 
 func encodeVectorBlob(vector []float64) ([]byte, error) {
-	buf := make([]byte, len(vector)*4)
-	for i, v := range vector {
-		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(float32(v)))
-	}
-	return buf, nil
+	return ststore.EncodeVectorBlob(vector)
 }
 
 // EncodeVectorBlob encodes float64 embeddings into the sqlite-vec blob format.
 func EncodeVectorBlob(vector []float64) ([]byte, error) {
-	return encodeVectorBlob(vector)
+	return ststore.EncodeVectorBlob(vector)
 }
 
 func decodeVectorBlob(blob []byte) ([]float64, error) {
-	if len(blob)%4 != 0 {
-		return nil, fmt.Errorf("invalid vector blob length %d", len(blob))
-	}
-	decoded := make([]float32, len(blob)/4)
-	if err := binary.Read(bytes.NewReader(blob), binary.LittleEndian, decoded); err != nil {
-		return nil, fmt.Errorf("decode vector blob: %w", err)
-	}
-	vector := make([]float64, len(decoded))
-	for i, value := range decoded {
-		vector[i] = float64(value)
-	}
-	return vector, nil
+	return ststore.DecodeVectorBlob(blob)
 }
 
 // DecodeVectorBlob decodes a sqlite-vec float32 blob into float64 values.
 func DecodeVectorBlob(blob []byte) ([]float64, error) {
-	return decodeVectorBlob(blob)
+	return ststore.DecodeVectorBlob(blob)
 }
 
 func cosineScoreFromDistance(distance float64) float64 {
-	score := 1 - distance
-	switch {
-	case score < 0:
-		return 0
-	case score > 1:
-		return 1
-	default:
-		return score
-	}
+	return ststore.CosineScoreFromDistance(distance)
 }


### PR DESCRIPTION
## What changed
- switch Pituitary index rebuild to stage through Stroma corpus records and `stroma/index.Rebuild`
- augment the Stroma-built SQLite database with Pituitary governance tables and compatibility views for `artifacts` and `chunks`
- keep rebuild progress, chunk reuse accounting, temporal edge metadata, and AST-derived governance edges intact on top of the new substrate
- update incremental index writes/deletes to use the Stroma base tables and refresh rebuild tests for the compatibility schema shape

## Why
Pituitary had already delegated low-level chunk/embed/store helpers to Stroma, but rebuild still owned the full substrate schema directly. This PR moves the rebuild path onto Stroma's corpus/index model while preserving current read behavior for the rest of Pituitary.

## Impact
- narrows Pituitary's substrate ownership to governance-specific augmentation instead of the full corpus schema
- keeps existing analysis and CLI surfaces working through compatibility views
- leaves the next extraction slices clearly scoped to search and remaining read paths

## Validation
- `go test ./internal/index`
- `go test ./cmd`
- `go test ./...`