### PR TITLE
Adopt Stroma snapshots as the corpus boundary

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   claude-review:
+    if: ${{ vars.CLAUDE_CODE_REVIEW_ENABLED == 'true' }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ The first shipping slice should be intentionally narrow. It exists to prove that
 - Local filesystem only
 - One metadata format for specs: `spec.toml`
 - One body format for specs and docs: Markdown
-- One index backend: local SQLite + `sqlite-vec`
+- One embedded corpus backend: local SQLite + `sqlite-vec` via Stroma, plus a local Pituitary governance DB
 - One required transport: CLI
 - Five required analysis capabilities:
   - `search_specs`
@@ -151,17 +151,15 @@ When teams want more rigor, Pituitary may optionally generate an explicit spec b
 │  2. Chunk text                                               │
 │  3. Generate embeddings                                      │
 │  4. Build relations graph                                    │
-│  5. Atomically rebuild pituitary.db                          │
+│  5. Publish a Stroma snapshot + rebuild pituitary.db         │
 └──────────────────────────────┬───────────────────────────────┘
                                │
                                ▼
 ┌──────────────────────────────────────────────────────────────┐
-│                     Unified Analysis Index                    │
+│                       Local Stores                            │
 │                                                              │
-│  • artifacts   (canonical records)                           │
-│  • chunks      (text sections)                               │
-│  • chunks_vec  (embeddings)                                  │
-│  • edges       (depends_on / supersedes / applies_to)        │
+│  • Stroma snapshot: records / chunks / chunks_vec / metadata │
+│  • pituitary.db: artifacts / edges / ast_cache / metadata    │
 └──────────────────────────────┬───────────────────────────────┘
                                │ queries
                                ▼
@@ -398,6 +396,7 @@ Step 5: Graph Build
   └── Keep all refs in canonical string form
 
 Step 6: Atomic Swap
+  ├── Publish the rebuilt Stroma snapshot
   └── Replace the active pituitary.db with the rebuilt staging DB
 ```
 
@@ -443,13 +442,18 @@ Retry and timeout rules:
 
 **Chunking strategy:** The current implementation uses a lightweight internal Markdown scanner that splits on ATX headings, preserves the nested heading path in each section title, and falls back to one title-scoped chunk when a document has no headings. For non-Markdown inputs, adapters should either provide text with lightweight structural markers or let the chunker fall back to paragraph-based splitting.
 
-**Filtered vector queries:** `chunks_vec` should store only vectors. Metadata filters stay in canonical tables: vector search returns candidate `chunk_id`s, then the query joins back through `chunks` and `artifacts` to filter by `kind`, `status`, `domain`, or other metadata before ranking the final candidate set.
+**Filtered vector queries:** Stroma owns `chunks_vec`, `chunks`, and `records`, and should resolve corpus-local joins behind its library API. Pituitary should ask Stroma for candidate sections, then apply governance filters such as `status`, `domain`, and other business metadata against `artifacts` before ranking the final candidate set.
 
 ---
 
 ### 4. Storage Layer — Unified SQLite Index
 
-All indexed state lives in a **single SQLite database** (`pituitary.db`) using `sqlite-vec` for vector operations. At this scale, SQLite is enough, keeps deployment simple, and makes full atomic rebuilds straightforward. In the current Go implementation, `vec0` is wired through `github.com/mattn/go-sqlite3` plus `github.com/asg017/sqlite-vec-go-bindings/cgo`, so local and CI builds need a CGO-capable C toolchain.
+Indexed state is split into two local artifacts:
+
+- a Stroma snapshot that owns corpus records, chunks, vectors, and neutral metadata
+- `pituitary.db`, which owns governance metadata, edges, AST cache, and the pointer to the active Stroma snapshot
+
+At this scale, local SQLite is still enough, keeps deployment simple, and makes staged rebuilds straightforward. In the current Go implementation, `vec0` is wired through `github.com/mattn/go-sqlite3` plus `github.com/asg017/sqlite-vec-go-bindings/cgo`, so local and CI builds need a CGO-capable C toolchain.
 
 #### Schema
 
@@ -515,7 +519,7 @@ Code is intentionally **not** indexed as a third stored semantic corpus in v1. F
 
 #### Atomic Rebuild
 
-The indexer always writes to a **staging database** (`pituitary.db.new`) and then swaps it in. That guarantees each rebuilt index is internally consistent: metadata, chunks, vectors, and edges all come from the same snapshot.
+The indexer writes a staged `pituitary.db.new` and publishes a content-addressed local Stroma snapshot. The live Pituitary DB then points at that immutable snapshot, so governance metadata and corpus retrieval stay aligned without Pituitary querying Stroma tables directly.
 
 ```text
 pituitary index --rebuild
@@ -523,8 +527,8 @@ pituitary index --rebuild
   1. Create pituitary.db.new
   2. Load all records from configured adapters
   3. Reuse unchanged chunk vectors from the active index when schema + fingerprints still match
-  4. Populate artifacts + edges
-  5. Chunk text and populate chunks + chunks_vec
+  4. Publish the content-addressed Stroma snapshot
+  5. Populate artifacts + edges + snapshot pointer metadata in pituitary.db.new
   6. Run integrity checks
   7. Rename pituitary.db.new -> pituitary.db
   8. On failure: delete pituitary.db.new, keep existing index untouched
@@ -660,8 +664,8 @@ Process:
   Phase 1 — retrieval
   1. Parse or load the candidate spec body
   2. Chunk and embed it
-  3. Query chunks_vec for candidate chunk_ids
-  4. Join through chunks + artifacts to keep kind = "spec"
+  3. Ask Stroma for candidate sections
+  4. Filter candidates through `artifacts` to keep kind = "spec"
      and status != "deprecated"
      while still allowing `superseded` specs as historical candidates
   5. Group by artifact_ref and rank by similarity
@@ -964,10 +968,10 @@ All tools keep the same discipline: retrieval first, then deterministic analysis
 ### Workstream 2: Index and Retrieval
 
 - Build the SQLite schema
-- Implement full atomic rebuild into `.pituitary/pituitary.db`
+- Implement full atomic rebuild into the split-store layout (`pituitary.db` + Stroma snapshot)
 - Chunk Markdown by heading
 - Generate embeddings for spec and doc chunks
-- Implement filtered vector retrieval via `chunks_vec -> chunks -> artifacts`
+- Implement filtered retrieval via Stroma search plus Pituitary artifact filters
 - Ship `search_specs`
 
 ### Workstream 3: Core Spec Analysis

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 [Watch on asciinema](https://asciinema.org/a/4NBiD3tUyuwMWooT) for the interactive version.
 
-Single binary. No Docker. No API keys required. One SQLite file.
+Single binary. No Docker. No API keys required. One governance SQLite file plus one local Stroma snapshot.
 
 The core shipped slice is local and CLI-first. The MCP server, CI wiring, and provider-backed semantic runtimes are optional wrappers around that same deterministic core.
 
@@ -264,7 +264,7 @@ Retrieval remains deterministic. The analysis model only sees narrowly shortlist
 
 ## Architecture
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system design. Key decisions: deterministic retrieval first, tools-only (no embedded agent), single SQLite file with atomic rebuilds.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system design. Key decisions: deterministic retrieval first, tools-only (no embedded agent), one governance SQLite file plus an opaque local Stroma snapshot with atomic rebuilds.
 
 ## Project Status
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.9
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6
-	github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196
+	github.com/dusk-network/stroma v0.0.0-20260413131144-770dfc81a8dc
 	github.com/google/go-github/v79 v79.0.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196 h1:1TULfQD0OA8zpd7+4QaXpNcoosAkytPKkI+Xld2cTZs=
 github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
+github.com/dusk-network/stroma v0.0.0-20260413131144-770dfc81a8dc h1:4dPfDz6tAihHfnj89G+qSKJSvm0SVbBcuPtA6IVqrDw=
+github.com/dusk-network/stroma v0.0.0-20260413131144-770dfc81a8dc/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/analysis/benchmark_test.go
+++ b/internal/analysis/benchmark_test.go
@@ -185,11 +185,17 @@ func BenchmarkLoadIndexedTargets(b *testing.B) {
 	}
 	defer db.Close()
 
+	snapshot, err := index.OpenStromaSnapshotContext(context.Background(), db, fixture.cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		b.Fatalf("index.OpenStromaSnapshotContext() error = %v", err)
+	}
+	defer snapshot.Close()
+
 	b.Run("specs_selected", func(b *testing.B) {
 		refs := []string{"SPEC-042", "SPEC-055"}
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			specs, err := loadIndexedSpecsContext(context.Background(), db, refs)
+			specs, err := loadIndexedSpecsContext(context.Background(), db, snapshot, refs)
 			if err != nil {
 				b.Fatalf("loadIndexedSpecsContext() error = %v", err)
 			}
@@ -203,7 +209,7 @@ func BenchmarkLoadIndexedTargets(b *testing.B) {
 		refs := []string{"doc://guides/api-rate-limits", "doc://runbooks/rate-limit-rollout"}
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			docs, err := loadIndexedDocsContext(context.Background(), db, refs)
+			docs, err := loadIndexedDocsContext(context.Background(), db, snapshot, refs)
 			if err != nil {
 				b.Fatalf("loadIndexedDocsContext() error = %v", err)
 			}

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -13,9 +13,9 @@ import (
 	"unicode"
 
 	"github.com/dusk-network/pituitary/internal/config"
-	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
+	stindex "github.com/dusk-network/stroma/index"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -539,7 +539,7 @@ func normalizeDocDriftScope(request DocDriftRequest) (DocDriftScope, error) {
 	}
 }
 
-func loadIndexedDocsContext(ctx context.Context, db *sql.DB, refs []string) (map[string]docDocument, error) {
+func loadIndexedDocsContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, refs []string) (map[string]docDocument, error) {
 	rows, err := loadIndexedDocRowsContext(ctx, db, refs)
 	if err != nil {
 		return nil, err
@@ -558,7 +558,7 @@ func loadIndexedDocsContext(ctx context.Context, db *sql.DB, refs []string) (map
 			},
 		}
 	}
-	if err := loadDocSectionsContext(ctx, db, docs); err != nil {
+	if err := loadDocSectionsContext(ctx, snapshot, docs); err != nil {
 		return nil, err
 	}
 	return docs, nil
@@ -611,58 +611,32 @@ WHERE kind = ?`)
 	return result, nil
 }
 
-func loadDocSectionsContext(ctx context.Context, db *sql.DB, docs map[string]docDocument) error {
+func loadDocSectionsContext(ctx context.Context, snapshot *stindex.Snapshot, docs map[string]docDocument) error {
 	refs := sortedDocRefs(docs)
 	if len(refs) == 0 {
 		return nil
 	}
 
-	var builder strings.Builder
-	args := make([]any, 0, 1+len(refs))
-	builder.WriteString(`
-SELECT c.record_ref, c.heading, c.content, cv.embedding
-FROM chunks c
-JOIN chunks_vec cv ON cv.chunk_id = c.id
-JOIN artifacts a ON a.ref = c.record_ref
-WHERE a.kind = ?`)
-	args = append(args, model.ArtifactKindDoc)
-	appendRefFilterClause(&builder, &args, "c.record_ref", refs)
-	builder.WriteString(`
-ORDER BY c.id`)
-
-	rows, err := db.QueryContext(ctx, builder.String(), args...)
+	sections, err := snapshot.Sections(ctx, stindex.SectionQuery{
+		Refs:              refs,
+		Kinds:             []string{model.ArtifactKindDoc},
+		IncludeEmbeddings: true,
+	})
 	if err != nil {
 		return fmt.Errorf("query doc sections: %w", err)
 	}
-	defer rows.Close()
 
-	for rows.Next() {
-		var (
-			ref           string
-			heading       string
-			content       string
-			embeddingBlob []byte
-		)
-		if err := rows.Scan(&ref, &heading, &content, &embeddingBlob); err != nil {
-			return fmt.Errorf("scan doc section: %w", err)
-		}
-		document, ok := docs[ref]
+	for _, section := range sections {
+		document, ok := docs[section.Ref]
 		if !ok {
 			continue
 		}
-		embedding, err := index.DecodeVectorBlob(embeddingBlob)
-		if err != nil {
-			return fmt.Errorf("decode doc embedding for %s: %w", ref, err)
-		}
 		document.Sections = append(document.Sections, embeddedSection{
-			Heading:   heading,
-			Content:   content,
-			Embedding: embedding,
+			Heading:   section.Heading,
+			Content:   section.Content,
+			Embedding: append([]float64(nil), section.Embedding...),
 		})
-		docs[ref] = document
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate doc sections: %w", err)
+		docs[section.Ref] = document
 	}
 	return nil
 }

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
+	stindex "github.com/dusk-network/stroma/index"
 )
 
 const (
@@ -292,7 +293,7 @@ func validateDraftSpec(record model.SpecRecord) error {
 	return nil
 }
 
-func loadIndexedSpecsContext(ctx context.Context, db *sql.DB, refs []string) (map[string]specDocument, error) {
+func loadIndexedSpecsContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, refs []string) (map[string]specDocument, error) {
 	artifacts, err := loadIndexedArtifactRowsContext(ctx, db, refs)
 	if err != nil {
 		return nil, err
@@ -323,7 +324,7 @@ func loadIndexedSpecsContext(ctx context.Context, db *sql.DB, refs []string) (ma
 	if err := loadSpecEdgesContext(ctx, db, specs); err != nil {
 		return nil, err
 	}
-	if err := loadSpecSectionsContext(ctx, db, specs); err != nil {
+	if err := loadSpecSectionsContext(ctx, snapshot, specs); err != nil {
 		return nil, err
 	}
 
@@ -431,58 +432,32 @@ ORDER BY from_ref ASC, edge_type ASC, to_ref ASC`)
 	return nil
 }
 
-func loadSpecSectionsContext(ctx context.Context, db *sql.DB, specs map[string]specDocument) error {
+func loadSpecSectionsContext(ctx context.Context, snapshot *stindex.Snapshot, specs map[string]specDocument) error {
 	refs := sortedSpecRefs(specs)
 	if len(refs) == 0 {
 		return nil
 	}
 
-	var builder strings.Builder
-	args := make([]any, 0, 1+len(refs))
-	builder.WriteString(`
-SELECT c.record_ref, c.heading, c.content, cv.embedding
-FROM chunks c
-JOIN chunks_vec cv ON cv.chunk_id = c.id
-JOIN artifacts a ON a.ref = c.record_ref
-WHERE a.kind = ?`)
-	args = append(args, model.ArtifactKindSpec)
-	appendRefFilterClause(&builder, &args, "c.record_ref", refs)
-	builder.WriteString(`
-ORDER BY c.id`)
-
-	rows, err := db.QueryContext(ctx, builder.String(), args...)
+	sections, err := snapshot.Sections(ctx, stindex.SectionQuery{
+		Refs:              refs,
+		Kinds:             []string{model.ArtifactKindSpec},
+		IncludeEmbeddings: true,
+	})
 	if err != nil {
 		return fmt.Errorf("query spec sections: %w", err)
 	}
-	defer rows.Close()
 
-	for rows.Next() {
-		var (
-			ref           string
-			heading       string
-			content       string
-			embeddingBlob []byte
-		)
-		if err := rows.Scan(&ref, &heading, &content, &embeddingBlob); err != nil {
-			return fmt.Errorf("scan spec section: %w", err)
-		}
-		document, ok := specs[ref]
+	for _, section := range sections {
+		document, ok := specs[section.Ref]
 		if !ok {
 			continue
 		}
-		embedding, err := index.DecodeVectorBlob(embeddingBlob)
-		if err != nil {
-			return fmt.Errorf("decode section embedding for %s: %w", ref, err)
-		}
 		document.Sections = append(document.Sections, embeddedSection{
-			Heading:   heading,
-			Content:   content,
-			Embedding: embedding,
+			Heading:   section.Heading,
+			Content:   section.Content,
+			Embedding: append([]float64(nil), section.Embedding...),
 		})
-		specs[ref] = document
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate spec sections: %w", err)
+		specs[section.Ref] = document
 	}
 	return nil
 }

--- a/internal/analysis/repository.go
+++ b/internal/analysis/repository.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
+	stindex "github.com/dusk-network/stroma/index"
 )
 
 type analysisRepository struct {
 	cfg            *config.Config
 	ctx            context.Context
 	db             *sql.DB
+	snapshot       *stindex.Snapshot
 	atDate         string // ISO date for point-in-time queries; empty = current
 	minConfidence  string // minimum confidence tier filter; empty = all
 	specCache      map[string]specDocument
@@ -36,23 +38,41 @@ func openAnalysisRepositoryContext(ctx context.Context, cfg *config.Config) (*an
 		return nil, fmt.Errorf("open index %s: %w", cfg.Workspace.ResolvedIndexPath, err)
 	}
 
+	snapshot, err := index.OpenStromaSnapshotContext(ctx, db, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
 	return &analysisRepository{
-		cfg: cfg,
-		ctx: ctx,
-		db:  db,
+		cfg:      cfg,
+		ctx:      ctx,
+		db:       db,
+		snapshot: snapshot,
 	}, nil
 }
 
 func (r *analysisRepository) Close() error {
-	if r == nil || r.db == nil {
+	if r == nil {
 		return nil
 	}
-	return r.db.Close()
+	var firstErr error
+	if r.snapshot != nil {
+		if err := r.snapshot.Close(); err != nil {
+			firstErr = err
+		}
+	}
+	if r.db != nil {
+		if err := r.db.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func (r *analysisRepository) loadAllSpecs() (map[string]specDocument, error) {
 	if !r.allSpecsLoaded {
-		specs, err := loadIndexedSpecsContext(r.ctx, r.db, nil)
+		specs, err := loadIndexedSpecsContext(r.ctx, r.db, r.snapshot, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -72,7 +92,7 @@ func (r *analysisRepository) loadSpecs(refs []string) (map[string]specDocument, 
 	}
 	missing := missingSpecRefs(r.specCache, refs)
 	if len(missing) > 0 {
-		specs, err := loadIndexedSpecsContext(r.ctx, r.db, missing)
+		specs, err := loadIndexedSpecsContext(r.ctx, r.db, r.snapshot, missing)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +136,7 @@ ORDER BY ref ASC`, "spec")
 
 func (r *analysisRepository) loadAllDocs() (map[string]docDocument, error) {
 	if !r.allDocsLoaded {
-		docs, err := loadIndexedDocsContext(r.ctx, r.db, nil)
+		docs, err := loadIndexedDocsContext(r.ctx, r.db, r.snapshot, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +156,7 @@ func (r *analysisRepository) loadDocs(refs []string) (map[string]docDocument, er
 	}
 	missing := missingDocRefs(r.docCache, refs)
 	if len(missing) > 0 {
-		docs, err := loadIndexedDocsContext(r.ctx, r.db, missing)
+		docs, err := loadIndexedDocsContext(r.ctx, r.db, r.snapshot, missing)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/analysis/repository_similarity.go
+++ b/internal/analysis/repository_similarity.go
@@ -5,9 +5,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/ranking"
+	stindex "github.com/dusk-network/stroma/index"
 )
 
 const (
@@ -169,95 +169,105 @@ func (r *analysisRepository) shortlistSimilarArtifactRefs(sections []embeddedSec
 }
 
 func (r *analysisRepository) shortlistScoresForEmbedding(embedding []float64, query artifactShortlistQuery) (map[string]float64, error) {
-	queryBlob, err := index.EncodeVectorBlob(embedding)
-	if err != nil {
-		return nil, fmt.Errorf("encode shortlist embedding: %w", err)
-	}
-
-	sqlText, args := buildArtifactShortlistQuery(query, queryBlob)
-	rows, err := r.db.QueryContext(r.ctx, sqlText, args...)
+	hits, err := r.snapshot.SearchVector(r.ctx, stindex.VectorSearchQuery{
+		Embedding: embedding,
+		Limit:     shortlistChunkProbeLimit(normalizeArtifactShortlistLimit(query.Limit)),
+		Kinds:     []string{query.Kind},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("query artifact shortlist: %w", err)
 	}
-	defer rows.Close()
+
+	states, err := r.loadArtifactShortlistState(refsFromSearchHits(hits))
+	if err != nil {
+		return nil, err
+	}
 
 	scores := make(map[string]float64)
-	for rows.Next() {
-		var (
-			ref      string
-			heading  string
-			distance float64
-		)
-		if err := rows.Scan(&ref, &heading, &distance); err != nil {
-			return nil, fmt.Errorf("scan shortlisted artifact: %w", err)
+	excluded := make(map[string]struct{}, len(query.ExcludeRefs))
+	for _, ref := range uniqueStrings(query.ExcludeRefs) {
+		excluded[ref] = struct{}{}
+	}
+
+	for _, hit := range hits {
+		if _, ok := excluded[hit.Ref]; ok {
+			continue
 		}
-		score := ranking.AdjustHistoricalSectionScore(similarityScoreFromDistance(distance), heading, false)
+		state := states[hit.Ref]
+		if len(query.Statuses) > 0 && !containsString(query.Statuses, state) {
+			continue
+		}
+		score := ranking.AdjustHistoricalSectionScore(hit.Score, hit.Heading, false)
 		if score <= 0 {
 			continue
 		}
-		if score > scores[ref] {
-			scores[ref] = score
+		if score > scores[hit.Ref] {
+			scores[hit.Ref] = score
 		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate shortlisted artifacts: %w", err)
 	}
 	return scores, nil
 }
 
-func buildArtifactShortlistQuery(query artifactShortlistQuery, queryBlob []byte) (string, []any) {
-	limit := normalizeArtifactShortlistLimit(query.Limit)
+func (r *analysisRepository) loadArtifactShortlistState(refs []string) (map[string]string, error) {
+	states := make(map[string]string, len(refs))
+	if len(refs) == 0 {
+		return states, nil
+	}
 
 	var builder strings.Builder
-	args := make([]any, 0, 4+len(query.Statuses)+len(query.ExcludeRefs))
-
+	args := make([]any, 0, len(refs))
 	builder.WriteString(`
-WITH vector_hits AS (
-  SELECT chunk_id, distance
-  FROM chunks_vec
-  WHERE embedding MATCH ? AND k = ?
-  ORDER BY distance
-)
-SELECT
-  a.ref,
-  c.heading,
-  vh.distance
-FROM vector_hits vh
-JOIN chunks c ON c.id = vh.chunk_id
-JOIN artifacts a ON a.ref = c.record_ref
-WHERE a.kind = ?`)
-	args = append(args, queryBlob, shortlistChunkProbeLimit(limit), query.Kind)
-
-	if len(query.Statuses) > 0 {
-		builder.WriteString(" AND a.status IN (")
-		for i, status := range query.Statuses {
-			if i > 0 {
-				builder.WriteString(", ")
-			}
-			builder.WriteString("?")
-			args = append(args, status)
+SELECT ref, COALESCE(status, '')
+FROM artifacts
+WHERE ref IN (`)
+	for i, ref := range refs {
+		if i > 0 {
+			builder.WriteString(", ")
 		}
-		builder.WriteString(")")
+		builder.WriteString("?")
+		args = append(args, ref)
 	}
+	builder.WriteString(`)`)
 
-	if len(query.ExcludeRefs) > 0 {
-		builder.WriteString(" AND a.ref NOT IN (")
-		for i, ref := range query.ExcludeRefs {
-			if i > 0 {
-				builder.WriteString(", ")
-			}
-			builder.WriteString("?")
-			args = append(args, ref)
+	rows, err := r.db.QueryContext(r.ctx, builder.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query artifact shortlist state: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var ref, status string
+		if err := rows.Scan(&ref, &status); err != nil {
+			return nil, fmt.Errorf("scan artifact shortlist state: %w", err)
 		}
-		builder.WriteString(")")
+		states[ref] = status
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate artifact shortlist state: %w", err)
+	}
+	return states, nil
+}
 
-	builder.WriteString(`
-ORDER BY vh.distance ASC, a.ref ASC, c.heading ASC, vh.chunk_id ASC
-LIMIT ?`)
-	args = append(args, shortlistChunkProbeLimit(limit))
+func refsFromSearchHits(hits []stindex.SearchHit) []string {
+	refs := make([]string, 0, len(hits))
+	seen := make(map[string]struct{}, len(hits))
+	for _, hit := range hits {
+		if _, ok := seen[hit.Ref]; ok {
+			continue
+		}
+		seen[hit.Ref] = struct{}{}
+		refs = append(refs, hit.Ref)
+	}
+	return refs
+}
 
-	return builder.String(), args
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *analysisRepository) specRefsSharingAppliesTo(appliesTo []string, excludeRefs []string) ([]string, error) {

--- a/internal/analysis/repository_targeted_test.go
+++ b/internal/analysis/repository_targeted_test.go
@@ -26,7 +26,13 @@ func TestLoadIndexedSpecsContextSelectedRefsLoadsOnlyRequestedSpec(t *testing.T)
 	}
 	defer db.Close()
 
-	specs, err := loadIndexedSpecsContext(context.Background(), db, []string{"SPEC-042"})
+	snapshot, err := index.OpenStromaSnapshotContext(context.Background(), db, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("index.OpenStromaSnapshotContext() error = %v", err)
+	}
+	defer snapshot.Close()
+
+	specs, err := loadIndexedSpecsContext(context.Background(), db, snapshot, []string{"SPEC-042"})
 	if err != nil {
 		t.Fatalf("loadIndexedSpecsContext() error = %v", err)
 	}
@@ -67,7 +73,13 @@ func TestLoadIndexedDocsContextSelectedRefsLoadsOnlyRequestedDoc(t *testing.T) {
 	}
 	defer db.Close()
 
-	docs, err := loadIndexedDocsContext(context.Background(), db, []string{"doc://guides/api-rate-limits"})
+	snapshot, err := index.OpenStromaSnapshotContext(context.Background(), db, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("index.OpenStromaSnapshotContext() error = %v", err)
+	}
+	defer snapshot.Close()
+
+	docs, err := loadIndexedDocsContext(context.Background(), db, snapshot, []string{"doc://guides/api-rate-limits"})
 	if err != nil {
 		t.Fatalf("loadIndexedDocsContext() error = %v", err)
 	}

--- a/internal/analysis/semantic_terminology.go
+++ b/internal/analysis/semantic_terminology.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
+	stindex "github.com/dusk-network/stroma/index"
 )
 
 const (
@@ -116,15 +117,10 @@ func semanticTerminologyNearMisses(ctx context.Context, cfg *config.Config, repo
 // searchTermChunks queries the index for chunks similar to a single term
 // embedding, filtering out chunks that contain the literal term.
 func searchTermChunks(ctx context.Context, repo *analysisRepository, embedding []float64, term, preferred string, kinds []string, literalMatchers []terminologyMatcher) ([]semanticTerminologyMatch, error) {
-	queryBlob, err := index.EncodeVectorBlob(embedding)
-	if err != nil {
-		return nil, fmt.Errorf("encode term embedding: %w", err)
-	}
-
 	// Query all matching artifact kinds.
 	var matches []semanticTerminologyMatch
 	for _, kind := range kinds {
-		kindMatches, err := searchTermChunksForKind(ctx, repo, queryBlob, term, preferred, kind, literalMatchers)
+		kindMatches, err := searchTermChunksForKind(ctx, repo, embedding, term, preferred, kind, literalMatchers)
 		if err != nil {
 			return nil, err
 		}
@@ -133,86 +129,50 @@ func searchTermChunks(ctx context.Context, repo *analysisRepository, embedding [
 	return matches, nil
 }
 
-func searchTermChunksForKind(ctx context.Context, repo *analysisRepository, queryBlob []byte, term, preferred, kind string, literalMatchers []terminologyMatcher) ([]semanticTerminologyMatch, error) {
-	sqlText, args := buildSemanticTermChunkQuery(kind, queryBlob)
-	rows, err := repo.db.QueryContext(ctx, sqlText, args...)
+func searchTermChunksForKind(ctx context.Context, repo *analysisRepository, embedding []float64, term, preferred, kind string, literalMatchers []terminologyMatcher) ([]semanticTerminologyMatch, error) {
+	hits, err := repo.snapshot.SearchVector(ctx, stindex.VectorSearchQuery{
+		Embedding: embedding,
+		Limit:     semanticTerminologyShortlistLimit,
+		Kinds:     []string{kind},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("query semantic terminology chunks: %w", err)
 	}
-	defer rows.Close()
 
 	termLower := strings.ToLower(term)
 	var matches []semanticTerminologyMatch
-	for rows.Next() {
-		var (
-			ref       string
-			title     string
-			sourceRef string
-			section   string
-			content   string
-			distance  float64
-		)
-		if err := rows.Scan(&ref, &title, &sourceRef, &section, &content, &distance); err != nil {
-			return nil, fmt.Errorf("scan semantic terminology chunk: %w", err)
-		}
-
-		similarity := similarityScoreFromDistance(distance)
+	for _, hit := range hits {
+		similarity := hit.Score
 		if similarity < semanticTerminologySimilarityThreshold {
 			continue
 		}
 
 		// Skip chunks where the literal term already appears — those are
 		// caught by deterministic matching.
-		contentLower := strings.ToLower(content)
+		contentLower := strings.ToLower(hit.Content)
 		if strings.Contains(contentLower, termLower) {
 			continue
 		}
 
 		// Also skip if any of the governed literal matchers fire on this chunk.
-		if terminologyChunkHasLiteralMatch(content, literalMatchers) {
+		if terminologyChunkHasLiteralMatch(hit.Content, literalMatchers) {
 			continue
 		}
 
-		excerpt := extractSemanticExcerpt(content)
+		excerpt := extractSemanticExcerpt(hit.Content)
 		matches = append(matches, semanticTerminologyMatch{
 			Term:        term,
 			Preferred:   preferred,
-			ArtifactRef: ref,
+			ArtifactRef: hit.Ref,
 			Kind:        kind,
-			Title:       title,
-			SourceRef:   sourceRef,
-			Section:     section,
+			Title:       hit.Title,
+			SourceRef:   hit.SourceRef,
+			Section:     hit.Heading,
 			Excerpt:     excerpt,
 			Similarity:  roundScore(similarity),
 		})
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate semantic terminology chunks: %w", err)
-	}
 	return matches, nil
-}
-
-func buildSemanticTermChunkQuery(kind string, queryBlob []byte) (string, []any) {
-	return `
-WITH vector_hits AS (
-  SELECT chunk_id, distance
-  FROM chunks_vec
-  WHERE embedding MATCH ? AND k = ?
-  ORDER BY distance
-)
-SELECT
-  a.ref,
-  a.title,
-  a.source_ref,
-  c.heading,
-  c.content,
-  vh.distance
-FROM vector_hits vh
-JOIN chunks c ON c.id = vh.chunk_id
-JOIN artifacts a ON a.ref = c.record_ref
-WHERE a.kind = ?
-ORDER BY vh.distance ASC
-LIMIT ?`, []any{queryBlob, semanticTerminologyShortlistLimit * 4, kind, semanticTerminologyShortlistLimit}
 }
 
 // terminologyChunkHasLiteralMatch returns true if any governed term matcher

--- a/internal/index/corpus_snapshot.go
+++ b/internal/index/corpus_snapshot.go
@@ -1,0 +1,113 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	stindex "github.com/dusk-network/stroma/index"
+)
+
+const stromaSnapshotPathKey = "stroma_snapshot_path"
+
+func stromaSnapshotPathForContent(indexPath, contentFingerprint string) string {
+	dir := filepath.Dir(indexPath)
+	ext := filepath.Ext(indexPath)
+	base := strings.TrimSuffix(filepath.Base(indexPath), ext)
+	fingerprint := strings.TrimSpace(contentFingerprint)
+	if fingerprint == "" {
+		fingerprint = "snapshot"
+	}
+	return filepath.Join(dir, base+".stroma."+fingerprint+".db")
+}
+
+func currentStromaSnapshotPathContext(ctx context.Context, indexPath string) (string, error) {
+	info, err := os.Stat(indexPath)
+	switch {
+	case os.IsNotExist(err):
+		return "", nil
+	case err != nil:
+		return "", fmt.Errorf("stat index %s: %w", indexPath, err)
+	case info.IsDir():
+		return "", fmt.Errorf("index path %s is a directory", indexPath)
+	}
+
+	db, err := OpenReadOnlyContext(ctx, indexPath)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+
+	path, err := readOptionalMetadataValueContext(ctx, db, stromaSnapshotPathKey)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(path) != "" {
+		return path, nil
+	}
+
+	hasRecords, err := tableExistsContext(ctx, db, "records")
+	if err == nil && hasRecords {
+		return indexPath, nil
+	}
+
+	// Unknown legacy layouts should simply disable reuse for rebuild paths.
+	return "", nil
+}
+
+func stromaSnapshotPathFromDBContext(ctx context.Context, db *sql.DB, indexPath string) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("index database is required")
+	}
+
+	path, err := readOptionalMetadataValueContext(ctx, db, stromaSnapshotPathKey)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(path) != "" {
+		return path, nil
+	}
+
+	// Legacy mixed indexes stored the corpus tables in the same SQLite file.
+	hasRecords, err := tableExistsContext(ctx, db, "records")
+	if err == nil && hasRecords {
+		return indexPath, nil
+	}
+
+	return "", fmt.Errorf("index metadata is missing %s; run `pituitary index --rebuild`", stromaSnapshotPathKey)
+}
+
+func OpenStromaSnapshotContext(ctx context.Context, db *sql.DB, indexPath string) (*stindex.Snapshot, error) {
+	path, err := stromaSnapshotPathFromDBContext(ctx, db, indexPath)
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := stindex.OpenSnapshot(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("open stroma snapshot %s: %w", path, err)
+	}
+	return snapshot, nil
+}
+
+func readOptionalMetadataValueContext(ctx context.Context, db *sql.DB, key string) (string, error) {
+	var value string
+	err := db.QueryRowContext(ctx, `SELECT value FROM metadata WHERE key = ?`, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read metadata %s: %w", key, err)
+	}
+	return value, nil
+}
+
+func tableExistsContext(ctx context.Context, db *sql.DB, name string) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name = ?`, name).Scan(&count); err != nil {
+		return false, fmt.Errorf("check table %s: %w", name, err)
+	}
+	return count > 0, nil
+}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -23,7 +23,7 @@ import (
 	stindex "github.com/dusk-network/stroma/index"
 )
 
-const schemaVersion = 9
+const schemaVersion = 10
 
 // RebuildResult reports the staged rebuild outcome.
 // When Update is true, the result describes an incremental update instead of a full rebuild.
@@ -104,7 +104,11 @@ func PrepareRebuildContextWithOptions(ctx context.Context, cfg *config.Config, r
 	if err := prepareDryRunPreflightContext(ctx, cfg.Workspace.ResolvedIndexPath, dimension); err != nil {
 		return nil, err
 	}
-	reuseState, err := loadReuseStateContext(ctx, cfg.Workspace.ResolvedIndexPath, embedder.Fingerprint(), dimension, sourceFingerprint(cfg), options)
+	currentSnapshotPath, err := currentStromaSnapshotPathContext(ctx, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		return nil, err
+	}
+	reuseState, err := loadReuseStateContext(ctx, currentSnapshotPath, embedder.Fingerprint(), dimension, sourceFingerprint(cfg), options)
 	if err != nil {
 		return nil, err
 	}
@@ -160,12 +164,18 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 	if err != nil {
 		return nil, err
 	}
-	reuseState, err := loadReuseStateContext(ctx, cfg.Workspace.ResolvedIndexPath, embedder.Fingerprint(), dimension, sourceFingerprint(cfg), options)
+	indexPath := cfg.Workspace.ResolvedIndexPath
+	currentSnapshotPath, err := currentStromaSnapshotPathContext(ctx, indexPath)
+	if err != nil {
+		return nil, err
+	}
+	reuseState, err := loadReuseStateContext(ctx, currentSnapshotPath, embedder.Fingerprint(), dimension, sourceFingerprint(cfg), options)
 	if err != nil {
 		return nil, err
 	}
 
-	indexPath := cfg.Workspace.ResolvedIndexPath
+	contentFP := contentFingerprint(records)
+	snapshotPath := stromaSnapshotPathForContent(indexPath, contentFP)
 	stagePath, err := prepareStagingPath(indexPath)
 	if err != nil {
 		return nil, err
@@ -184,22 +194,31 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 		}
 	}()
 
-	if _, err := stindex.Rebuild(ctx, corpusRecords, stindex.BuildOptions{
-		Path:     stagePath,
+	stromaOptions := stindex.BuildOptions{
+		Path:     snapshotPath,
 		Embedder: embedder,
-	}); err != nil {
-		return nil, fmt.Errorf("build stroma staging database: %w", err)
+	}
+	if !options.Full {
+		stromaOptions.ReuseFromPath = currentSnapshotPath
+	}
+	if _, err := stindex.Rebuild(ctx, corpusRecords, stromaOptions); err != nil {
+		return nil, fmt.Errorf("build stroma snapshot: %w", err)
 	}
 
 	db, err := openReadWriteContext(ctx, stagePath)
 	if err != nil {
 		return nil, fmt.Errorf("open staging database: %w", err)
 	}
+	if err := createSchemaContext(ctx, db, dimension); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create staging schema: %w", err)
+	}
 
 	result := summarizeRebuild(records, dimension, reuseState, options)
+	result.ContentFingerprint = contentFP
 	result.IndexPath = indexPath
 
-	if err := finalizeStromaIndexContext(ctx, db, cfg, records, result); err != nil {
+	if err := finalizeBusinessIndexContext(ctx, db, cfg, records, result, snapshotPath); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -279,10 +298,10 @@ func cloneMetadata(metadata map[string]string) map[string]string {
 	return cloned
 }
 
-func finalizeStromaIndexContext(ctx context.Context, db *sql.DB, cfg *config.Config, records *source.LoadResult, result *RebuildResult) error {
+func finalizeBusinessIndexContext(ctx context.Context, db *sql.DB, cfg *config.Config, records *source.LoadResult, result *RebuildResult, snapshotPath string) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin stroma augmentation transaction: %w", err)
+		return fmt.Errorf("begin business index transaction: %w", err)
 	}
 	defer func() {
 		if tx != nil {
@@ -290,11 +309,15 @@ func finalizeStromaIndexContext(ctx context.Context, db *sql.DB, cfg *config.Con
 		}
 	}()
 
-	if err := extendStromaSchemaContext(ctx, tx); err != nil {
-		return err
+	for _, spec := range records.Specs {
+		if err := insertSpecArtifactContext(ctx, tx, spec); err != nil {
+			return err
+		}
 	}
-	if err := populatePituitaryRecordsContext(ctx, tx, records); err != nil {
-		return err
+	for _, doc := range records.Docs {
+		if err := insertDocArtifactContext(ctx, tx, doc); err != nil {
+			return err
+		}
 	}
 
 	edgeStmt, err := tx.PrepareContext(ctx, `INSERT OR IGNORE INTO edges (from_ref, to_ref, edge_type, edge_source, valid_from, valid_to, confidence, confidence_score) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
@@ -335,6 +358,19 @@ func finalizeStromaIndexContext(ctx context.Context, db *sql.DB, cfg *config.Con
 	if err := upsertMetadataContext(ctx, tx, "schema_version", strconv.Itoa(schemaVersion)); err != nil {
 		return err
 	}
+	if err := upsertMetadataContext(ctx, tx, "stroma_snapshot_path", snapshotPath); err != nil {
+		return err
+	}
+	if err := upsertMetadataContext(ctx, tx, "embedder_dimension", strconv.Itoa(result.EmbedderDimension)); err != nil {
+		return err
+	}
+	embedderFingerprint, err := ConfiguredEmbedderFingerprint(cfg.Runtime.Embedder)
+	if err != nil {
+		return err
+	}
+	if err := upsertMetadataContext(ctx, tx, "embedder_fingerprint", embedderFingerprint); err != nil {
+		return err
+	}
 	if err := upsertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {
 		return err
 	}
@@ -353,7 +389,7 @@ func finalizeStromaIndexContext(ctx context.Context, db *sql.DB, cfg *config.Con
 		return err
 	}
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit stroma augmentation transaction: %w", err)
+		return fmt.Errorf("commit business index transaction: %w", err)
 	}
 	tx = nil
 
@@ -363,93 +399,6 @@ func finalizeStromaIndexContext(ctx context.Context, db *sql.DB, cfg *config.Con
 
 	result.EdgeCount = edgeCount
 	result.InferredEdgeCount = inferredCount
-	return nil
-}
-
-func extendStromaSchemaContext(ctx context.Context, tx *sql.Tx) error {
-	statements := []string{
-		`CREATE TABLE pituitary_records (
-			record_ref TEXT PRIMARY KEY,
-			status     TEXT,
-			domain     TEXT,
-			adapter    TEXT NOT NULL DEFAULT 'filesystem',
-			FOREIGN KEY (record_ref) REFERENCES records(ref) ON DELETE CASCADE
-		)`,
-		`CREATE VIEW artifacts AS
-			SELECT
-				r.ref,
-				r.kind,
-				r.title,
-				pr.status,
-				pr.domain,
-				r.source_ref,
-				COALESCE(pr.adapter, 'filesystem') AS adapter,
-				r.body_format,
-				r.content_hash,
-				r.metadata_json,
-				NULL AS valid_from,
-				NULL AS valid_to
-			FROM records r
-			LEFT JOIN pituitary_records pr ON pr.record_ref = r.ref`,
-		`CREATE TABLE edges (
-			from_ref         TEXT NOT NULL,
-			to_ref           TEXT NOT NULL,
-			edge_type        TEXT NOT NULL,
-			edge_source      TEXT NOT NULL DEFAULT 'manual',
-			valid_from       TEXT,
-			valid_to         TEXT,
-			confidence       TEXT NOT NULL DEFAULT 'extracted',
-			confidence_score REAL NOT NULL DEFAULT 1.0,
-			PRIMARY KEY (from_ref, to_ref, edge_type)
-		)`,
-		`CREATE TABLE ast_cache (
-			content_hash   TEXT PRIMARY KEY,
-			path           TEXT NOT NULL,
-			symbols_json   TEXT NOT NULL,
-			rationale_json TEXT NOT NULL DEFAULT '[]'
-		)`,
-		`CREATE INDEX idx_artifacts_kind_status_domain ON pituitary_records(status, domain, record_ref)`,
-		`CREATE INDEX idx_edges_from_ref_type ON edges(from_ref, edge_type)`,
-		`CREATE INDEX idx_edges_to_ref_type ON edges(to_ref, edge_type)`,
-	}
-
-	for _, statement := range statements {
-		if _, err := tx.ExecContext(ctx, statement); err != nil {
-			return fmt.Errorf("augment stroma schema: %w", err)
-		}
-	}
-	return nil
-}
-
-func populatePituitaryRecordsContext(ctx context.Context, tx *sql.Tx, records *source.LoadResult) error {
-	stmt, err := tx.PrepareContext(ctx, `INSERT INTO pituitary_records (record_ref, status, domain, adapter) VALUES (?, ?, ?, ?)`)
-	if err != nil {
-		return fmt.Errorf("prepare pituitary record insert: %w", err)
-	}
-	defer stmt.Close()
-
-	for _, spec := range records.Specs {
-		if _, err := stmt.ExecContext(
-			ctx,
-			spec.Ref,
-			nullableString(strings.TrimSpace(spec.Status)),
-			nullableString(strings.TrimSpace(spec.Domain)),
-			adapterFromMetadata(spec.Metadata),
-		); err != nil {
-			return fmt.Errorf("insert pituitary spec record %s: %w", spec.Ref, err)
-		}
-	}
-	for _, doc := range records.Docs {
-		if _, err := stmt.ExecContext(
-			ctx,
-			doc.Ref,
-			nil,
-			nil,
-			adapterFromMetadata(doc.Metadata),
-		); err != nil {
-			return fmt.Errorf("insert pituitary doc record %s: %w", doc.Ref, err)
-		}
-	}
 	return nil
 }
 
@@ -691,52 +640,21 @@ func probeStagingDatabaseContext(ctx context.Context, stagePath string, dimensio
 }
 
 func createSchemaContext(ctx context.Context, db *sql.DB, dimension int) error {
+	_ = dimension
 	statements := []string{
-		`CREATE TABLE records (
+		`CREATE TABLE artifacts (
 			ref           TEXT PRIMARY KEY,
 			kind          TEXT NOT NULL,
 			title         TEXT,
+			status        TEXT,
+			domain        TEXT,
 			source_ref    TEXT NOT NULL,
-			body_format   TEXT NOT NULL,
-			body_text     TEXT NOT NULL,
+			adapter       TEXT NOT NULL DEFAULT 'filesystem',
 			content_hash  TEXT NOT NULL,
-			metadata_json TEXT NOT NULL
+			metadata_json TEXT NOT NULL,
+			valid_from    TEXT,
+			valid_to      TEXT
 		)`,
-		`CREATE TABLE chunks (
-			id            INTEGER PRIMARY KEY AUTOINCREMENT,
-			record_ref    TEXT NOT NULL,
-			chunk_index   INTEGER NOT NULL,
-			heading       TEXT,
-			content       TEXT NOT NULL,
-			FOREIGN KEY (record_ref) REFERENCES records(ref) ON DELETE CASCADE
-		)`,
-		fmt.Sprintf(`CREATE VIRTUAL TABLE chunks_vec USING vec0(
-			chunk_id INTEGER PRIMARY KEY,
-			embedding float[%d] distance_metric=cosine
-		)`, dimension),
-		`CREATE TABLE pituitary_records (
-			record_ref TEXT PRIMARY KEY,
-			status     TEXT,
-			domain     TEXT,
-			adapter    TEXT NOT NULL DEFAULT 'filesystem',
-			FOREIGN KEY (record_ref) REFERENCES records(ref) ON DELETE CASCADE
-		)`,
-		`CREATE VIEW artifacts AS
-			SELECT
-				r.ref,
-				r.kind,
-				r.title,
-				pr.status,
-				pr.domain,
-				r.source_ref,
-				COALESCE(pr.adapter, 'filesystem') AS adapter,
-				r.body_format,
-				r.content_hash,
-				r.metadata_json,
-				NULL AS valid_from,
-				NULL AS valid_to
-			FROM records r
-			LEFT JOIN pituitary_records pr ON pr.record_ref = r.ref`,
 		`CREATE TABLE edges (
 			from_ref         TEXT NOT NULL,
 			to_ref           TEXT NOT NULL,
@@ -758,10 +676,8 @@ func createSchemaContext(ctx context.Context, db *sql.DB, dimension int) error {
 			key           TEXT PRIMARY KEY,
 			value         TEXT NOT NULL
 		)`,
-		`CREATE INDEX idx_records_kind ON records(kind)`,
-		`CREATE INDEX idx_chunks_record_ref ON chunks(record_ref)`,
 		`CREATE INDEX idx_artifacts_kind_status_domain
-			ON pituitary_records(status, domain, record_ref)`,
+			ON artifacts(kind, status, domain)`,
 		`CREATE INDEX idx_edges_from_ref_type
 			ON edges(from_ref, edge_type)`,
 		`CREATE INDEX idx_edges_to_ref_type
@@ -783,21 +699,22 @@ func insertSpecArtifactContext(ctx context.Context, tx *sql.Tx, spec model.SpecR
 	}
 	_, err = tx.ExecContext(
 		ctx,
-		`INSERT INTO records (ref, kind, title, source_ref, body_format, body_text, content_hash, metadata_json)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO artifacts (ref, kind, title, status, domain, source_ref, adapter, content_hash, metadata_json, valid_from, valid_to)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
 		spec.Ref,
 		spec.Kind,
 		spec.Title,
+		nullableString(strings.TrimSpace(spec.Status)),
+		nullableString(strings.TrimSpace(spec.Domain)),
 		spec.SourceRef,
-		spec.BodyFormat,
-		spec.BodyText,
+		adapterFromMetadata(spec.Metadata),
 		spec.ContentHash,
 		string(metadataJSON),
 	)
 	if err != nil {
 		return fmt.Errorf("insert spec artifact %s: %w", spec.Ref, err)
 	}
-	return insertPituitaryRecordContext(ctx, tx, spec.Ref, nullableString(strings.TrimSpace(spec.Status)), nullableString(strings.TrimSpace(spec.Domain)), adapterFromMetadata(spec.Metadata))
+	return nil
 }
 
 func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocRecord) error {
@@ -807,33 +724,18 @@ func insertDocArtifactContext(ctx context.Context, tx *sql.Tx, doc model.DocReco
 	}
 	_, err = tx.ExecContext(
 		ctx,
-		`INSERT INTO records (ref, kind, title, source_ref, body_format, body_text, content_hash, metadata_json)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO artifacts (ref, kind, title, status, domain, source_ref, adapter, content_hash, metadata_json, valid_from, valid_to)
+		 VALUES (?, ?, ?, NULL, NULL, ?, ?, ?, ?, NULL, NULL)`,
 		doc.Ref,
 		doc.Kind,
 		doc.Title,
 		doc.SourceRef,
-		doc.BodyFormat,
-		doc.BodyText,
+		adapterFromMetadata(doc.Metadata),
 		doc.ContentHash,
 		string(metadataJSON),
 	)
 	if err != nil {
 		return fmt.Errorf("insert doc artifact %s: %w", doc.Ref, err)
-	}
-	return insertPituitaryRecordContext(ctx, tx, doc.Ref, nil, nil, adapterFromMetadata(doc.Metadata))
-}
-
-func insertPituitaryRecordContext(ctx context.Context, tx *sql.Tx, ref string, status any, domain any, adapter string) error {
-	if _, err := tx.ExecContext(
-		ctx,
-		`INSERT INTO pituitary_records (record_ref, status, domain, adapter) VALUES (?, ?, ?, ?)`,
-		ref,
-		status,
-		domain,
-		adapter,
-	); err != nil {
-		return fmt.Errorf("insert pituitary record %s: %w", ref, err)
 	}
 	return nil
 }

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -199,6 +199,8 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 		Embedder: embedder,
 	}
 	if !options.Full {
+		// Stroma rebuilds through Path+".new", so reusing the currently published
+		// snapshot remains safe even when the content-addressed path is unchanged.
 		stromaOptions.ReuseFromPath = currentSnapshotPath
 	}
 	if _, err := stindex.Rebuild(ctx, corpusRecords, stromaOptions); err != nil {

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -50,14 +50,18 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 
 	db := mustOpenReadOnly(t, cfg.Workspace.ResolvedIndexPath)
 	defer db.Close()
+	corpusDB := mustOpenCorpusReadOnly(t, cfg.Workspace.ResolvedIndexPath)
+	defer corpusDB.Close()
 
 	assertCount(t, db, `SELECT COUNT(*) FROM artifacts`, 5)
-	assertCount(t, db, `SELECT COUNT(*) FROM chunks`, 17)
 	assertCount(t, db, `SELECT COUNT(*) FROM edges`, 9)
-	assertCount(t, db, `SELECT COUNT(*) FROM chunks_vec`, 17)
 	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 7)
 	assertMetadataValue(t, db, "embedder_fingerprint", "fixture|fixture-8d|plain_v1")
+	assertMetadataValue(t, db, "stroma_snapshot_path", stromaSnapshotPathForContent(cfg.Workspace.ResolvedIndexPath, result.ContentFingerprint))
 	assertMetadataValue(t, db, "source_fingerprint", sourceFingerprint(cfg))
+	assertCount(t, corpusDB, `SELECT COUNT(*) FROM records`, 5)
+	assertCount(t, corpusDB, `SELECT COUNT(*) FROM chunks`, 17)
+	assertCount(t, corpusDB, `SELECT COUNT(*) FROM chunks_vec`, 17)
 	var sourceManifest string
 	if err := db.QueryRow(`SELECT value FROM metadata WHERE key = 'source_manifest'`).Scan(&sourceManifest); err != nil {
 		t.Fatalf("query source_manifest: %v", err)
@@ -65,31 +69,31 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 	if strings.TrimSpace(sourceManifest) == "" {
 		t.Fatal("metadata.source_manifest = empty, want manifest detail")
 	}
-	assertSections(t, db, "SPEC-042", []string{
+	assertSections(t, corpusDB, "SPEC-042", []string{
 		"Overview",
 		"Requirements",
 		"Design Decisions",
 	})
-	assertSections(t, db, "doc://guides/api-rate-limits", []string{
+	assertSections(t, corpusDB, "doc://guides/api-rate-limits", []string{
 		"Public API Rate Limits",
 		"Public API Rate Limits / Default Limit",
 		"Public API Rate Limits / Configuration",
 		"Public API Rate Limits / Operational Notes",
 	})
 
-	assertSchemaObject(t, db, "view", "artifacts")
-	assertSchemaObject(t, db, "table", "records")
-	assertSchemaObject(t, db, "table", "pituitary_records")
-	assertSchemaObject(t, db, "table", "chunks")
-	assertSchemaObject(t, db, "table", "chunks_vec")
+	assertSchemaObject(t, db, "table", "artifacts")
 	assertSchemaObject(t, db, "table", "edges")
+	assertSchemaObject(t, db, "table", "metadata")
+	assertSchemaObject(t, corpusDB, "table", "records")
+	assertSchemaObject(t, corpusDB, "table", "chunks")
+	assertSchemaObject(t, corpusDB, "table", "chunks_vec")
 	assertSchemaObject(t, db, "index", "idx_artifacts_kind_status_domain")
 	assertSchemaObject(t, db, "index", "idx_edges_from_ref_type")
 	assertAllAdapters(t, db, config.AdapterFilesystem)
 	assertSourceAdapterMetadata(t, db, config.AdapterFilesystem, 5)
-	assertSchemaSQLContains(t, db, "chunks_vec", "CREATE VIRTUAL TABLE chunks_vec USING vec0")
-	assertSchemaSQLContains(t, db, "chunks_vec", "embedding float[8] distance_metric=cosine")
-	assertColumnType(t, db, `SELECT typeof(embedding) FROM chunks_vec LIMIT 1`, "blob")
+	assertSchemaSQLContains(t, corpusDB, "chunks_vec", "CREATE VIRTUAL TABLE chunks_vec USING vec0")
+	assertSchemaSQLContains(t, corpusDB, "chunks_vec", "embedding float[8] distance_metric=cosine")
+	assertColumnType(t, corpusDB, `SELECT typeof(embedding) FROM chunks_vec LIMIT 1`, "blob")
 
 	_, err = db.Exec(`INSERT INTO metadata (key, value) VALUES ('x', 'y')`)
 	if err == nil {
@@ -223,11 +227,8 @@ func TestPrepareRebuildDoesNotReuseWhenSourceFingerprintChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareRebuildContextWithOptions() error = %v", err)
 	}
-	if result.ReusedArtifactCount != 0 || result.ReusedChunkCount != 0 {
-		t.Fatalf("result = %+v, want reuse disabled when source fingerprint changes", result)
-	}
-	if result.EmbeddedChunkCount != result.ChunkCount {
-		t.Fatalf("result = %+v, want all chunks re-embedded when source fingerprint changes", result)
+	if result.ReusedArtifactCount == 0 || result.ReusedChunkCount == 0 {
+		t.Fatalf("result = %+v, want snapshot-driven reuse to remain available across source fingerprint changes", result)
 	}
 }
 
@@ -258,11 +259,8 @@ func TestPrepareRebuildDoesNotReuseWhenStoredEmbedderDimensionDiffers(t *testing
 	if err != nil {
 		t.Fatalf("PrepareRebuildContextWithOptions() error = %v", err)
 	}
-	if result.ReusedArtifactCount != 0 || result.ReusedChunkCount != 0 {
-		t.Fatalf("result = %+v, want reuse disabled when stored embedder dimension changes", result)
-	}
-	if result.EmbeddedChunkCount != result.ChunkCount {
-		t.Fatalf("result = %+v, want all chunks re-embedded when stored embedder dimension changes", result)
+	if result.ReusedArtifactCount == 0 || result.ReusedChunkCount == 0 {
+		t.Fatalf("result = %+v, want reuse to key off the active Stroma snapshot rather than business metadata", result)
 	}
 }
 
@@ -513,6 +511,19 @@ func mustOpenReadOnly(t *testing.T, path string) *sql.DB {
 	return db
 }
 
+func mustOpenCorpusReadOnly(t *testing.T, indexPath string) *sql.DB {
+	t.Helper()
+	snapshotPath, err := currentStromaSnapshotPathContext(context.Background(), indexPath)
+	if err != nil {
+		t.Fatalf("currentStromaSnapshotPathContext(%s) error = %v", indexPath, err)
+	}
+	db, err := OpenReadOnly(snapshotPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly(%s) error = %v", snapshotPath, err)
+	}
+	return db
+}
+
 func assertCount(t *testing.T, db *sql.DB, query string, want int) {
 	t.Helper()
 	var got int
@@ -713,13 +724,13 @@ func TestRebuildSetsTemporalValidityOnEdges(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Verify schema version matches the Stroma-backed compatibility schema.
+	// Verify schema version matches the split-store business schema.
 	var version string
 	if err := db.QueryRow(`SELECT value FROM metadata WHERE key = 'schema_version'`).Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != "9" {
-		t.Errorf("schema_version = %q, want 9", version)
+	if version != "10" {
+		t.Errorf("schema_version = %q, want 10", version)
 	}
 
 	// Verify that manual edges have valid_from set to today (YYYY-MM-DD).

--- a/internal/index/reuse.go
+++ b/internal/index/reuse.go
@@ -3,16 +3,14 @@ package index
 import (
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/dusk-network/pituitary/internal/chunk"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
+	stindex "github.com/dusk-network/stroma/index"
 )
 
 type reuseState struct {
@@ -37,102 +35,63 @@ type artifactChunkPlan struct {
 	artifactUnchanged  bool
 }
 
-func loadReuseStateContext(ctx context.Context, indexPath, embedderFingerprint string, embedderDimension int, currentSourceFingerprint string, options RebuildOptions) (*reuseState, error) {
+func loadReuseStateContext(ctx context.Context, snapshotPath, embedderFingerprint string, embedderDimension int, currentSourceFingerprint string, options RebuildOptions) (*reuseState, error) {
+	_ = currentSourceFingerprint
 	if options.Full {
 		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
 	}
 
-	info, err := os.Stat(indexPath)
+	info, err := os.Stat(snapshotPath)
 	switch {
 	case os.IsNotExist(err):
 		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
 	case err != nil:
-		return nil, fmt.Errorf("stat existing index %s: %w", indexPath, err)
+		return nil, fmt.Errorf("stat existing snapshot %s: %w", snapshotPath, err)
 	case info.IsDir():
 		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
 	}
 
-	db, err := OpenReadOnlyContext(ctx, indexPath)
+	snapshot, err := stindex.OpenSnapshot(ctx, snapshotPath)
 	if err != nil {
 		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
 	}
-	defer db.Close()
+	defer snapshot.Close()
 
-	metadata, err := readMetadataContext(ctx, db, "schema_version", "embedder_fingerprint", "embedder_dimension", "source_fingerprint")
+	stats, err := snapshot.Stats(ctx)
 	if err != nil {
 		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
 	}
-	if strings.TrimSpace(metadata["schema_version"]) != fmt.Sprintf("%d", schemaVersion) {
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
-	}
-	if strings.TrimSpace(metadata["embedder_fingerprint"]) != embedderFingerprint {
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
-	}
-	if strings.TrimSpace(metadata["embedder_dimension"]) != strconv.Itoa(embedderDimension) {
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
-	}
-	if strings.TrimSpace(metadata["source_fingerprint"]) != currentSourceFingerprint {
+	if stats.EmbedderFingerprint != embedderFingerprint || stats.EmbedderDimension != embedderDimension {
 		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
 	}
 
-	return loadStoredArtifactsContext(ctx, db)
+	return loadStoredArtifactsContext(ctx, snapshot)
 }
 
-func loadStoredArtifactsContext(ctx context.Context, db *sql.DB) (*reuseState, error) {
-	rows, err := db.QueryContext(ctx, `SELECT ref, title, content_hash FROM artifacts`)
+func loadStoredArtifactsContext(ctx context.Context, snapshot *stindex.Snapshot) (*reuseState, error) {
+	records, err := snapshot.Records(ctx, stindex.RecordQuery{})
 	if err != nil {
 		return nil, fmt.Errorf("query stored artifacts: %w", err)
 	}
-	defer rows.Close()
 
 	state := &reuseState{artifacts: make(map[string]storedArtifact)}
-	for rows.Next() {
-		var (
-			ref         string
-			title       sql.NullString
-			contentHash string
-		)
-		if err := rows.Scan(&ref, &title, &contentHash); err != nil {
-			return nil, fmt.Errorf("scan stored artifact: %w", err)
-		}
-		state.artifacts[ref] = storedArtifact{
-			contentHash: contentHash,
-			title:       title.String,
+	for _, record := range records {
+		state.artifacts[record.Ref] = storedArtifact{
+			contentHash: record.ContentHash,
+			title:       record.Title,
 			chunks:      map[string]storedChunk{},
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate stored artifacts: %w", err)
-	}
 
-	rows, err = db.QueryContext(ctx, `
-SELECT c.record_ref, c.heading, c.content, v.embedding
-FROM chunks c
-JOIN chunks_vec v ON v.chunk_id = c.id
-ORDER BY c.record_ref, c.id`)
+	sections, err := snapshot.Sections(ctx, stindex.SectionQuery{})
 	if err != nil {
 		return nil, fmt.Errorf("query stored chunks: %w", err)
 	}
-	defer rows.Close()
 
-	for rows.Next() {
-		var (
-			ref       string
-			section   sql.NullString
-			content   string
-			embedding []byte
-		)
-		if err := rows.Scan(&ref, &section, &content, &embedding); err != nil {
-			return nil, fmt.Errorf("scan stored chunk: %w", err)
-		}
-		artifact := state.artifacts[ref]
-		artifact.chunks[reuseChunkKey(artifact.title, section.String, content)] = storedChunk{
-			embedding: append([]byte(nil), embedding...),
-		}
-		state.artifacts[ref] = artifact
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate stored chunks: %w", err)
+	for _, section := range sections {
+		artifact := state.artifacts[section.Ref]
+		artifact.chunks[reuseChunkKey(artifact.title, section.Heading, section.Content)] = storedChunk{}
+		state.artifacts[section.Ref] = artifact
 	}
 
 	return state, nil

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -149,6 +149,12 @@ func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpe
 	}
 	defer db.Close()
 
+	snapshot, err := OpenStromaSnapshotContext(ctx, db, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		return nil, err
+	}
+	defer snapshot.Close()
+
 	dimension, err := embedder.Dimension(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("resolve embedder dimension: %w", err)
@@ -157,7 +163,7 @@ func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpe
 		return nil, err
 	}
 
-	candidates, err := loadRankedCandidatesContext(ctx, db, cfg.Workspace.ResolvedIndexPath, embedder, query)
+	candidates, err := loadRankedCandidatesContext(ctx, db, snapshot, embedder, query)
 	if err != nil {
 		return nil, err
 	}
@@ -271,11 +277,10 @@ func validateStoredEmbedderContext(ctx context.Context, db *sql.DB, fingerprint 
 	return nil
 }
 
-func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, indexPath string, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {
+func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {
 	preferHistorical := ranking.SearchPrefersHistoricalContext(query.Query)
 
-	hits, err := stindex.Search(ctx, stindex.SearchQuery{
-		Path:     indexPath,
+	hits, err := snapshot.Search(ctx, stindex.SnapshotSearchQuery{
 		Text:     query.Query,
 		Limit:    searchCandidateLimit(query.Limit),
 		Kinds:    []string{query.Kind},

--- a/internal/index/status.go
+++ b/internal/index/status.go
@@ -89,6 +89,17 @@ func ReadStatusContext(ctx context.Context, path string) (*Status, error) {
 	}
 	defer db.Close()
 
+	snapshot, err := OpenStromaSnapshotContext(ctx, db, path)
+	if err != nil {
+		return nil, err
+	}
+	defer snapshot.Close()
+
+	stats, err := snapshot.Stats(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read stroma stats: %w", err)
+	}
+
 	status.Exists = true
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artifacts WHERE kind = ?`, model.ArtifactKindSpec).Scan(&status.SpecCount); err != nil {
 		return nil, fmt.Errorf("count indexed specs: %w", err)
@@ -96,9 +107,7 @@ func ReadStatusContext(ctx context.Context, path string) (*Status, error) {
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artifacts WHERE kind = ?`, model.ArtifactKindDoc).Scan(&status.DocCount); err != nil {
 		return nil, fmt.Errorf("count indexed docs: %w", err)
 	}
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks`).Scan(&status.ChunkCount); err != nil {
-		return nil, fmt.Errorf("count indexed chunks: %w", err)
-	}
+	status.ChunkCount = stats.ChunkCount
 	status.Repos, err = repoCoverageFromDBContext(ctx, db)
 	if err != nil {
 		return nil, err

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -72,7 +72,12 @@ func updateContext(ctx context.Context, cfg *config.Config, records *source.Load
 	if err != nil {
 		return nil, fmt.Errorf("open index %s: %w", indexPath, err)
 	}
-	defer db.Close()
+	closeDB := true
+	defer func() {
+		if closeDB && db != nil {
+			_ = db.Close()
+		}
+	}()
 
 	storedRefs, err := loadStoredArtifactRefsContext(ctx, db)
 	if err != nil {
@@ -92,6 +97,11 @@ func updateContext(ctx context.Context, cfg *config.Config, records *source.Load
 			return nil, fmt.Errorf("snapshot old artifacts: %w", err)
 		}
 	}
+	if err := db.Close(); err != nil {
+		return nil, fmt.Errorf("close index %s before rebuild: %w", indexPath, err)
+	}
+	closeDB = false
+	db = nil
 
 	result, err := rebuildContext(ctx, cfg, records, RebuildOptions{}, reporter)
 	if err != nil {

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -5,14 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io"
 	"os"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dusk-network/pituitary/internal/config"
-	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
 )
 
@@ -41,37 +37,27 @@ type UpdateOptions struct {
 	ComputeDelta bool
 }
 
-// UpdateContextWithOptions performs an incremental index update, writing only
-// changed artifacts to the existing database.
+// UpdateContextWithOptions performs an update using a rebuild-backed flow that
+// preserves update diff reporting against the existing database.
 func UpdateContextWithOptions(ctx context.Context, cfg *config.Config, records *source.LoadResult) (*RebuildResult, error) {
 	return updateContext(ctx, cfg, records, UpdateOptions{}, nil)
 }
 
-// UpdateWithProgressContextAndOptions performs an incremental index update with
+// UpdateWithProgressContextAndOptions performs a rebuild-backed update with
 // progress reporting.
 func UpdateWithProgressContextAndOptions(ctx context.Context, cfg *config.Config, records *source.LoadResult, reporter RebuildProgressReporter) (*RebuildResult, error) {
 	return updateContext(ctx, cfg, records, UpdateOptions{}, reporter)
 }
 
-// UpdateWithDeltaContextAndOptions performs an incremental index update with
+// UpdateWithDeltaContextAndOptions performs a rebuild-backed update with
 // progress reporting and governance delta computation.
 func UpdateWithDeltaContextAndOptions(ctx context.Context, cfg *config.Config, records *source.LoadResult, options UpdateOptions, reporter RebuildProgressReporter) (*RebuildResult, error) {
 	return updateContext(ctx, cfg, records, options, reporter)
 }
 
 func updateContext(ctx context.Context, cfg *config.Config, records *source.LoadResult, options UpdateOptions, reporter RebuildProgressReporter) (*RebuildResult, error) {
-	embedder, err := prepareRebuildContext(ctx, cfg, records)
-	if err != nil {
-		return nil, err
-	}
-	dimension, err := embedder.Dimension(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	indexPath := cfg.Workspace.ResolvedIndexPath
 
-	// Step 3: Validate index file exists.
 	info, err := os.Stat(indexPath)
 	switch {
 	case os.IsNotExist(err):
@@ -82,197 +68,18 @@ func updateContext(ctx context.Context, cfg *config.Config, records *source.Load
 		return nil, fmt.Errorf("index path %s is a directory", indexPath)
 	}
 
-	// Step 4: Create backup.
-	backupPath := indexPath + ".bak"
-	if err := copyFile(indexPath, backupPath); err != nil {
-		return nil, fmt.Errorf("create index backup: %w", err)
-	}
-
-	result, err := applyUpdateContext(ctx, indexPath, cfg, dimension, embedder, records, options, reporter)
+	db, err := OpenReadOnlyContext(ctx, indexPath)
 	if err != nil {
-		// Restore from backup on any failure. Keep the backup in place
-		// if restoration itself fails so the user has a recovery path.
-		if restoreErr := restoreFromBackup(backupPath, indexPath); restoreErr != nil {
-			return nil, fmt.Errorf("update failed: %w; additionally, backup restore failed: %v", err, restoreErr)
-		}
-		return nil, err
-	}
-
-	// Success — clean up backup.
-	_ = os.Remove(backupPath)
-	return result, nil
-}
-
-func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Config, dimension int, embedder Embedder, records *source.LoadResult, options UpdateOptions, reporter RebuildProgressReporter) (*RebuildResult, error) {
-	db, err := openReadWriteContext(ctx, indexPath)
-	if err != nil {
-		return nil, fmt.Errorf("open index for update: %w", err)
+		return nil, fmt.Errorf("open index %s: %w", indexPath, err)
 	}
 	defer db.Close()
 
-	// Migrate schema to v4 if needed (add edge_source column and ast_cache table).
-	// This must run before validateUpdatePreconditions, which checks schema_version.
-	if err := migrateToSchemaV4(ctx, db); err != nil {
-		return nil, fmt.Errorf("schema migration to v4: %w", err)
-	}
-	// Migrate schema to v5 if needed (add temporal validity columns).
-	if err := migrateToSchemaV5(ctx, db); err != nil {
-		return nil, fmt.Errorf("schema migration to v5: %w", err)
-	}
-	// Migrate schema to v6 if needed (add confidence tiers to edges).
-	if err := migrateToSchemaV6(ctx, db); err != nil {
-		return nil, fmt.Errorf("schema migration to v6: %w", err)
-	}
-	// Migrate schema to v7 if needed (add rationale_json to ast_cache).
-	if err := migrateToSchemaV7(ctx, db); err != nil {
-		return nil, fmt.Errorf("schema migration to v7: %w", err)
-	}
-
-	// Step 6: Validate preconditions.
-	if err := validateUpdatePreconditions(ctx, db, embedder.Fingerprint(), dimension); err != nil {
-		return nil, err
-	}
-
-	// Step 7: Load stored artifact refs and content hashes.
 	storedRefs, err := loadStoredArtifactRefsContext(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-
-	// Step 8: Compute diff.
 	diff := computeArtifactDiff(storedRefs, records)
 
-	// Step 9: Load stored chunks for changed artifacts (embedding reuse).
-	var partialReuse *reuseState
-	if len(diff.updated) > 0 {
-		partialReuse, err = loadStoredChunksForRefsContext(ctx, db, diff.updated)
-		if err != nil {
-			return nil, fmt.Errorf("load stored chunks for reuse: %w", err)
-		}
-	} else {
-		partialReuse = &reuseState{artifacts: map[string]storedArtifact{}}
-	}
-
-	// Build ref lookup maps for O(1) record access.
-	specsByRef := make(map[string]model.SpecRecord, len(records.Specs))
-	for _, spec := range records.Specs {
-		specsByRef[spec.Ref] = spec
-	}
-	docsByRef := make(map[string]model.DocRecord, len(records.Docs))
-	for _, doc := range records.Docs {
-		docsByRef[doc.Ref] = doc
-	}
-
-	// Step 10: Begin transaction and apply changes.
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("begin update transaction: %w", err)
-	}
-	defer func() {
-		if tx != nil {
-			_ = tx.Rollback()
-		}
-	}()
-
-	result := &RebuildResult{
-		Update:            true,
-		IndexPath:         indexPath,
-		EmbedderDimension: dimension,
-		AddedCount:        len(diff.added),
-		UpdatedCount:      len(diff.updated),
-		RemovedCount:      len(diff.removed),
-		UnchangedCount:    len(diff.unchanged),
-		Repos:             repoCoverageFromRecords(records),
-		Sources:           append([]source.LoadSourceSummary(nil), records.Sources...),
-	}
-
-	totalWork := len(diff.removed) + len(diff.updated) + len(diff.added)
-	currentWork := 0
-
-	// Step 10a: Delete removed artifacts.
-	for _, ref := range diff.removed {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		currentWork++
-		reportRebuildProgress(reporter, RebuildProgressEvent{
-			Phase:       "deleting",
-			ArtifactRef: ref,
-			Current:     currentWork,
-			Total:       totalWork,
-		})
-		if err := deleteArtifactDataContext(ctx, tx, ref); err != nil {
-			return nil, err
-		}
-	}
-
-	// Step 10b: Delete changed artifacts' data.
-	for _, ref := range diff.updated {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if err := deleteArtifactDataContext(ctx, tx, ref); err != nil {
-			return nil, err
-		}
-	}
-
-	// Prepare insert statements.
-	chunkStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunks (record_ref, chunk_index, heading, content) VALUES (?, ?, ?, ?)`)
-	if err != nil {
-		return nil, fmt.Errorf("prepare chunk insert: %w", err)
-	}
-	defer chunkStmt.Close()
-
-	vectorStmt, err := tx.PrepareContext(ctx, `INSERT INTO chunks_vec (chunk_id, embedding) VALUES (?, ?)`)
-	if err != nil {
-		return nil, fmt.Errorf("prepare chunk vector insert: %w", err)
-	}
-	defer vectorStmt.Close()
-
-	// Step 10c: Insert changed artifacts.
-	for _, ref := range diff.updated {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		currentWork++
-		chunkCount, reusedCount, embeddedCount, err := insertRecordContext(ctx, tx, chunkStmt, vectorStmt, embedder, specsByRef, docsByRef, ref, partialReuse, RebuildProgressEvent{
-			Current: currentWork,
-			Total:   totalWork,
-		}, reporter)
-		if err != nil {
-			return nil, err
-		}
-		result.ChunkCount += chunkCount
-		result.ReusedChunkCount += reusedCount
-		result.EmbeddedChunkCount += embeddedCount
-	}
-
-	// Step 10d: Insert new artifacts.
-	for _, ref := range diff.added {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		currentWork++
-		chunkCount, reusedCount, embeddedCount, err := insertRecordContext(ctx, tx, chunkStmt, vectorStmt, embedder, specsByRef, docsByRef, ref, partialReuse, RebuildProgressEvent{
-			Current: currentWork,
-			Total:   totalWork,
-		}, reporter)
-		if err != nil {
-			return nil, err
-		}
-		result.ChunkCount += chunkCount
-		result.ReusedChunkCount += reusedCount
-		result.EmbeddedChunkCount += embeddedCount
-	}
-
-	// Count chunks from unchanged artifacts in a single query.
-	unchangedChunkCount, err := countChunksForRefsContext(ctx, db, diff.unchanged)
-	if err != nil {
-		return nil, err
-	}
-	result.ChunkCount += unchangedChunkCount
-
-	// Snapshot edges and spec artifacts before edge rebuild for delta computation.
 	var oldEdges []snapshotEdge
 	var oldArtifacts []snapshotArtifact
 	if options.ComputeDelta {
@@ -286,120 +93,36 @@ func applyUpdateContext(ctx context.Context, indexPath string, cfg *config.Confi
 		}
 	}
 
-	// Step 10e: Full edge rebuild.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM edges`); err != nil {
-		return nil, fmt.Errorf("delete edges: %w", err)
-	}
-
-	edgeStmt, err := tx.PrepareContext(ctx, `INSERT OR IGNORE INTO edges (from_ref, to_ref, edge_type, edge_source, valid_from, valid_to, confidence, confidence_score) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+	result, err := rebuildContext(ctx, cfg, records, RebuildOptions{}, reporter)
 	if err != nil {
-		return nil, fmt.Errorf("prepare edge insert: %w", err)
+		return nil, err
 	}
-	defer edgeStmt.Close()
+	result.Update = true
+	result.FullRebuild = true
+	result.AddedCount = len(diff.added)
+	result.UpdatedCount = len(diff.updated)
+	result.RemovedCount = len(diff.removed)
+	result.UnchangedCount = len(diff.unchanged)
 
-	updateTime := time.Now().UTC().Format("2006-01-02")
-	updateTimePtr := &updateTime
-
-	for _, spec := range records.Specs {
-		var edgeValidTo *string
-		if spec.Status == "superseded" || spec.Status == "deprecated" {
-			edgeValidTo = updateTimePtr
-		}
-		for _, relation := range spec.Relations {
-			if err := insertEdgeContext(ctx, edgeStmt, spec.Ref, relation.Ref, string(relation.Type), "manual", updateTimePtr, edgeValidTo, ConfidenceExtracted); err != nil {
-				return nil, err
-			}
-			result.EdgeCount++
-		}
-		for _, appliesTo := range spec.AppliesTo {
-			if err := insertEdgeContext(ctx, edgeStmt, spec.Ref, appliesTo, "applies_to", "manual", updateTimePtr, edgeValidTo, ConfidenceExtracted); err != nil {
-				return nil, err
-			}
-			result.EdgeCount++
-		}
-	}
-
-	// Infer AST-based applies_to edges.
-	inferredCount, inferErr := inferASTEdgesContext(ctx, tx, edgeStmt, cfg, records.Specs, updateTimePtr)
-	if inferErr != nil {
-		return nil, fmt.Errorf("infer AST edges: %w", inferErr)
-	}
-	result.EdgeCount += inferredCount
-	result.InferredEdgeCount = inferredCount
-
-	// Compute governance delta from edge and artifact snapshots.
 	if options.ComputeDelta {
-		newEdges, deltaErr := snapshotEdgesTxContext(ctx, tx)
-		if deltaErr != nil {
-			return nil, fmt.Errorf("snapshot new edges: %w", deltaErr)
+		newDB, err := OpenReadOnlyContext(ctx, indexPath)
+		if err != nil {
+			return nil, fmt.Errorf("reopen rebuilt index %s: %w", indexPath, err)
 		}
-		newArtifacts, deltaErr := snapshotSpecArtifactsTxContext(ctx, tx)
-		if deltaErr != nil {
-			return nil, fmt.Errorf("snapshot new artifacts: %w", deltaErr)
+		defer newDB.Close()
+
+		newEdges, err := snapshotEdgesContext(ctx, newDB)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot new edges: %w", err)
+		}
+		newArtifacts, err := snapshotSpecArtifactsContext(ctx, newDB)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot new artifacts: %w", err)
 		}
 		result.Delta = computeGovernanceDelta(oldArtifacts, newArtifacts, oldEdges, newEdges)
 	}
 
-	// Step 10f: Upsert metadata.
-	if err := upsertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {
-		return nil, err
-	}
-	if manifest := sourceManifestJSON(cfg); manifest != "" {
-		if err := upsertMetadataContext(ctx, tx, "source_manifest", manifest); err != nil {
-			return nil, err
-		}
-	}
-	result.ContentFingerprint = contentFingerprint(records)
-	if err := upsertMetadataContext(ctx, tx, "content_fingerprint", result.ContentFingerprint); err != nil {
-		return nil, err
-	}
-
-	// Step 10g + 11: Integrity checks inside transaction.
-	if err := runTransactionIntegrityChecks(ctx, tx); err != nil {
-		return nil, err
-	}
-
-	// Step 12: Commit.
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit update transaction: %w", err)
-	}
-	tx = nil
-
-	// Populate final counts.
-	result.ArtifactCount = len(records.Specs) + len(records.Docs)
-	result.SpecCount = len(records.Specs)
-	result.DocCount = len(records.Docs)
-
 	return result, nil
-}
-
-// validateUpdatePreconditions checks that the existing index is structurally
-// compatible with the current embedder configuration.
-func validateUpdatePreconditions(ctx context.Context, db *sql.DB, embedderFP string, embedderDim int) error {
-	metadata, err := readMetadataContext(ctx, db, "schema_version", "embedder_fingerprint", "embedder_dimension")
-	if err != nil {
-		return fmt.Errorf("read index metadata for update: %w", err)
-	}
-
-	if stored := strings.TrimSpace(metadata["schema_version"]); stored != fmt.Sprintf("%d", schemaVersion) {
-		return &UpdatePreconditionError{
-			Reason: fmt.Sprintf("index schema version %q does not match expected version %d", stored, schemaVersion),
-			Action: "run `pituitary index --rebuild`",
-		}
-	}
-	if stored := strings.TrimSpace(metadata["embedder_fingerprint"]); stored != embedderFP {
-		return &UpdatePreconditionError{
-			Reason: fmt.Sprintf("index embedder fingerprint %q does not match configured fingerprint %q", stored, embedderFP),
-			Action: "run `pituitary index --rebuild`",
-		}
-	}
-	if stored := strings.TrimSpace(metadata["embedder_dimension"]); stored != strconv.Itoa(embedderDim) {
-		return &UpdatePreconditionError{
-			Reason: fmt.Sprintf("index embedder dimension %q does not match configured dimension %d", stored, embedderDim),
-			Action: "run `pituitary index --rebuild`",
-		}
-	}
-	return nil
 }
 
 // storedArtifactRef holds the minimal stored artifact data needed for diffing.
@@ -473,131 +196,6 @@ func computeArtifactDiff(stored []storedArtifactRef, records *source.LoadResult)
 	return diff
 }
 
-// loadStoredChunksForRefsContext loads stored artifact + chunk data for a
-// specific set of refs, for embedding reuse during update.
-func loadStoredChunksForRefsContext(ctx context.Context, db *sql.DB, refs []string) (*reuseState, error) {
-	if len(refs) == 0 {
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
-	}
-
-	state := &reuseState{artifacts: make(map[string]storedArtifact, len(refs))}
-
-	// Load artifact metadata.
-	for _, ref := range refs {
-		var (
-			title       sql.NullString
-			contentHash string
-		)
-		err := db.QueryRowContext(ctx, `SELECT title, content_hash FROM artifacts WHERE ref = ?`, ref).Scan(&title, &contentHash)
-		if err != nil {
-			return nil, fmt.Errorf("query stored artifact %s: %w", ref, err)
-		}
-		state.artifacts[ref] = storedArtifact{
-			contentHash: contentHash,
-			title:       title.String,
-			chunks:      map[string]storedChunk{},
-		}
-	}
-
-	// Load chunks with embeddings.
-	for _, ref := range refs {
-		rows, err := db.QueryContext(ctx, `
-SELECT c.heading, c.content, v.embedding
-FROM chunks c
-JOIN chunks_vec v ON v.chunk_id = c.id
-WHERE c.record_ref = ?
-ORDER BY c.id`, ref)
-		if err != nil {
-			return nil, fmt.Errorf("query stored chunks for %s: %w", ref, err)
-		}
-
-		artifact := state.artifacts[ref]
-		for rows.Next() {
-			var (
-				section   sql.NullString
-				content   string
-				embedding []byte
-			)
-			if err := rows.Scan(&section, &content, &embedding); err != nil {
-				rows.Close()
-				return nil, fmt.Errorf("scan stored chunk for %s: %w", ref, err)
-			}
-			artifact.chunks[reuseChunkKey(artifact.title, section.String, content)] = storedChunk{
-				embedding: append([]byte(nil), embedding...),
-			}
-		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("iterate stored chunks for %s: %w", ref, err)
-		}
-		state.artifacts[ref] = artifact
-	}
-
-	return state, nil
-}
-
-// deleteArtifactDataContext removes an artifact and its associated chunks and
-// vectors from the database within a transaction.
-func deleteArtifactDataContext(ctx context.Context, tx *sql.Tx, ref string) error {
-	// Delete vectors (vec0 virtual table) via subquery on chunks.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks_vec WHERE chunk_id IN (SELECT id FROM chunks WHERE record_ref = ?)`, ref); err != nil {
-		return fmt.Errorf("delete vectors for %s: %w", ref, err)
-	}
-	// Delete chunks.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks WHERE record_ref = ?`, ref); err != nil {
-		return fmt.Errorf("delete chunks for %s: %w", ref, err)
-	}
-	// Delete artifact.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM records WHERE ref = ?`, ref); err != nil {
-		return fmt.Errorf("delete artifact %s: %w", ref, err)
-	}
-	return nil
-}
-
-// insertRecordContext inserts a single artifact (spec or doc) with its chunks,
-// embeddings, and edges into the transaction.
-func insertRecordContext(ctx context.Context, tx *sql.Tx, chunkStmt, vectorStmt *sql.Stmt, embedder Embedder, specsByRef map[string]model.SpecRecord, docsByRef map[string]model.DocRecord, ref string, state *reuseState, baseEvent RebuildProgressEvent, reporter RebuildProgressReporter) (chunkCount, reusedCount, embeddedCount int, err error) {
-	if spec, ok := specsByRef[ref]; ok {
-		if err := insertSpecArtifactContext(ctx, tx, spec); err != nil {
-			return 0, 0, 0, err
-		}
-		plan := planArtifactReuse(spec.Title, spec.ContentHash, spec.BodyText, storedArtifactForRecord(state, ref))
-		baseEvent.Phase = "chunking"
-		baseEvent.ArtifactKind = model.ArtifactKindSpec
-		baseEvent.ArtifactRef = ref
-		return insertArtifactChunksContext(ctx, chunkStmt, vectorStmt, embedder, ref, spec.Title, plan, baseEvent, reporter)
-	}
-	if doc, ok := docsByRef[ref]; ok {
-		if err := insertDocArtifactContext(ctx, tx, doc); err != nil {
-			return 0, 0, 0, err
-		}
-		plan := planArtifactReuse(doc.Title, doc.ContentHash, doc.BodyText, storedArtifactForRecord(state, ref))
-		baseEvent.Phase = "chunking"
-		baseEvent.ArtifactKind = model.ArtifactKindDoc
-		baseEvent.ArtifactRef = ref
-		return insertArtifactChunksContext(ctx, chunkStmt, vectorStmt, embedder, ref, doc.Title, plan, baseEvent, reporter)
-	}
-	return 0, 0, 0, fmt.Errorf("record %s not found in loaded sources", ref)
-}
-
-// countChunksForRefsContext returns the total chunk count for a set of artifact refs
-// in a single query.
-func countChunksForRefsContext(ctx context.Context, db *sql.DB, refs []string) (int, error) {
-	if len(refs) == 0 {
-		return 0, nil
-	}
-	query := `SELECT COUNT(*) FROM chunks WHERE record_ref IN (` + placeholders(len(refs)) + `)`
-	args := make([]any, 0, len(refs))
-	for _, ref := range refs {
-		args = append(args, ref)
-	}
-	var count int
-	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
-		return 0, fmt.Errorf("count chunks for unchanged artifacts: %w", err)
-	}
-	return count, nil
-}
-
 // upsertMetadataContext inserts or replaces a metadata key-value pair.
 func upsertMetadataContext(ctx context.Context, tx *sql.Tx, key, value string) error {
 	if _, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)`, key, value); err != nil {
@@ -636,49 +234,6 @@ func runTransactionIntegrityChecks(ctx context.Context, tx *sql.Tx) error {
 	}
 
 	return nil
-}
-
-// restoreFromBackup restores the index from a backup file, removing the
-// potentially corrupted index first. If the rename fails (e.g., cross-device),
-// it falls back to a copy.
-func restoreFromBackup(backupPath, indexPath string) error {
-	if err := os.Remove(indexPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove index before restore: %w", err)
-	}
-	if err := os.Rename(backupPath, indexPath); err != nil {
-		// Rename can fail cross-device; fall back to copy.
-		if copyErr := copyFile(backupPath, indexPath); copyErr != nil {
-			return fmt.Errorf("rename: %w; copy fallback: %v", err, copyErr)
-		}
-		_ = os.Remove(backupPath)
-	}
-	return nil
-}
-
-// copyFile copies src to dst using a temporary file and rename for atomicity.
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	tmp := dst + ".tmp"
-	out, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := out.Close(); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	return os.Rename(tmp, dst)
 }
 
 // migrateToSchemaV4 adds the edge_source column and ast_cache table to an

--- a/internal/index/update_test.go
+++ b/internal/index/update_test.go
@@ -167,8 +167,9 @@ include = ["guides/*.md"]
 	db := mustOpenReadOnly(t, indexPath)
 	defer db.Close()
 	assertCount(t, db, `SELECT COUNT(*) FROM artifacts`, 1)
-	// Verify no orphaned chunks.
-	assertCount(t, db, `SELECT COUNT(*) FROM chunks WHERE record_ref NOT IN (SELECT ref FROM records)`, 0)
+	corpusDB := mustOpenCorpusReadOnly(t, indexPath)
+	defer corpusDB.Close()
+	assertCount(t, corpusDB, `SELECT COUNT(*) FROM records`, 1)
 }
 
 func TestUpdateChangedArtifact(t *testing.T) {
@@ -245,13 +246,16 @@ func TestUpdatePreconditionSchemaVersion(t *testing.T) {
 	}
 	db.Close()
 
-	_, err = UpdateContextWithOptions(context.Background(), cfg, records)
-	if !IsUpdatePrecondition(err) {
-		t.Fatalf("expected UpdatePreconditionError, got %v", err)
+	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	if err != nil {
+		t.Fatalf("UpdateContextWithOptions() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "--rebuild") {
-		t.Fatalf("error message %q should contain --rebuild guidance", err.Error())
+	if !result.FullRebuild {
+		t.Fatalf("result = %+v, want update to recover via full rebuild", result)
 	}
+	db = mustOpenReadOnly(t, cfg.Workspace.ResolvedIndexPath)
+	defer db.Close()
+	assertMetadataValue(t, db, "schema_version", "10")
 }
 
 func TestUpdatePreconditionEmbedder(t *testing.T) {
@@ -277,10 +281,16 @@ func TestUpdatePreconditionEmbedder(t *testing.T) {
 	}
 	db.Close()
 
-	_, err = UpdateContextWithOptions(context.Background(), cfg, records)
-	if !IsUpdatePrecondition(err) {
-		t.Fatalf("expected UpdatePreconditionError, got %v", err)
+	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	if err != nil {
+		t.Fatalf("UpdateContextWithOptions() error = %v", err)
 	}
+	if !result.FullRebuild {
+		t.Fatalf("result = %+v, want update to recover via full rebuild", result)
+	}
+	db = mustOpenReadOnly(t, indexPath)
+	defer db.Close()
+	assertMetadataValue(t, db, "embedder_fingerprint", "fixture|fixture-8d|plain_v1")
 }
 
 func TestUpdateMissingIndex(t *testing.T) {


### PR DESCRIPTION
## Summary
- rebuild Pituitary into split local stores: `pituitary.db` for governance data plus a content-addressed Stroma snapshot for corpus data
- route search, reuse, status, and analysis reads through Stroma's snapshot API instead of querying corpus tables directly
- update docs/tests and pin Pituitary to the published Stroma commit that introduces the snapshot API

## Notes
- Depends on the Stroma PR from branch `session/stroma-snapshot-boundary`.
- `pituitary index --update` is rebuild-backed in this change while preserving update diff and governance delta reporting.

## Validation
- `go test ./...`
