### PR TITLE
[codex] Clarify search score semantics for stroma v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pituitary status                       # index health and governance hotspots at
 | Debug why a file is in or out of scope | `pituitary explain-file PATH` |
 | Full spec review | `pituitary review-spec --path specs/X` |
 | Auto-fix deterministic drift | `pituitary fix --scope all --dry-run` |
-| Search specs semantically | `pituitary search-specs --query "rate limiting"` |
+| Search specs by hybrid relevance | `pituitary search-specs --query "rate limiting"` |
 | Trace impact of a spec change | `pituitary analyze-impact --path specs/X` |
 | Compare two specs | `pituitary compare-specs --path specs/A --path specs/B` |
 | Detect stale specs | `pituitary check-spec-freshness --scope all` |

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -235,7 +235,7 @@ func pathWithinRootNew(root, path string) bool {
 }
 
 func checkNewSpecOverlap(ctx context.Context, cfg *config.Config, title string) []source.NewSpecBundleWarning {
-	searchResult, err := index.SearchSpecsContext(ctx, cfg, index.SearchSpecQuery{
+	searchResult, err := index.SearchSpecsBySemanticSimilarityContext(ctx, cfg, index.SearchSpecQuery{
 		Query:    title,
 		Kind:     "spec",
 		Statuses: []string{"draft", "review", "accepted"},
@@ -251,7 +251,7 @@ func checkNewSpecOverlap(ctx context.Context, cfg *config.Config, title string) 
 		if match.Score >= overlapThreshold {
 			warnings = append(warnings, source.NewSpecBundleWarning{
 				Code:    "similar_spec_exists",
-				Message: fmt.Sprintf("existing spec %s %q has %.0f%% semantic similarity; review before proceeding", match.Ref, match.Title, match.Score*100),
+				Message: fmt.Sprintf("existing spec %s %q has %.0f%% semantic similarity to this title; review before proceeding", match.Ref, match.Title, match.Score*100),
 			})
 		}
 	}

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -110,3 +110,51 @@ func TestRunNewDefaultsDomainToUnknown(t *testing.T) {
 		t.Fatalf("warnings = %+v, want placeholder domain warning", payload.Warnings)
 	}
 }
+
+func TestRunNewWarnsOnSemanticallySimilarExistingSpec(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return 0
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runNew([]string{
+			"--title", "Per-Tenant Rate Limiting for Public API Endpoints",
+			"--domain", "api",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runNew() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runNew() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Warnings []cliIssue `json:"warnings"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal new payload: %v", err)
+	}
+
+	var found bool
+	for _, warning := range payload.Warnings {
+		if warning.Code != "similar_spec_exists" {
+			continue
+		}
+		found = true
+		if !strings.Contains(warning.Message, "semantic similarity to this title") {
+			t.Fatalf("warning message = %q, want semantic similarity wording", warning.Message)
+		}
+	}
+	if !found {
+		t.Fatalf("warnings = %+v, want similar_spec_exists warning", payload.Warnings)
+	}
+}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -760,6 +760,9 @@ func renderSearchSpecsResult(w io.Writer, result *index.SearchSpecResult) {
 		fmt.Fprintln(w, "no matches")
 		return
 	}
+	if note := searchSpecScoreNote(result); note != "" {
+		fmt.Fprintf(w, "score semantics: %s\n\n", note)
+	}
 
 	for i, match := range result.Matches {
 		fmt.Fprintf(w, "%d. %s | %s | %.3f\n", i+1, match.Ref, match.SectionHeading, match.Score)
@@ -780,9 +783,12 @@ func renderSearchSpecsTable(w io.Writer, result *index.SearchSpecResult) {
 		fmt.Fprintln(w, "no matches")
 		return
 	}
+	if note := searchSpecScoreNote(result); note != "" {
+		fmt.Fprintf(w, "score semantics: %s\n\n", note)
+	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "REF\tREPO\tTITLE\tSECTION\tSOURCE\tSCORE")
+	fmt.Fprintf(tw, "REF\tREPO\tTITLE\tSECTION\tSOURCE\t%s\n", index.SearchSpecScoreColumnLabel(result.ScoreKind))
 	for _, match := range result.Matches {
 		fmt.Fprintf(
 			tw,
@@ -825,6 +831,16 @@ func searchMatchDetailLine(match index.SearchSpecMatch) string {
 		parts = append(parts, "source: "+displaySourcePath(match.SourceRef))
 	}
 	return strings.Join(parts, " | ")
+}
+
+func searchSpecScoreNote(result *index.SearchSpecResult) string {
+	if result == nil {
+		return ""
+	}
+	if note := strings.TrimSpace(result.ScoreDescription); note != "" {
+		return note
+	}
+	return index.SearchSpecScoreDescription(result.ScoreKind)
 }
 
 func renderIndexRepoCoverage(w io.Writer, repos []index.RepoCoverage) {

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -280,11 +280,12 @@ func TestRenderCommandTableSearchSpecs(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
-		"pituitary search-specs: search spec sections semantically",
+		"pituitary search-specs: search spec sections by hybrid relevance",
+		"score semantics: hybrid relevance from fused vector and lexical retrieval; not a cosine similarity percentage",
 		"REF",
 		"TITLE",
 		"SECTION",
-		"SCORE",
+		"RELEVANCE",
 		"SPEC-042",
 		"Tenant-aware rate limiting",
 		"Per-tenant quotas",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ func commandRegistry() map[string]commandSpec {
 		"version":              {Description: "show Pituitary and Go runtime versions", Formats: commandFormats(), Run: runVersionContext},
 		"preview-sources":      {Description: "preview indexed files per source and selector diagnostics", Formats: commandFormats(), Run: runPreviewSourcesContext},
 		"explain-file":         {Description: "debug why one file is in or out of scope for configured sources", Formats: commandFormats(), Run: runExplainFileContext},
-		"search-specs":         {Description: "search spec sections semantically", Formats: commandFormats(commandFormatTable), Run: runSearchSpecsContext},
+		"search-specs":         {Description: "search spec sections by hybrid relevance", Formats: commandFormats(commandFormatTable), Run: runSearchSpecsContext},
 		"check-overlap":        {Description: "find overlapping specs", Formats: commandFormats(), Run: runCheckOverlapContext},
 		"compare-specs":        {Description: "compare design tradeoffs across specs", Formats: commandFormats(), Run: runCompareSpecsContext},
 		"analyze-impact":       {Description: "report affected specs and docs", Formats: commandFormats(), Run: runAnalyzeImpactContext},

--- a/cmd/search_specs_test.go
+++ b/cmd/search_specs_test.go
@@ -37,7 +37,9 @@ func TestRunSearchSpecsJSON(t *testing.T) {
 			} `json:"filters"`
 		} `json:"request"`
 		Result struct {
-			Matches []struct {
+			ScoreKind        string `json:"score_kind"`
+			ScoreDescription string `json:"score_description"`
+			Matches          []struct {
 				Ref            string `json:"ref"`
 				SectionHeading string `json:"section_heading"`
 			} `json:"matches"`
@@ -59,6 +61,12 @@ func TestRunSearchSpecsJSON(t *testing.T) {
 	}
 	if len(payload.Errors) != 0 {
 		t.Fatalf("payload errors = %+v, want none", payload.Errors)
+	}
+	if payload.Result.ScoreKind != "hybrid_relevance" {
+		t.Fatalf("payload result.score_kind = %q, want hybrid_relevance", payload.Result.ScoreKind)
+	}
+	if !strings.Contains(payload.Result.ScoreDescription, "hybrid relevance") {
+		t.Fatalf("payload result.score_description = %q, want hybrid relevance guidance", payload.Result.ScoreDescription)
 	}
 	if len(payload.Result.Matches) == 0 {
 		t.Fatal("payload returned no matches")
@@ -138,11 +146,12 @@ func TestRunSearchSpecsTable(t *testing.T) {
 
 	out := stdout.String()
 	for _, want := range []string{
-		"pituitary search-specs: search spec sections semantically",
+		"pituitary search-specs: search spec sections by hybrid relevance",
+		"score semantics: hybrid relevance from fused vector and lexical retrieval; not a cosine similarity percentage",
 		"REF",
 		"TITLE",
 		"SECTION",
-		"SCORE",
+		"RELEVANCE",
 		"SPEC-008",
 	} {
 		if !strings.Contains(out, want) {

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -32,7 +32,7 @@ pituitary schema review-spec --format json      # machine-readable command contr
 ## Analysis
 
 ```sh
-pituitary search-specs --query "rate limiting"  # semantic search
+pituitary search-specs --query "rate limiting"  # hybrid relevance search
 pituitary search-specs --query "auth" --family 0  # search within a spec family
 pituitary check-overlap --path specs/X          # find overlapping specs
 pituitary compare-specs --path specs/A --path specs/B  # side-by-side tradeoff

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -46,7 +46,7 @@ Text output now also promotes the strongest per-finding guidance into a short `T
 | `index --dry-run` | Validate config and sources without writing |
 | `status [--check-runtime all] [--show-families]` | Report index state, config, freshness, runtime readiness, spec families |
 | `version` | Print version info |
-| `search-specs --query "..."` | Semantic search across indexed spec sections |
+| `search-specs --query "..."` | Hybrid relevance search across indexed spec sections |
 | `check-overlap --path SPEC` | Detect specs that cover overlapping ground |
 | `compare-specs --path A --path B` | Side-by-side tradeoff analysis |
 | `analyze-impact --path SPEC` | Trace what is affected by a change |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.9
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6
-	github.com/dusk-network/stroma v0.0.0-20260413131144-770dfc81a8dc
+	github.com/dusk-network/stroma v0.2.0
 	github.com/google/go-github/v79 v79.0.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196 h1:1TULfQD0OA8
 github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
 github.com/dusk-network/stroma v0.0.0-20260413131144-770dfc81a8dc h1:4dPfDz6tAihHfnj89G+qSKJSvm0SVbBcuPtA6IVqrDw=
 github.com/dusk-network/stroma v0.0.0-20260413131144-770dfc81a8dc/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
+github.com/dusk-network/stroma v0.2.0 h1:Un+D0j4J4LPIVkyX/p+FcLfU0sBl/T5EGCvQTliqdK8=
+github.com/dusk-network/stroma v0.2.0/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -20,6 +20,16 @@ const (
 	maxSearchLimit     = 50
 )
 
+const (
+	// SearchSpecScoreKindHybridRelevance indicates scores from hybrid retrieval
+	// that blends vector and lexical matches into a fused relevance rank.
+	SearchSpecScoreKindHybridRelevance = "hybrid_relevance"
+
+	// SearchSpecScoreKindSemanticSimilarity indicates scores from vector-only
+	// retrieval where the score remains cosine-similarity-like.
+	SearchSpecScoreKindSemanticSimilarity = "semantic_similarity"
+)
+
 // SearchSpecFilters captures the optional search filters exposed by transports.
 type SearchSpecFilters struct {
 	Domain   string   `json:"domain,omitempty"`
@@ -59,8 +69,10 @@ type SearchSpecMatch struct {
 
 // SearchSpecResult is the ranked retrieval output.
 type SearchSpecResult struct {
-	Matches      []SearchSpecMatch        `json:"matches"`
-	ContentTrust *resultmeta.ContentTrust `json:"content_trust,omitempty"`
+	Matches          []SearchSpecMatch        `json:"matches"`
+	ScoreKind        string                   `json:"score_kind,omitempty"`
+	ScoreDescription string                   `json:"score_description,omitempty"`
+	ContentTrust     *resultmeta.ContentTrust `json:"content_trust,omitempty"`
 }
 
 type chunkCandidate struct {
@@ -126,6 +138,40 @@ func SearchSpecs(cfg *config.Config, query SearchSpecQuery) (*SearchSpecResult, 
 
 // SearchSpecsContext executes semantic retrieval over the indexed spec corpus.
 func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpecQuery) (*SearchSpecResult, error) {
+	return searchSpecsContextWithScoreKind(ctx, cfg, query, SearchSpecScoreKindHybridRelevance, loadRankedCandidatesContext)
+}
+
+// SearchSpecsBySemanticSimilarityContext executes vector-only retrieval over
+// the indexed spec corpus and returns cosine-similarity-like scores.
+func SearchSpecsBySemanticSimilarityContext(ctx context.Context, cfg *config.Config, query SearchSpecQuery) (*SearchSpecResult, error) {
+	return searchSpecsContextWithScoreKind(ctx, cfg, query, SearchSpecScoreKindSemanticSimilarity, loadSemanticSimilarityCandidatesContext)
+}
+
+// SearchSpecScoreColumnLabel returns the user-facing score column name for one
+// search result score kind.
+func SearchSpecScoreColumnLabel(kind string) string {
+	switch kind {
+	case SearchSpecScoreKindSemanticSimilarity:
+		return "SIMILARITY"
+	default:
+		return "RELEVANCE"
+	}
+}
+
+// SearchSpecScoreDescription returns a user-facing description of what the
+// search score represents for one search result score kind.
+func SearchSpecScoreDescription(kind string) string {
+	switch kind {
+	case SearchSpecScoreKindSemanticSimilarity:
+		return "cosine-style semantic similarity from vector-only retrieval"
+	default:
+		return "hybrid relevance from fused vector and lexical retrieval; not a cosine similarity percentage"
+	}
+}
+
+type candidateLoader func(context.Context, *sql.DB, *stindex.Snapshot, Embedder, SearchSpecQuery) ([]chunkCandidate, error)
+
+func searchSpecsContextWithScoreKind(ctx context.Context, cfg *config.Config, query SearchSpecQuery, scoreKind string, loader candidateLoader) (*SearchSpecResult, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
@@ -143,52 +189,18 @@ func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpe
 		return nil, err
 	}
 
-	db, err := OpenReadOnlyContext(ctx, cfg.Workspace.ResolvedIndexPath)
-	if err != nil {
-		return nil, fmt.Errorf("open index %s: %w", cfg.Workspace.ResolvedIndexPath, err)
-	}
-	defer db.Close()
-
-	snapshot, err := OpenStromaSnapshotContext(ctx, db, cfg.Workspace.ResolvedIndexPath)
+	searchCtx, err := openSearchContext(ctx, cfg, embedder)
 	if err != nil {
 		return nil, err
 	}
-	defer snapshot.Close()
+	defer searchCtx.Close()
 
-	dimension, err := embedder.Dimension(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolve embedder dimension: %w", err)
-	}
-	if err := validateStoredEmbedderContext(ctx, db, embedder.Fingerprint(), dimension); err != nil {
-		return nil, err
-	}
-
-	candidates, err := loadRankedCandidatesContext(ctx, db, snapshot, embedder, query)
+	candidates, err := loader(ctx, searchCtx.db, searchCtx.snapshot, searchCtx.embedder, query)
 	if err != nil {
 		return nil, err
 	}
 
-	result := &SearchSpecResult{
-		Matches:      make([]SearchSpecMatch, 0, len(candidates)),
-		ContentTrust: resultmeta.UntrustedWorkspaceText(),
-	}
-	for _, candidate := range candidates {
-		result.Matches = append(result.Matches, SearchSpecMatch{
-			Ref:            candidate.Ref,
-			Title:          candidate.Title,
-			SectionHeading: candidate.SectionHeading,
-			Excerpt:        excerpt(candidate.Content),
-			Repo:           candidate.Repo,
-			SourceRef:      candidate.SourceRef,
-			Kind:           candidate.Kind,
-			Status:         candidate.Status,
-			Domain:         candidate.Domain,
-			Score:          candidate.Score,
-			Inference:      candidate.Inference,
-		})
-	}
-
-	return result, nil
+	return buildSearchSpecResult(candidates, scoreKind), nil
 }
 
 func normalizeSearchSpecQuery(query SearchSpecQuery) (SearchSpecQuery, error) {
@@ -277,6 +289,54 @@ func validateStoredEmbedderContext(ctx context.Context, db *sql.DB, fingerprint 
 	return nil
 }
 
+type searchContext struct {
+	db       *sql.DB
+	snapshot *stindex.Snapshot
+	embedder Embedder
+}
+
+func openSearchContext(ctx context.Context, cfg *config.Config, embedder Embedder) (*searchContext, error) {
+	db, err := OpenReadOnlyContext(ctx, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		return nil, fmt.Errorf("open index %s: %w", cfg.Workspace.ResolvedIndexPath, err)
+	}
+
+	snapshot, err := OpenStromaSnapshotContext(ctx, db, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	dimension, err := embedder.Dimension(ctx)
+	if err != nil {
+		_ = snapshot.Close()
+		_ = db.Close()
+		return nil, fmt.Errorf("resolve embedder dimension: %w", err)
+	}
+	if err := validateStoredEmbedderContext(ctx, db, embedder.Fingerprint(), dimension); err != nil {
+		_ = snapshot.Close()
+		_ = db.Close()
+		return nil, err
+	}
+	return &searchContext{
+		db:       db,
+		snapshot: snapshot,
+		embedder: embedder,
+	}, nil
+}
+
+func (s *searchContext) Close() {
+	if s == nil {
+		return
+	}
+	if s.snapshot != nil {
+		_ = s.snapshot.Close()
+	}
+	if s.db != nil {
+		_ = s.db.Close()
+	}
+}
+
 func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {
 	preferHistorical := ranking.SearchPrefersHistoricalContext(query.Query)
 
@@ -290,6 +350,33 @@ func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stin
 		return nil, fmt.Errorf("query search candidates: %w", err)
 	}
 
+	return buildRankedCandidatesContext(ctx, db, hits, query, preferHistorical)
+}
+
+func loadSemanticSimilarityCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {
+	preferHistorical := ranking.SearchPrefersHistoricalContext(query.Query)
+
+	vectors, err := embedder.EmbedQueries(ctx, []string{query.Query})
+	if err != nil {
+		return nil, fmt.Errorf("embed search query: %w", err)
+	}
+	if len(vectors) != 1 {
+		return nil, fmt.Errorf("embedder returned %d query vectors, want 1", len(vectors))
+	}
+
+	hits, err := snapshot.SearchVector(ctx, stindex.VectorSearchQuery{
+		Embedding: vectors[0],
+		Limit:     searchCandidateLimit(query.Limit),
+		Kinds:     []string{query.Kind},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query semantic similarity candidates: %w", err)
+	}
+
+	return buildRankedCandidatesContext(ctx, db, hits, query, preferHistorical)
+}
+
+func buildRankedCandidatesContext(ctx context.Context, db *sql.DB, hits []stindex.SearchHit, query SearchSpecQuery, preferHistorical bool) ([]chunkCandidate, error) {
 	states, err := loadSearchArtifactStateContext(ctx, db, refsForSearchHits(hits))
 	if err != nil {
 		return nil, err
@@ -341,6 +428,31 @@ func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stin
 		candidates = candidates[:query.Limit]
 	}
 	return candidates, nil
+}
+
+func buildSearchSpecResult(candidates []chunkCandidate, scoreKind string) *SearchSpecResult {
+	result := &SearchSpecResult{
+		Matches:          make([]SearchSpecMatch, 0, len(candidates)),
+		ScoreKind:        scoreKind,
+		ScoreDescription: SearchSpecScoreDescription(scoreKind),
+		ContentTrust:     resultmeta.UntrustedWorkspaceText(),
+	}
+	for _, candidate := range candidates {
+		result.Matches = append(result.Matches, SearchSpecMatch{
+			Ref:            candidate.Ref,
+			Title:          candidate.Title,
+			SectionHeading: candidate.SectionHeading,
+			Excerpt:        excerpt(candidate.Content),
+			Repo:           candidate.Repo,
+			SourceRef:      candidate.SourceRef,
+			Kind:           candidate.Kind,
+			Status:         candidate.Status,
+			Domain:         candidate.Domain,
+			Score:          candidate.Score,
+			Inference:      candidate.Inference,
+		})
+	}
+	return result
 }
 
 type searchArtifactState struct {

--- a/internal/index/search_test.go
+++ b/internal/index/search_test.go
@@ -33,6 +33,12 @@ func TestSearchSpecsReturnsRankedSections(t *testing.T) {
 	if len(result.Matches) == 0 {
 		t.Fatal("SearchSpecs() returned no matches")
 	}
+	if got, want := result.ScoreKind, SearchSpecScoreKindHybridRelevance; got != want {
+		t.Fatalf("result.ScoreKind = %q, want %q", got, want)
+	}
+	if !strings.Contains(result.ScoreDescription, "hybrid relevance") {
+		t.Fatalf("result.ScoreDescription = %q, want hybrid relevance guidance", result.ScoreDescription)
+	}
 	if result.Matches[0].Ref == "" || result.Matches[0].SectionHeading == "" {
 		t.Fatalf("top match = %+v, want stable ref and section heading", result.Matches[0])
 	}
@@ -51,6 +57,40 @@ func TestSearchSpecsReturnsRankedSections(t *testing.T) {
 	}
 	if !found042 {
 		t.Fatalf("SearchSpecs() matches = %+v, want SPEC-042 among results", result.Matches)
+	}
+}
+
+func TestSearchSpecsBySemanticSimilarityReturnsSimilarityScores(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	result, err := SearchSpecsBySemanticSimilarityContext(context.Background(), cfg, SearchSpecQuery{
+		Query:    "Per-Tenant Rate Limiting for Public API Endpoints",
+		Statuses: []string{model.StatusDraft, model.StatusReview, model.StatusAccepted},
+		Limit:    3,
+	})
+	if err != nil {
+		t.Fatalf("SearchSpecsBySemanticSimilarityContext() error = %v", err)
+	}
+	if got, want := result.ScoreKind, SearchSpecScoreKindSemanticSimilarity; got != want {
+		t.Fatalf("result.ScoreKind = %q, want %q", got, want)
+	}
+	if !strings.Contains(result.ScoreDescription, "cosine-style semantic similarity") {
+		t.Fatalf("result.ScoreDescription = %q, want semantic similarity guidance", result.ScoreDescription)
+	}
+	if len(result.Matches) == 0 {
+		t.Fatal("SearchSpecsBySemanticSimilarityContext() returned no matches")
+	}
+	if result.Matches[0].Score < 0.50 {
+		t.Fatalf("top similarity score = %f, want a cosine-similarity-like value", result.Matches[0].Score)
 	}
 }
 


### PR DESCRIPTION
## Summary
- clarify that `search-specs` scores are hybrid relevance scores once Stroma mixes vector and lexical retrieval
- keep `pituitary new` overlap detection on vector-only semantic similarity so its warning threshold still means what it says
- bump `github.com/dusk-network/stroma` to `v0.2.0`

## Why
Stroma `v0.2.0` changes `Snapshot.Search` to hybrid retrieval with reciprocal-rank fusion. That makes the returned score a fused relevance rank when lexical matches participate, not a cosine similarity percentage. Pituitary was still presenting those scores as semantic similarity and was using them for the new-spec overlap warning.

## Impact
- `pituitary search-specs` now labels scores as hybrid relevance and explains their semantics in text and JSON output
- `pituitary new` overlap warnings continue to use cosine-style vector similarity
- docs and tests now match the new behavior

## Validation
- `go test ./...`

Closes #315