### PR TITLE
refactor(index): finish Stroma extraction

### DIFF
--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -620,13 +620,13 @@ func loadDocSectionsContext(ctx context.Context, db *sql.DB, docs map[string]doc
 	var builder strings.Builder
 	args := make([]any, 0, 1+len(refs))
 	builder.WriteString(`
-SELECT c.artifact_ref, c.section, c.content, cv.embedding
+SELECT c.record_ref, c.heading, c.content, cv.embedding
 FROM chunks c
 JOIN chunks_vec cv ON cv.chunk_id = c.id
-JOIN artifacts a ON a.ref = c.artifact_ref
+JOIN artifacts a ON a.ref = c.record_ref
 WHERE a.kind = ?`)
 	args = append(args, model.ArtifactKindDoc)
-	appendRefFilterClause(&builder, &args, "c.artifact_ref", refs)
+	appendRefFilterClause(&builder, &args, "c.record_ref", refs)
 	builder.WriteString(`
 ORDER BY c.id`)
 

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -440,13 +440,13 @@ func loadSpecSectionsContext(ctx context.Context, db *sql.DB, specs map[string]s
 	var builder strings.Builder
 	args := make([]any, 0, 1+len(refs))
 	builder.WriteString(`
-SELECT c.artifact_ref, c.section, c.content, cv.embedding
+SELECT c.record_ref, c.heading, c.content, cv.embedding
 FROM chunks c
 JOIN chunks_vec cv ON cv.chunk_id = c.id
-JOIN artifacts a ON a.ref = c.artifact_ref
+JOIN artifacts a ON a.ref = c.record_ref
 WHERE a.kind = ?`)
 	args = append(args, model.ArtifactKindSpec)
-	appendRefFilterClause(&builder, &args, "c.artifact_ref", refs)
+	appendRefFilterClause(&builder, &args, "c.record_ref", refs)
 	builder.WriteString(`
 ORDER BY c.id`)
 

--- a/internal/analysis/repository_similarity.go
+++ b/internal/analysis/repository_similarity.go
@@ -220,11 +220,11 @@ WITH vector_hits AS (
 )
 SELECT
   a.ref,
-  c.section,
+  c.heading,
   vh.distance
 FROM vector_hits vh
 JOIN chunks c ON c.id = vh.chunk_id
-JOIN artifacts a ON a.ref = c.artifact_ref
+JOIN artifacts a ON a.ref = c.record_ref
 WHERE a.kind = ?`)
 	args = append(args, queryBlob, shortlistChunkProbeLimit(limit), query.Kind)
 
@@ -253,7 +253,7 @@ WHERE a.kind = ?`)
 	}
 
 	builder.WriteString(`
-ORDER BY vh.distance ASC, a.ref ASC, c.section ASC, vh.chunk_id ASC
+ORDER BY vh.distance ASC, a.ref ASC, c.heading ASC, vh.chunk_id ASC
 LIMIT ?`)
 	args = append(args, shortlistChunkProbeLimit(limit))
 

--- a/internal/analysis/semantic_terminology.go
+++ b/internal/analysis/semantic_terminology.go
@@ -204,12 +204,12 @@ SELECT
   a.ref,
   a.title,
   a.source_ref,
-  c.section,
+  c.heading,
   c.content,
   vh.distance
 FROM vector_hits vh
 JOIN chunks c ON c.id = vh.chunk_id
-JOIN artifacts a ON a.ref = c.artifact_ref
+JOIN artifacts a ON a.ref = c.record_ref
 WHERE a.kind = ?
 ORDER BY vh.distance ASC
 LIMIT ?`, []any{queryBlob, semanticTerminologyShortlistLimit * 4, kind, semanticTerminologyShortlistLimit}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -23,7 +23,7 @@ import (
 	stindex "github.com/dusk-network/stroma/index"
 )
 
-const schemaVersion = 8
+const schemaVersion = 9
 
 // RebuildResult reports the staged rebuild outcome.
 // When Update is true, the result describes an incremental update instead of a full rebuild.
@@ -242,13 +242,6 @@ func corpusRecordsFromLoadResult(records *source.LoadResult) ([]stcorpus.Record,
 
 func corpusRecordFromSpec(spec model.SpecRecord) (stcorpus.Record, error) {
 	metadata := cloneMetadata(spec.Metadata)
-	if status := strings.TrimSpace(spec.Status); status != "" {
-		metadata["pituitary_status"] = status
-	}
-	if domain := strings.TrimSpace(spec.Domain); domain != "" {
-		metadata["pituitary_domain"] = domain
-	}
-	metadata["pituitary_adapter"] = adapterFromMetadata(metadata)
 
 	return stcorpus.Record{
 		Ref:         spec.Ref,
@@ -263,9 +256,6 @@ func corpusRecordFromSpec(spec model.SpecRecord) (stcorpus.Record, error) {
 }
 
 func corpusRecordFromDoc(doc model.DocRecord) (stcorpus.Record, error) {
-	metadata := cloneMetadata(doc.Metadata)
-	metadata["pituitary_adapter"] = adapterFromMetadata(metadata)
-
 	return stcorpus.Record{
 		Ref:         doc.Ref,
 		Kind:        doc.Kind,
@@ -274,7 +264,7 @@ func corpusRecordFromDoc(doc model.DocRecord) (stcorpus.Record, error) {
 		BodyFormat:  doc.BodyFormat,
 		BodyText:    doc.BodyText,
 		ContentHash: doc.ContentHash,
-		Metadata:    metadata,
+		Metadata:    cloneMetadata(doc.Metadata),
 	}.Normalized()
 }
 
@@ -303,7 +293,7 @@ func finalizeStromaIndexContext(ctx context.Context, db *sql.DB, cfg *config.Con
 	if err := extendStromaSchemaContext(ctx, tx); err != nil {
 		return err
 	}
-	if err := populatePituitaryRecordFieldsContext(ctx, tx, records); err != nil {
+	if err := populatePituitaryRecordsContext(ctx, tx, records); err != nil {
 		return err
 	}
 
@@ -378,37 +368,29 @@ func finalizeStromaIndexContext(ctx context.Context, db *sql.DB, cfg *config.Con
 
 func extendStromaSchemaContext(ctx context.Context, tx *sql.Tx) error {
 	statements := []string{
-		`ALTER TABLE records ADD COLUMN status TEXT`,
-		`ALTER TABLE records ADD COLUMN domain TEXT`,
-		`ALTER TABLE records ADD COLUMN adapter TEXT NOT NULL DEFAULT 'filesystem'`,
-		`ALTER TABLE records ADD COLUMN valid_from TEXT`,
-		`ALTER TABLE records ADD COLUMN valid_to TEXT`,
-		`ALTER TABLE chunks RENAME TO chunk_records`,
+		`CREATE TABLE pituitary_records (
+			record_ref TEXT PRIMARY KEY,
+			status     TEXT,
+			domain     TEXT,
+			adapter    TEXT NOT NULL DEFAULT 'filesystem',
+			FOREIGN KEY (record_ref) REFERENCES records(ref) ON DELETE CASCADE
+		)`,
 		`CREATE VIEW artifacts AS
 			SELECT
-				ref,
-				kind,
-				title,
-				status,
-				domain,
-				source_ref,
-				adapter,
-				body_format,
-				content_hash,
-				metadata_json,
-				valid_from,
-				valid_to
-			FROM records`,
-		`CREATE VIEW chunks AS
-			SELECT
-				id,
-				record_ref,
-				chunk_index,
-				heading,
-				content,
-				record_ref AS artifact_ref,
-				heading AS section
-			FROM chunk_records`,
+				r.ref,
+				r.kind,
+				r.title,
+				pr.status,
+				pr.domain,
+				r.source_ref,
+				COALESCE(pr.adapter, 'filesystem') AS adapter,
+				r.body_format,
+				r.content_hash,
+				r.metadata_json,
+				NULL AS valid_from,
+				NULL AS valid_to
+			FROM records r
+			LEFT JOIN pituitary_records pr ON pr.record_ref = r.ref`,
 		`CREATE TABLE edges (
 			from_ref         TEXT NOT NULL,
 			to_ref           TEXT NOT NULL,
@@ -426,8 +408,7 @@ func extendStromaSchemaContext(ctx context.Context, tx *sql.Tx) error {
 			symbols_json   TEXT NOT NULL,
 			rationale_json TEXT NOT NULL DEFAULT '[]'
 		)`,
-		`CREATE INDEX idx_artifacts_kind_status_domain ON records(kind, status, domain)`,
-		`CREATE INDEX idx_chunks_artifact_ref ON chunk_records(record_ref)`,
+		`CREATE INDEX idx_artifacts_kind_status_domain ON pituitary_records(status, domain, record_ref)`,
 		`CREATE INDEX idx_edges_from_ref_type ON edges(from_ref, edge_type)`,
 		`CREATE INDEX idx_edges_to_ref_type ON edges(to_ref, edge_type)`,
 	}
@@ -440,37 +421,33 @@ func extendStromaSchemaContext(ctx context.Context, tx *sql.Tx) error {
 	return nil
 }
 
-func populatePituitaryRecordFieldsContext(ctx context.Context, tx *sql.Tx, records *source.LoadResult) error {
-	stmt, err := tx.PrepareContext(ctx, `UPDATE records SET status = ?, domain = ?, adapter = ?, valid_from = ?, valid_to = ? WHERE ref = ?`)
+func populatePituitaryRecordsContext(ctx context.Context, tx *sql.Tx, records *source.LoadResult) error {
+	stmt, err := tx.PrepareContext(ctx, `INSERT INTO pituitary_records (record_ref, status, domain, adapter) VALUES (?, ?, ?, ?)`)
 	if err != nil {
-		return fmt.Errorf("prepare record augmentation: %w", err)
+		return fmt.Errorf("prepare pituitary record insert: %w", err)
 	}
 	defer stmt.Close()
 
 	for _, spec := range records.Specs {
 		if _, err := stmt.ExecContext(
 			ctx,
+			spec.Ref,
 			nullableString(strings.TrimSpace(spec.Status)),
 			nullableString(strings.TrimSpace(spec.Domain)),
 			adapterFromMetadata(spec.Metadata),
-			nil,
-			nil,
-			spec.Ref,
 		); err != nil {
-			return fmt.Errorf("augment spec record %s: %w", spec.Ref, err)
+			return fmt.Errorf("insert pituitary spec record %s: %w", spec.Ref, err)
 		}
 	}
 	for _, doc := range records.Docs {
 		if _, err := stmt.ExecContext(
 			ctx,
+			doc.Ref,
 			nil,
 			nil,
 			adapterFromMetadata(doc.Metadata),
-			nil,
-			nil,
-			doc.Ref,
 		); err != nil {
-			return fmt.Errorf("augment doc record %s: %w", doc.Ref, err)
+			return fmt.Errorf("insert pituitary doc record %s: %w", doc.Ref, err)
 		}
 	}
 	return nil
@@ -723,50 +700,43 @@ func createSchemaContext(ctx context.Context, db *sql.DB, dimension int) error {
 			body_format   TEXT NOT NULL,
 			body_text     TEXT NOT NULL,
 			content_hash  TEXT NOT NULL,
-			metadata_json TEXT NOT NULL,
-			status        TEXT,
-			domain        TEXT,
-			adapter       TEXT NOT NULL DEFAULT 'filesystem',
-			valid_from    TEXT,
-			valid_to      TEXT
+			metadata_json TEXT NOT NULL
 		)`,
-		`CREATE TABLE chunk_records (
+		`CREATE TABLE chunks (
 			id            INTEGER PRIMARY KEY AUTOINCREMENT,
 			record_ref    TEXT NOT NULL,
 			chunk_index   INTEGER NOT NULL,
 			heading       TEXT,
 			content       TEXT NOT NULL,
-			FOREIGN KEY (record_ref) REFERENCES records(ref)
+			FOREIGN KEY (record_ref) REFERENCES records(ref) ON DELETE CASCADE
 		)`,
 		fmt.Sprintf(`CREATE VIRTUAL TABLE chunks_vec USING vec0(
 			chunk_id INTEGER PRIMARY KEY,
 			embedding float[%d] distance_metric=cosine
 		)`, dimension),
+		`CREATE TABLE pituitary_records (
+			record_ref TEXT PRIMARY KEY,
+			status     TEXT,
+			domain     TEXT,
+			adapter    TEXT NOT NULL DEFAULT 'filesystem',
+			FOREIGN KEY (record_ref) REFERENCES records(ref) ON DELETE CASCADE
+		)`,
 		`CREATE VIEW artifacts AS
 			SELECT
-				ref,
-				kind,
-				title,
-				status,
-				domain,
-				source_ref,
-				adapter,
-				body_format,
-				content_hash,
-				metadata_json,
-				valid_from,
-				valid_to
-			FROM records`,
-		`CREATE VIEW chunks AS
-			SELECT
-				id,
-				record_ref,
-				chunk_index,
-				heading,
-				content,
-				record_ref AS artifact_ref,
-				heading AS section
-			FROM chunk_records`,
+				r.ref,
+				r.kind,
+				r.title,
+				pr.status,
+				pr.domain,
+				r.source_ref,
+				COALESCE(pr.adapter, 'filesystem') AS adapter,
+				r.body_format,
+				r.content_hash,
+				r.metadata_json,
+				NULL AS valid_from,
+				NULL AS valid_to
+			FROM records r
+			LEFT JOIN pituitary_records pr ON pr.record_ref = r.ref`,
 		`CREATE TABLE edges (
 			from_ref         TEXT NOT NULL,
 			to_ref           TEXT NOT NULL,
@@ -788,10 +758,10 @@ func createSchemaContext(ctx context.Context, db *sql.DB, dimension int) error {
 			key           TEXT PRIMARY KEY,
 			value         TEXT NOT NULL
 		)`,
+		`CREATE INDEX idx_records_kind ON records(kind)`,
+		`CREATE INDEX idx_chunks_record_ref ON chunks(record_ref)`,
 		`CREATE INDEX idx_artifacts_kind_status_domain
-			ON records(kind, status, domain)`,
-		`CREATE INDEX idx_chunks_artifact_ref
-			ON chunk_records(record_ref)`,
+			ON pituitary_records(status, domain, record_ref)`,
 		`CREATE INDEX idx_edges_from_ref_type
 			ON edges(from_ref, edge_type)`,
 		`CREATE INDEX idx_edges_to_ref_type
@@ -813,8 +783,8 @@ func insertSpecArtifactContext(ctx context.Context, tx *sql.Tx, spec model.SpecR
 	}
 	_, err = tx.ExecContext(
 		ctx,
-		`INSERT INTO records (ref, kind, title, source_ref, body_format, body_text, content_hash, metadata_json, status, domain, adapter)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO records (ref, kind, title, source_ref, body_format, body_text, content_hash, metadata_json)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		spec.Ref,
 		spec.Kind,
 		spec.Title,
@@ -823,14 +793,11 @@ func insertSpecArtifactContext(ctx context.Context, tx *sql.Tx, spec model.SpecR
 		spec.BodyText,
 		spec.ContentHash,
 		string(metadataJSON),
-		nullableString(strings.TrimSpace(spec.Status)),
-		nullableString(strings.TrimSpace(spec.Domain)),
-		adapterFromMetadata(spec.Metadata),
 	)
 	if err != nil {
 		return fmt.Errorf("insert spec artifact %s: %w", spec.Ref, err)
 	}
-	return nil
+	return insertPituitaryRecordContext(ctx, tx, spec.Ref, nullableString(strings.TrimSpace(spec.Status)), nullableString(strings.TrimSpace(spec.Domain)), adapterFromMetadata(spec.Metadata))
 }
 
 func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocRecord) error {
@@ -840,8 +807,8 @@ func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocReco
 	}
 	_, err = tx.ExecContext(
 		ctx,
-		`INSERT INTO records (ref, kind, title, source_ref, body_format, body_text, content_hash, metadata_json, status, domain, adapter)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO records (ref, kind, title, source_ref, body_format, body_text, content_hash, metadata_json)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		doc.Ref,
 		doc.Kind,
 		doc.Title,
@@ -850,12 +817,23 @@ func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocReco
 		doc.BodyText,
 		doc.ContentHash,
 		string(metadataJSON),
-		nil,
-		nil,
-		adapterFromMetadata(doc.Metadata),
 	)
 	if err != nil {
 		return fmt.Errorf("insert doc artifact %s: %w", doc.Ref, err)
+	}
+	return insertPituitaryRecordContext(ctx, tx, doc.Ref, nil, nil, adapterFromMetadata(doc.Metadata))
+}
+
+func insertPituitaryRecordContext(ctx context.Context, tx *sql.Tx, ref string, status any, domain any, adapter string) error {
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO pituitary_records (record_ref, status, domain, adapter) VALUES (?, ?, ?, ?)`,
+		ref,
+		status,
+		domain,
+		adapter,
+	); err != nil {
+		return fmt.Errorf("insert pituitary record %s: %w", ref, err)
 	}
 	return nil
 }

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -78,9 +78,9 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 	})
 
 	assertSchemaObject(t, db, "view", "artifacts")
-	assertSchemaObject(t, db, "view", "chunks")
 	assertSchemaObject(t, db, "table", "records")
-	assertSchemaObject(t, db, "table", "chunk_records")
+	assertSchemaObject(t, db, "table", "pituitary_records")
+	assertSchemaObject(t, db, "table", "chunks")
 	assertSchemaObject(t, db, "table", "chunks_vec")
 	assertSchemaObject(t, db, "table", "edges")
 	assertSchemaObject(t, db, "index", "idx_artifacts_kind_status_domain")
@@ -571,7 +571,7 @@ func assertMetadataValue(t *testing.T, db *sql.DB, key, want string) {
 func assertSections(t *testing.T, db *sql.DB, artifactRef string, want []string) {
 	t.Helper()
 
-	rows, err := db.Query(`SELECT section FROM chunks WHERE artifact_ref = ? ORDER BY id`, artifactRef)
+	rows, err := db.Query(`SELECT heading FROM chunks WHERE record_ref = ? ORDER BY id`, artifactRef)
 	if err != nil {
 		t.Fatalf("query sections for %s: %v", artifactRef, err)
 	}
@@ -718,8 +718,8 @@ func TestRebuildSetsTemporalValidityOnEdges(t *testing.T) {
 	if err := db.QueryRow(`SELECT value FROM metadata WHERE key = 'schema_version'`).Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != "8" {
-		t.Errorf("schema_version = %q, want 8", version)
+	if version != "9" {
+		t.Errorf("schema_version = %q, want 9", version)
 	}
 
 	// Verify that manual edges have valid_from set to today (YYYY-MM-DD).

--- a/internal/index/reuse.go
+++ b/internal/index/reuse.go
@@ -106,11 +106,10 @@ func loadStoredArtifactsContext(ctx context.Context, db *sql.DB) (*reuseState, e
 	}
 
 	rows, err = db.QueryContext(ctx, `
-SELECT a.ref, c.section, c.content, v.embedding
+SELECT c.record_ref, c.heading, c.content, v.embedding
 FROM chunks c
-JOIN artifacts a ON a.ref = c.artifact_ref
 JOIN chunks_vec v ON v.chunk_id = c.id
-ORDER BY a.ref, c.id`)
+ORDER BY c.record_ref, c.id`)
 	if err != nil {
 		return nil, fmt.Errorf("query stored chunks: %w", err)
 	}

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -3,7 +3,6 @@ package index
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/ranking"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
+	stindex "github.com/dusk-network/stroma/index"
 )
 
 const (
@@ -149,18 +149,15 @@ func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpe
 	}
 	defer db.Close()
 
-	vectors, err := embedder.EmbedQueries(ctx, []string{query.Query})
+	dimension, err := embedder.Dimension(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("embed query: %w", err)
+		return nil, fmt.Errorf("resolve embedder dimension: %w", err)
 	}
-	if len(vectors) != 1 {
-		return nil, fmt.Errorf("embed query: returned %d vector(s) for 1 query", len(vectors))
-	}
-	if err := validateStoredEmbedderContext(ctx, db, embedder.Fingerprint(), len(vectors[0])); err != nil {
+	if err := validateStoredEmbedderContext(ctx, db, embedder.Fingerprint(), dimension); err != nil {
 		return nil, err
 	}
 
-	candidates, err := loadRankedCandidatesContext(ctx, db, query, vectors[0])
+	candidates, err := loadRankedCandidatesContext(ctx, db, cfg.Workspace.ResolvedIndexPath, embedder, query)
 	if err != nil {
 		return nil, err
 	}
@@ -274,67 +271,54 @@ func validateStoredEmbedderContext(ctx context.Context, db *sql.DB, fingerprint 
 	return nil
 }
 
-func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, query SearchSpecQuery, queryEmbedding []float64) ([]chunkCandidate, error) {
-	queryBlob, err := encodeVectorBlob(queryEmbedding)
-	if err != nil {
-		return nil, fmt.Errorf("encode query embedding: %w", err)
-	}
+func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, indexPath string, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {
 	preferHistorical := ranking.SearchPrefersHistoricalContext(query.Query)
 
-	sqlText, args := buildCandidateQuery(query, queryBlob)
-	rows, err := db.QueryContext(ctx, sqlText, args...)
+	hits, err := stindex.Search(ctx, stindex.SearchQuery{
+		Path:     indexPath,
+		Text:     query.Query,
+		Limit:    searchCandidateLimit(query.Limit),
+		Kinds:    []string{query.Kind},
+		Embedder: embedder,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("query search candidates: %w", err)
 	}
-	defer rows.Close()
+
+	states, err := loadSearchArtifactStateContext(ctx, db, refsForSearchHits(hits))
+	if err != nil {
+		return nil, err
+	}
 
 	candidates := make([]chunkCandidate, 0, query.Limit)
-	for rows.Next() {
-		var (
-			candidate   chunkCandidate
-			rawMetadata string
-			distance    float64
-		)
-		if err := rows.Scan(
-			&candidate.ChunkID,
-			&candidate.Ref,
-			&candidate.Title,
-			&candidate.SectionHeading,
-			&candidate.Content,
-			&candidate.SourceRef,
-			&candidate.Kind,
-			&candidate.Status,
-			&candidate.Domain,
-			&rawMetadata,
-			&distance,
-		); err != nil {
-			return nil, fmt.Errorf("scan search candidate: %w", err)
+	for _, hit := range hits {
+		state := states[hit.Ref]
+		candidate := chunkCandidate{
+			ChunkID:        hit.ChunkID,
+			Ref:            hit.Ref,
+			Title:          hit.Title,
+			SectionHeading: hit.Heading,
+			Content:        strings.TrimSpace(hit.Content),
+			SourceRef:      hit.SourceRef,
+			Kind:           hit.Kind,
+			Status:         state.Status,
+			Domain:         state.Domain,
 		}
-		if strings.TrimSpace(rawMetadata) != "" {
-			metadata := map[string]string{}
-			if err := json.Unmarshal([]byte(rawMetadata), &metadata); err != nil {
-				return nil, fmt.Errorf("parse search metadata for %s: %w", candidate.Ref, err)
-			}
-			candidate.Repo = strings.TrimSpace(metadata["repo_id"])
-			candidate.Inference, err = model.DecodeInferenceConfidence(metadata)
+		if !candidateMatchesSearchQuery(candidate, query) {
+			continue
+		}
+		if len(hit.Metadata) > 0 {
+			candidate.Repo = strings.TrimSpace(hit.Metadata["repo_id"])
+			candidate.Inference, err = model.DecodeInferenceConfidence(hit.Metadata)
 			if err != nil {
 				return nil, fmt.Errorf("decode search inference for %s: %w", candidate.Ref, err)
 			}
 		}
-
-		candidate.Content = strings.TrimSpace(candidate.Content)
-		candidate.Score = ranking.AdjustHistoricalSectionScore(
-			cosineScoreFromDistance(distance),
-			candidate.SectionHeading,
-			preferHistorical,
-		)
+		candidate.Score = ranking.AdjustHistoricalSectionScore(hit.Score, candidate.SectionHeading, preferHistorical)
 		if candidate.Score <= 0 {
 			continue
 		}
 		candidates = append(candidates, candidate)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate search candidates: %w", err)
 	}
 	sort.Slice(candidates, func(i, j int) bool {
 		switch {
@@ -354,58 +338,94 @@ func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, query SearchSp
 	return candidates, nil
 }
 
-func buildCandidateQuery(query SearchSpecQuery, queryBlob []byte) (string, []any) {
-	var builder strings.Builder
-	args := make([]any, 0, 4+len(query.Statuses))
+type searchArtifactState struct {
+	Status string
+	Domain string
+}
 
-	builder.WriteString(`
-WITH vector_hits AS (
-  SELECT chunk_id, distance
-  FROM chunks_vec
-  WHERE embedding MATCH ? AND k = ?
-  ORDER BY distance
-)
-SELECT
-  vh.chunk_id,
-  a.ref,
-  a.title,
-  c.section,
-  c.content,
-  a.source_ref,
-  a.kind,
-  COALESCE(a.status, ''),
-  COALESCE(a.domain, ''),
-  a.metadata_json,
-  vh.distance
-FROM vector_hits vh
-JOIN chunks c ON c.id = vh.chunk_id
-JOIN artifacts a ON a.ref = c.artifact_ref
-WHERE a.kind = ?`)
-	args = append(args, queryBlob, searchCandidateLimit(query.Limit), query.Kind)
-
-	if len(query.Statuses) > 0 {
-		builder.WriteString(" AND a.status IN (")
-		for i, status := range query.Statuses {
-			if i > 0 {
-				builder.WriteString(", ")
-			}
-			builder.WriteString("?")
-			args = append(args, status)
+func refsForSearchHits(hits []stindex.SearchHit) []string {
+	if len(hits) == 0 {
+		return nil
+	}
+	refs := make([]string, 0, len(hits))
+	seen := make(map[string]struct{}, len(hits))
+	for _, hit := range hits {
+		if _, ok := seen[hit.Ref]; ok {
+			continue
 		}
-		builder.WriteString(")")
+		seen[hit.Ref] = struct{}{}
+		refs = append(refs, hit.Ref)
+	}
+	return refs
+}
+
+func loadSearchArtifactStateContext(ctx context.Context, db *sql.DB, refs []string) (map[string]searchArtifactState, error) {
+	states := make(map[string]searchArtifactState, len(refs))
+	if len(refs) == 0 {
+		return states, nil
 	}
 
-	if query.Domain != "" {
-		builder.WriteString(" AND a.domain = ?")
-		args = append(args, query.Domain)
-	}
+	var builder strings.Builder
+	args := make([]any, 0, len(refs))
 
 	builder.WriteString(`
-ORDER BY vh.distance ASC, a.ref ASC, c.section ASC, vh.chunk_id ASC
-LIMIT ?`)
-	args = append(args, searchCandidateLimit(query.Limit))
+SELECT
+  a.ref,
+  COALESCE(a.status, ''),
+  COALESCE(a.domain, '')
+FROM artifacts a
+WHERE a.ref IN (`)
+	for i, ref := range refs {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString("?")
+		args = append(args, ref)
+	}
+	builder.WriteString(`)`)
 
-	return builder.String(), args
+	rows, err := db.QueryContext(ctx, builder.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query search record state: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			ref    string
+			status string
+			domain string
+		)
+		if err := rows.Scan(&ref, &status, &domain); err != nil {
+			return nil, fmt.Errorf("scan search record state: %w", err)
+		}
+		states[ref] = searchArtifactState{Status: status, Domain: domain}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate search record state: %w", err)
+	}
+	return states, nil
+}
+
+func candidateMatchesSearchQuery(candidate chunkCandidate, query SearchSpecQuery) bool {
+	if candidate.Kind != query.Kind {
+		return false
+	}
+	if len(query.Statuses) > 0 {
+		matched := false
+		for _, status := range query.Statuses {
+			if candidate.Status == status {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if query.Domain != "" && candidate.Domain != query.Domain {
+		return false
+	}
+	return true
 }
 
 func searchCandidateLimit(limit int) int {

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -217,7 +217,7 @@ func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Confi
 	}
 
 	// Prepare insert statements.
-	chunkStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunk_records (record_ref, chunk_index, heading, content) VALUES (?, ?, ?, ?)`)
+	chunkStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunks (record_ref, chunk_index, heading, content) VALUES (?, ?, ?, ?)`)
 	if err != nil {
 		return nil, fmt.Errorf("prepare chunk insert: %w", err)
 	}
@@ -502,10 +502,10 @@ func loadStoredChunksForRefsContext(ctx context.Context, db *sql.DB, refs []stri
 	// Load chunks with embeddings.
 	for _, ref := range refs {
 		rows, err := db.QueryContext(ctx, `
-SELECT c.section, c.content, v.embedding
+SELECT c.heading, c.content, v.embedding
 FROM chunks c
 JOIN chunks_vec v ON v.chunk_id = c.id
-WHERE c.artifact_ref = ?
+WHERE c.record_ref = ?
 ORDER BY c.id`, ref)
 		if err != nil {
 			return nil, fmt.Errorf("query stored chunks for %s: %w", ref, err)
@@ -540,11 +540,11 @@ ORDER BY c.id`, ref)
 // vectors from the database within a transaction.
 func deleteArtifactDataContext(ctx context.Context, tx *sql.Tx, ref string) error {
 	// Delete vectors (vec0 virtual table) via subquery on chunks.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks_vec WHERE chunk_id IN (SELECT id FROM chunk_records WHERE record_ref = ?)`, ref); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks_vec WHERE chunk_id IN (SELECT id FROM chunks WHERE record_ref = ?)`, ref); err != nil {
 		return fmt.Errorf("delete vectors for %s: %w", ref, err)
 	}
 	// Delete chunks.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM chunk_records WHERE record_ref = ?`, ref); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks WHERE record_ref = ?`, ref); err != nil {
 		return fmt.Errorf("delete chunks for %s: %w", ref, err)
 	}
 	// Delete artifact.
@@ -586,7 +586,7 @@ func countChunksForRefsContext(ctx context.Context, db *sql.DB, refs []string) (
 	if len(refs) == 0 {
 		return 0, nil
 	}
-	query := `SELECT COUNT(*) FROM chunk_records WHERE record_ref IN (` + placeholders(len(refs)) + `)`
+	query := `SELECT COUNT(*) FROM chunks WHERE record_ref IN (` + placeholders(len(refs)) + `)`
 	args := make([]any, 0, len(refs))
 	for _, ref := range refs {
 		args = append(args, ref)

--- a/internal/index/update_test.go
+++ b/internal/index/update_test.go
@@ -168,7 +168,7 @@ include = ["guides/*.md"]
 	defer db.Close()
 	assertCount(t, db, `SELECT COUNT(*) FROM artifacts`, 1)
 	// Verify no orphaned chunks.
-	assertCount(t, db, `SELECT COUNT(*) FROM chunks WHERE artifact_ref NOT IN (SELECT ref FROM artifacts)`, 0)
+	assertCount(t, db, `SELECT COUNT(*) FROM chunks WHERE record_ref NOT IN (SELECT ref FROM records)`, 0)
 }
 
 func TestUpdateChangedArtifact(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep Stroma as the owner of base index storage and move Pituitary-only fields into a `pituitary_records` sidecar table
- switch `search-specs` to `stroma/index.Search` and apply Pituitary status/domain ranking filters on top of Stroma hits
- migrate reuse, update, and section-loading analysis paths onto the Stroma `records`/`chunks` layout while keeping a zero-copy `artifacts` compatibility view

## Why
The previous branch only moved rebuild onto Stroma. Pituitary still duplicated substrate ownership by extending Stroma tables directly and by querying a Pituitary-shaped compatibility chunk surface. This change completes the extraction boundary so Stroma owns corpus storage and Pituitary owns governance/state on top.

## Validation
- `go test ./internal/index`
- `go test ./internal/analysis`
- `go test ./...`