### PR TITLE
Add commandRun[Req,Res] helper and migrate two CLI commands

### DIFF
--- a/cmd/check_doc_drift.go
+++ b/cmd/check_doc_drift.go
@@ -28,134 +28,77 @@ func runCheckDocDrift(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-doc-drift", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-doc-drift", "pituitary [--config PATH] check-doc-drift ([--doc-ref REF | --path PATH]... | [--scope all] | [--diff-file PATH|-]) [--request-file PATH|-] [--format FORMAT] [--timings]")
-
 	var (
-		docRefs     docRefList
-		docPaths    docRefList
-		scope       string
-		diffFile    string
-		requestFile string
-		format      string
-		configPath  string
-		atDate      string
-		timings     bool
+		docRefs       docRefList
+		docPaths      docRefList
+		scope         string
+		diffFile      string
+		atDate        string
+		minConfidence string
 	)
-	fs.Var(&docRefs, "doc-ref", "target doc ref; repeat to supply doc_refs")
-	fs.Var(&docPaths, "path", "workspace-relative or absolute path to an indexed doc; repeat to supply paths")
-	fs.StringVar(&scope, "scope", "", "scope selector; only \"all\" is valid")
-	fs.StringVar(&diffFile, "diff-file", "", "path to a unified diff file, or - for stdin")
-	fs.StringVar(&requestFile, "request-file", "", "path to doc drift request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
-	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
-	var minConfidence string
-	fs.StringVar(&minConfidence, "min-confidence", "", "minimum confidence tier: extracted, inferred, or ambiguous")
-
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("check-doc-drift", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-
-	var request analysis.DocDriftRequest
-	switch {
-	case trimmedRequestFile != "" && (len(docRefs) > 0 || len(docPaths) > 0 || strings.TrimSpace(scope) != "" || strings.TrimSpace(diffFile) != ""):
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or the doc-ref/path/scope/diff-file flags",
-		}, 2)
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.DocDriftRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		if request.DiffText == "" && strings.TrimSpace(request.DiffFile) != "" {
-			request.DiffText, err = loadComplianceDiffFile(cfg.Workspace.RootPath, request.DiffFile)
-			if err != nil {
-				return writeCLIError(stdout, stderr, format, "check-doc-drift", request, cliIssue{
-					Code:    "validation_error",
-					Message: err.Error(),
-				}, 2)
-			}
-		}
-	default:
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		resolvedDocRefs := append([]string(nil), docRefs...)
-		if len(docPaths) > 0 {
-			resolvedPaths, err := resolveIndexedDocRefsWithConfigContext(ctx, cfg, []string(docPaths))
-			if err != nil {
-				return writeDocPathResolutionError(stdout, stderr, format, "check-doc-drift", nil, err)
-			}
-			resolvedDocRefs = append(resolvedDocRefs, resolvedPaths...)
-		}
-		request, err = docDriftRequestFromFlags(cfg.Workspace.RootPath, resolvedDocRefs, strings.TrimSpace(scope), strings.TrimSpace(diffFile))
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-
-	if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
-		request.AtDate = trimmedAt
-	}
-	if trimmedConf := strings.TrimSpace(minConfidence); trimmedConf != "" {
-		request.MinConfidence = trimmedConf
-	}
-	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
-
-	operation := app.CheckDocDrift(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccessWithTimings(stdout, stderr, format, "check-doc-drift", operation.Request, operation.Result, nil, snapshotCommandTimings(tracker, started))
+	return runCommand[analysis.DocDriftRequest, analysis.DocDriftResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.DocDriftRequest, analysis.DocDriftResult]{
+			Name:  "check-doc-drift",
+			Usage: "pituitary [--config PATH] check-doc-drift ([--doc-ref REF | --path PATH]... | [--scope all] | [--diff-file PATH|-]) [--request-file PATH|-] [--format FORMAT] [--timings]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				Timings:        true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.Var(&docRefs, "doc-ref", "target doc ref; repeat to supply doc_refs")
+				fs.Var(&docPaths, "path", "workspace-relative or absolute path to an indexed doc; repeat to supply paths")
+				fs.StringVar(&scope, "scope", "", "scope selector; only \"all\" is valid")
+				fs.StringVar(&diffFile, "diff-file", "", "path to a unified diff file, or - for stdin")
+				fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
+				fs.StringVar(&minConfidence, "min-confidence", "", "minimum confidence tier: extracted, inferred, or ambiguous")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return len(docRefs) > 0 || len(docPaths) > 0 || strings.TrimSpace(scope) != "" || strings.TrimSpace(diffFile) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.DocDriftRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.DocDriftRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				if req.DiffText == "" && strings.TrimSpace(req.DiffFile) != "" {
+					diffText, diffErr := loadComplianceDiffFile(cfg.Workspace.RootPath, req.DiffFile)
+					if diffErr != nil {
+						return &req, diffErr
+					}
+					req.DiffText = diffText
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.DocDriftRequest, error) {
+				resolvedDocRefs := append([]string(nil), docRefs...)
+				if len(docPaths) > 0 {
+					resolvedPaths, err := resolveIndexedDocRefsWithConfigContext(ctx, cfg, []string(docPaths))
+					if err != nil {
+						return analysis.DocDriftRequest{}, docPathResolutionError(err)
+					}
+					resolvedDocRefs = append(resolvedDocRefs, resolvedPaths...)
+				}
+				return docDriftRequestFromFlags(cfg.Workspace.RootPath, resolvedDocRefs, strings.TrimSpace(scope), strings.TrimSpace(diffFile))
+			},
+			Normalize: func(_ context.Context, req analysis.DocDriftRequest) (analysis.DocDriftRequest, error) {
+				if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
+					req.AtDate = trimmedAt
+				}
+				if trimmedConf := strings.TrimSpace(minConfidence); trimmedConf != "" {
+					req.MinConfidence = trimmedConf
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.DocDriftRequest) (analysis.DocDriftRequest, *analysis.DocDriftResult, *app.Issue) {
+				op := app.CheckDocDrift(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func docDriftRequestFromFlags(workspaceRoot string, docRefs []string, scope, diffFile string) (analysis.DocDriftRequest, error) {

--- a/cmd/doc_path.go
+++ b/cmd/doc_path.go
@@ -17,6 +17,13 @@ func resolveIndexedDocRefsWithConfigContext(ctx context.Context, cfg *config.Con
 }
 
 func writeDocPathResolutionError(stdout, stderr io.Writer, format, command string, request any, err error) int {
+	issue := docPathResolutionIssue(err)
+	return writeCLIError(stdout, stderr, format, command, request, issue, 2)
+}
+
+// docPathResolutionIssue classifies a doc-path resolution error into the
+// cliIssue code previously emitted by writeDocPathResolutionError.
+func docPathResolutionIssue(err error) cliIssue {
 	code := "validation_error"
 	switch {
 	case index.IsMissingIndex(err):
@@ -24,8 +31,11 @@ func writeDocPathResolutionError(stdout, stderr io.Writer, format, command strin
 	case index.IsDocPathNotFound(err):
 		code = "not_found"
 	}
-	return writeCLIError(stdout, stderr, format, command, request, cliIssue{
-		Code:    code,
-		Message: err.Error(),
-	}, 2)
+	return cliIssue{Code: code, Message: err.Error()}
+}
+
+// docPathResolutionError wraps a doc-path resolution error in a cliIssueError
+// so runCommand's BuildRequest callback can surface the classified code.
+func docPathResolutionError(err error) error {
+	return &cliIssueError{issue: docPathResolutionIssue(err), exitCode: 2}
 }

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -46,7 +46,8 @@ type commandRun[Req any, Res any] struct {
 	// iff Options.ConfigForFlags is true. Required.
 	BuildRequest func(ctx context.Context, cfg *config.Config, resolvedConfigPath string) (Req, error)
 
-	// Normalize (optional) runs after the request is composed, before Execute.
+	// Normalize (optional) runs after the request is composed, before Execute,
+	// and fires for both the --request-file path and the inline-flags path.
 	// On error, the runner writes the returned Req into the envelope, so
 	// Normalize can return a pre- or post-normalize request as appropriate.
 	Normalize func(ctx context.Context, req Req) (Req, error)
@@ -54,8 +55,11 @@ type commandRun[Req any, Res any] struct {
 	// Execute calls the app layer. Required.
 	Execute func(ctx context.Context, resolvedConfigPath string, req Req) (Req, *Res, *app.Issue)
 
-	// PostProcess (optional) runs after Execute succeeds.
-	PostProcess func(ctx context.Context, resolvedConfigPath string, req Req, res *Res) (*Res, *cliIssue)
+	// PostProcess (optional) runs after Execute succeeds. When it returns a
+	// non-nil cliIssue, the runner writes it with the returned exit code. An
+	// exit code of 0 is treated as the default 2 so the common "validation
+	// error" case stays terse at the call site.
+	PostProcess func(ctx context.Context, resolvedConfigPath string, req Req, res *Res) (*Res, *cliIssue, int)
 }
 
 // commandRunOptions toggles the shared flags and config-loading behavior the
@@ -84,9 +88,6 @@ type cliIssueError struct {
 }
 
 func (e *cliIssueError) Error() string {
-	if e == nil {
-		return ""
-	}
 	return e.issue.Message
 }
 
@@ -111,6 +112,15 @@ func runCommand[Req any, Res any](
 	stdout, stderr io.Writer,
 	plan commandRun[Req, Res],
 ) int {
+	if plan.BuildRequest == nil {
+		panic("commandRun.BuildRequest is required for " + plan.Name)
+	}
+	if plan.Execute == nil {
+		panic("commandRun.Execute is required for " + plan.Name)
+	}
+	if plan.Options.RequestFile && (plan.LoadRequestFile == nil || plan.InlineFlagsSet == nil) {
+		panic("commandRun.LoadRequestFile and InlineFlagsSet are required when RequestFile is enabled for " + plan.Name)
+	}
 	fs := flag.NewFlagSet(plan.Name, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	help := newCommandHelp(plan.Name, plan.Usage)
@@ -247,9 +257,12 @@ func runCommand[Req any, Res any](
 	}
 
 	if plan.PostProcess != nil {
-		postResult, postIssue := plan.PostProcess(execCtx, resolvedConfigPath, enrichedReq, result)
+		postResult, postIssue, postExit := plan.PostProcess(execCtx, resolvedConfigPath, enrichedReq, result)
 		if postIssue != nil {
-			return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, *postIssue, 2)
+			if postExit == 0 {
+				postExit = 2
+			}
+			return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, *postIssue, postExit)
 		}
 		result = postResult
 	}

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -35,11 +35,16 @@ type commandRun[Req any, Res any] struct {
 	// Options.RequestFile is true.
 	InlineFlagsSet func(fs *flag.FlagSet) bool
 
-	// LoadRequestFile parses the request JSON and may run follow-up reads. It
-	// returns a pointer to the parsed request: nil means no request should
-	// surface in the error envelope (e.g., JSON parse failure); non-nil means
-	// write the pointee into the envelope. Required when Options.RequestFile
-	// is true.
+	// LoadRequestFile parses the request JSON and may run follow-up reads.
+	// Contract:
+	//   - On success (nil error), the returned pointer MUST be non-nil; the
+	//     runner dereferences it to build the request passed to Normalize and
+	//     Execute. Returning (nil, nil) is a programmer error.
+	//   - On error, nil means no request should surface in the envelope (e.g.
+	//     JSON parse failure). Non-nil means the pointee is a partial request
+	//     (e.g. JSON parsed but a follow-up diff-file resolution failed) and
+	//     the runner writes it into the error envelope.
+	// Required when Options.RequestFile is true.
 	LoadRequestFile func(ctx context.Context, cfg *config.Config, trimmedPath string) (*Req, error)
 
 	// BuildRequest builds the request from the inline flags. cfg is non-nil
@@ -208,9 +213,16 @@ func runCommand[Req any, Res any](
 				Message: loadErr.Error(),
 			}, 2)
 		}
-		if loaded != nil {
-			request = *loaded
+		if loaded == nil {
+			// Programmer error: LoadRequestFile returned (nil, nil). Surface as
+			// internal_error so the bug is visible in the envelope instead of
+			// letting Execute run against a zero-valued request.
+			return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+				Code:    "internal_error",
+				Message: plan.Name + ": request file loader returned no request",
+			}, 2)
 		}
+		request = *loaded
 	default:
 		var cfg *config.Config
 		if plan.Options.ConfigForFlags {

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/app"
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+// commandRun describes a CLI command's lifecycle for runCommand. It collapses
+// the shared parse → validate → resolve-config → branch-on-request-file →
+// build-request → normalize → execute → post-process → write pipeline that
+// every command in this package reproduces.
+//
+// Type parameters: Req is the command's request DTO; Res is the result value
+// type held by app.Response (the runner receives *Res from the app layer and
+// passes it to the renderer as-is).
+type commandRun[Req any, Res any] struct {
+	Name  string
+	Usage string
+
+	Options commandRunOptions
+
+	// BindFlags registers command-specific flags on fs. The runner pre-registers
+	// --config, --format, optionally --timings and --request-file per Options.
+	BindFlags func(fs *flag.FlagSet)
+
+	// InlineFlagsSet reports whether any fine-grained inline flag is set, used
+	// to reject combinations with --request-file. Required when
+	// Options.RequestFile is true.
+	InlineFlagsSet func(fs *flag.FlagSet) bool
+
+	// LoadRequestFile parses the request JSON and may run follow-up reads. It
+	// returns a pointer to the parsed request: nil means no request should
+	// surface in the error envelope (e.g., JSON parse failure); non-nil means
+	// write the pointee into the envelope. Required when Options.RequestFile
+	// is true.
+	LoadRequestFile func(ctx context.Context, cfg *config.Config, trimmedPath string) (*Req, error)
+
+	// BuildRequest builds the request from the inline flags. cfg is non-nil
+	// iff Options.ConfigForFlags is true. Required.
+	BuildRequest func(ctx context.Context, cfg *config.Config, resolvedConfigPath string) (Req, error)
+
+	// Normalize (optional) runs after the request is composed, before Execute.
+	// On error, the runner writes the returned Req into the envelope, so
+	// Normalize can return a pre- or post-normalize request as appropriate.
+	Normalize func(ctx context.Context, req Req) (Req, error)
+
+	// Execute calls the app layer. Required.
+	Execute func(ctx context.Context, resolvedConfigPath string, req Req) (Req, *Res, *app.Issue)
+
+	// PostProcess (optional) runs after Execute succeeds.
+	PostProcess func(ctx context.Context, resolvedConfigPath string, req Req, res *Res) (*Res, *cliIssue)
+}
+
+// commandRunOptions toggles the shared flags and config-loading behavior the
+// runner itself controls.
+type commandRunOptions struct {
+	// RequestFile enables the --request-file flag and the mutual-exclusion
+	// branch. Requires LoadRequestFile and InlineFlagsSet.
+	RequestFile bool
+	// Timings enables the --timings flag (JSON-only timing metadata).
+	Timings bool
+	// AcceptsPositional, when false (default), rejects fs.NArg() != 0.
+	AcceptsPositional bool
+	// ConfigForFlags loads config before calling BuildRequest.
+	ConfigForFlags bool
+	// ConfigForFile loads config before calling LoadRequestFile.
+	ConfigForFile bool
+}
+
+// cliIssueError lets BuildRequest/LoadRequestFile/Normalize callbacks surface a
+// classified cliIssue (Code/Message/Details/ExitCode) through the standard
+// error channel. The runner unwraps it via errors.As and writes the embedded
+// issue directly, rather than defaulting to validation_error/exit 2.
+type cliIssueError struct {
+	issue    cliIssue
+	exitCode int
+}
+
+func (e *cliIssueError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.issue.Message
+}
+
+// asCliIssue unwraps a cliIssueError chain into its (issue, exitCode) pair.
+func asCliIssue(err error) (cliIssue, int, bool) {
+	var wrap *cliIssueError
+	if errors.As(err, &wrap) && wrap != nil {
+		exitCode := wrap.exitCode
+		if exitCode == 0 {
+			exitCode = 2
+		}
+		return wrap.issue, exitCode, true
+	}
+	return cliIssue{}, 0, false
+}
+
+// runCommand executes the described CLI command lifecycle and returns the
+// process exit code.
+func runCommand[Req any, Res any](
+	ctx context.Context,
+	args []string,
+	stdout, stderr io.Writer,
+	plan commandRun[Req, Res],
+) int {
+	fs := flag.NewFlagSet(plan.Name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	help := newCommandHelp(plan.Name, plan.Usage)
+
+	var (
+		configPath  string
+		format      string
+		timings     bool
+		requestFile string
+	)
+	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
+	fs.StringVar(&configPath, "config", "", "path to workspace config")
+	if plan.Options.Timings {
+		fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
+	}
+	if plan.Options.RequestFile {
+		fs.StringVar(&requestFile, "request-file", "", "path to request JSON, or - for stdin")
+	}
+	if plan.BindFlags != nil {
+		plan.BindFlags(fs)
+	}
+
+	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	} else if handled {
+		return 0
+	}
+
+	if !plan.Options.AcceptsPositional && fs.NArg() != 0 {
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "validation_error",
+			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
+		}, 2)
+	}
+
+	if err := validateCLIFormat(plan.Name, format); err != nil {
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	trimmedRequestFile := strings.TrimSpace(requestFile)
+	var request Req
+	switch {
+	case plan.Options.RequestFile && trimmedRequestFile != "" && plan.InlineFlagsSet != nil && plan.InlineFlagsSet(fs):
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "validation_error",
+			Message: "use either --request-file or the fine-grained flags",
+		}, 2)
+	case plan.Options.RequestFile && trimmedRequestFile != "":
+		var cfg *config.Config
+		if plan.Options.ConfigForFile {
+			loaded, cfgErr := config.Load(resolvedConfigPath)
+			if cfgErr != nil {
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+					Code:    "config_error",
+					Message: cfgErr.Error(),
+				}, 2)
+			}
+			cfg = loaded
+		}
+		loaded, loadErr := plan.LoadRequestFile(ctx, cfg, trimmedRequestFile)
+		if loadErr != nil {
+			var envelopeReq any
+			if loaded != nil {
+				envelopeReq = *loaded
+			}
+			if issue, exitCode, ok := asCliIssue(loadErr); ok {
+				return writeCLIError(stdout, stderr, format, plan.Name, envelopeReq, issue, exitCode)
+			}
+			return writeCLIError(stdout, stderr, format, plan.Name, envelopeReq, cliIssue{
+				Code:    "validation_error",
+				Message: loadErr.Error(),
+			}, 2)
+		}
+		if loaded != nil {
+			request = *loaded
+		}
+	default:
+		var cfg *config.Config
+		if plan.Options.ConfigForFlags {
+			loaded, cfgErr := config.Load(resolvedConfigPath)
+			if cfgErr != nil {
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+					Code:    "config_error",
+					Message: cfgErr.Error(),
+				}, 2)
+			}
+			cfg = loaded
+		}
+		request, err = plan.BuildRequest(ctx, cfg, resolvedConfigPath)
+		if err != nil {
+			if issue, exitCode, ok := asCliIssue(err); ok {
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, issue, exitCode)
+			}
+			return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+				Code:    "validation_error",
+				Message: err.Error(),
+			}, 2)
+		}
+	}
+
+	if plan.Normalize != nil {
+		normalized, normErr := plan.Normalize(ctx, request)
+		if normErr != nil {
+			if issue, exitCode, ok := asCliIssue(normErr); ok {
+				return writeCLIError(stdout, stderr, format, plan.Name, normalized, issue, exitCode)
+			}
+			return writeCLIError(stdout, stderr, format, plan.Name, normalized, cliIssue{
+				Code:    "validation_error",
+				Message: normErr.Error(),
+			}, 2)
+		}
+		request = normalized
+	}
+
+	execCtx, tracker, started := withCommandTimings(ctx, plan.Options.Timings && timings && format == commandFormatJSON)
+
+	enrichedReq, result, issue := plan.Execute(execCtx, resolvedConfigPath, request)
+	if issue != nil {
+		return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, cliIssueFromAppIssue(issue), issue.ExitCode)
+	}
+
+	if plan.PostProcess != nil {
+		postResult, postIssue := plan.PostProcess(execCtx, resolvedConfigPath, enrichedReq, result)
+		if postIssue != nil {
+			return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, *postIssue, 2)
+		}
+		result = postResult
+	}
+
+	return writeCLISuccessWithTimings(stdout, stderr, format, plan.Name, enrichedReq, result, nil, snapshotCommandTimings(tracker, started))
+}

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -91,23 +91,23 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 				op := app.SearchSpecs(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},
-			PostProcess: func(ctx context.Context, cfgPath string, _ index.SearchSpecRequest, res *index.SearchSpecResult) (*index.SearchSpecResult, *cliIssue) {
+			PostProcess: func(ctx context.Context, cfgPath string, _ index.SearchSpecRequest, res *index.SearchSpecResult) (*index.SearchSpecResult, *cliIssue, int) {
 				if familyID < 0 || res == nil {
-					return res, nil
+					return res, nil, 0
 				}
 				cfg, cfgErr := config.Load(cfgPath)
 				if cfgErr != nil {
 					return res, &cliIssue{
 						Code:    "config_error",
 						Message: fmt.Sprintf("failed to load config for --family filtering: %v", cfgErr),
-					}
+					}, 2
 				}
 				familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
 				if famErr != nil {
 					return res, &cliIssue{
 						Code:    "internal_error",
 						Message: fmt.Sprintf("failed to compute families for --family filtering: %v", famErr),
-					}
+					}, 2
 				}
 				familyMembers := make(map[string]bool)
 				for _, a := range familyResult.Assignments {
@@ -122,7 +122,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 					}
 				}
 				res.Matches = filtered
-				return res, nil
+				return res, nil, 0
 			},
 		},
 	)

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -28,145 +28,102 @@ func runSearchSpecs(args []string, stdout, stderr io.Writer) int {
 }
 
 func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("search-specs", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("search-specs", "pituitary [--config PATH] search-specs (--query TEXT | --request-file PATH|-) [--domain VALUE] [--status VALUE]... [--limit N] [--format FORMAT]")
-
 	var (
-		query       string
-		requestFile string
-		format      string
-		domain      string
-		configPath  string
-		statuses    searchSpecsFlagList
-		limit       int
-		familyID    int
+		query    string
+		domain   string
+		statuses searchSpecsFlagList
+		limit    int
+		familyID int
 	)
-	fs.StringVar(&query, "query", "", "semantic query")
-	fs.StringVar(&requestFile, "request-file", "", "path to search request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format (text, json, table)")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.StringVar(&domain, "domain", "", "filter by domain")
-	fs.Var(&statuses, "status", "filter by status; repeat to set multiple statuses")
-	fs.IntVar(&limit, "limit", 10, "maximum matches to return")
-	fs.IntVar(&familyID, "family", -1, "filter results to specs in the given family ID")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("search-specs", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	var request index.SearchSpecRequest
-	switch {
-	case trimmedRequestFile != "" && (strings.TrimSpace(query) != "" || strings.TrimSpace(domain) != "" || len(statuses) > 0 || flagWasSet(fs, "limit")):
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or fine-grained search flags",
-		}, 2)
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[index.SearchSpecRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	default:
-		request = index.SearchSpecRequest{
-			Query: strings.TrimSpace(query),
-			Filters: index.SearchSpecFilters{
-				Domain:   strings.TrimSpace(domain),
-				Statuses: []string(statuses),
+	return runCommand[index.SearchSpecRequest, index.SearchSpecResult](
+		ctx, args, stdout, stderr,
+		commandRun[index.SearchSpecRequest, index.SearchSpecResult]{
+			Name:  "search-specs",
+			Usage: "pituitary [--config PATH] search-specs (--query TEXT | --request-file PATH|-) [--domain VALUE] [--status VALUE]... [--limit N] [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:   true,
+				ConfigForFile: true,
 			},
-			Limit: &limit,
-		}
-	}
-	queryArgs, err := request.ToQuery()
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	request.Filters.Statuses = queryArgs.Statuses
-	request.Query = queryArgs.Query
-	request.Filters.Domain = queryArgs.Domain
-	requestLimit := queryArgs.Limit
-	request.Limit = &requestLimit
-	if request.Query == "" {
-		return writeCLIError(stdout, stderr, format, "search-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "query is required",
-		}, 2)
-	}
-
-	operation := app.SearchSpecs(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	// Post-filter by family if --family was specified.
-	if familyID >= 0 && operation.Result != nil {
-		cfg, cfgErr := config.Load(resolvedConfigPath)
-		if cfgErr != nil {
-			return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssue{
-				Code:    "config_error",
-				Message: fmt.Sprintf("failed to load config for --family filtering: %v", cfgErr),
-			}, 2)
-		}
-		familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
-		if famErr != nil {
-			return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssue{
-				Code:    "internal_error",
-				Message: fmt.Sprintf("failed to compute families for --family filtering: %v", famErr),
-			}, 2)
-		}
-		familyMembers := make(map[string]bool)
-		for _, a := range familyResult.Assignments {
-			if a.FamilyID == familyID {
-				familyMembers[a.Ref] = true
-			}
-		}
-		var filtered []index.SearchSpecMatch
-		for _, m := range operation.Result.Matches {
-			if familyMembers[m.Ref] {
-				filtered = append(filtered, m)
-			}
-		}
-		operation.Result.Matches = filtered
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "search-specs", operation.Request, operation.Result, nil)
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&query, "query", "", "semantic query")
+				fs.StringVar(&domain, "domain", "", "filter by domain")
+				fs.Var(&statuses, "status", "filter by status; repeat to set multiple statuses")
+				fs.IntVar(&limit, "limit", 10, "maximum matches to return")
+				fs.IntVar(&familyID, "family", -1, "filter results to specs in the given family ID")
+			},
+			InlineFlagsSet: func(fs *flag.FlagSet) bool {
+				return strings.TrimSpace(query) != "" || strings.TrimSpace(domain) != "" || len(statuses) > 0 || flagWasSet(fs, "limit")
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*index.SearchSpecRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[index.SearchSpecRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(_ context.Context, _ *config.Config, _ string) (index.SearchSpecRequest, error) {
+				return index.SearchSpecRequest{
+					Query: strings.TrimSpace(query),
+					Filters: index.SearchSpecFilters{
+						Domain:   strings.TrimSpace(domain),
+						Statuses: []string(statuses),
+					},
+					Limit: &limit,
+				}, nil
+			},
+			Normalize: func(_ context.Context, req index.SearchSpecRequest) (index.SearchSpecRequest, error) {
+				queryArgs, err := req.ToQuery()
+				if err != nil {
+					return req, err
+				}
+				req.Filters.Statuses = queryArgs.Statuses
+				req.Query = queryArgs.Query
+				req.Filters.Domain = queryArgs.Domain
+				requestLimit := queryArgs.Limit
+				req.Limit = &requestLimit
+				if req.Query == "" {
+					return req, fmt.Errorf("query is required")
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req index.SearchSpecRequest) (index.SearchSpecRequest, *index.SearchSpecResult, *app.Issue) {
+				op := app.SearchSpecs(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+			PostProcess: func(ctx context.Context, cfgPath string, _ index.SearchSpecRequest, res *index.SearchSpecResult) (*index.SearchSpecResult, *cliIssue) {
+				if familyID < 0 || res == nil {
+					return res, nil
+				}
+				cfg, cfgErr := config.Load(cfgPath)
+				if cfgErr != nil {
+					return res, &cliIssue{
+						Code:    "config_error",
+						Message: fmt.Sprintf("failed to load config for --family filtering: %v", cfgErr),
+					}
+				}
+				familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
+				if famErr != nil {
+					return res, &cliIssue{
+						Code:    "internal_error",
+						Message: fmt.Sprintf("failed to compute families for --family filtering: %v", famErr),
+					}
+				}
+				familyMembers := make(map[string]bool)
+				for _, a := range familyResult.Assignments {
+					if a.FamilyID == familyID {
+						familyMembers[a.Ref] = true
+					}
+				}
+				var filtered []index.SearchSpecMatch
+				for _, m := range res.Matches {
+					if familyMembers[m.Ref] {
+						filtered = append(filtered, m)
+					}
+				}
+				res.Matches = filtered
+				return res, nil
+			},
+		},
+	)
 }


### PR DESCRIPTION
## Summary

First of a four-PR stack that collapses the CLI command scaffolding. Every command in `cmd/` reproduces the same pipeline — parse flags → reject positionals → validate format → resolve config → branch on `--request-file` vs inline flags → build request → normalize → execute → post-process → write envelope. This PR introduces a generic `runCommand[Req, Res](ctx, args, stdout, stderr, plan commandRun[Req, Res])` helper that owns the pipeline, and migrates two commands onto it as the first validation.

## What's in the helper

- `cmd/run_command.go`: defines `commandRun[Req, Res]` plus `commandRunOptions` that toggle `--request-file`, `--timings`, `ConfigForFile`/`ConfigForFlags`, and positional-arg acceptance. The runner pre-registers `--config`/`--format` (and `--timings`/`--request-file` on demand), validates format, resolves config, branches between the request-file and inline paths (with mutual-exclusion enforcement via `InlineFlagsSet`), threads a `Normalize` hook and an optional `PostProcess` hook, and writes the success envelope through `writeCLISuccessWithTimings`.
- `cliIssueError` lets `BuildRequest`/`LoadRequestFile`/`Normalize` callbacks surface classified codes (e.g. `config_error`/`not_found` from spec/doc-path resolution) through the standard `error` channel. `cmd/doc_path.go` uses this with `docPathResolutionError` to preserve the existing `writeDocPathResolutionError` classification.

## Commands migrated in this PR

- `cmd/check_doc_drift.go` — runCheckDocDriftContext body from ~130 LOC to ~60.
- `cmd/search_specs.go` — runSearchSpecsContext body from ~140 LOC to ~100 (`--family` post-filter + `ToQuery` normalization stay meaty).

## Preserved behavior (all existing tests green)

- Request-file partial-envelope surfacing: JSON parse failure → nil request written; post-parse failure (e.g. referenced diff-file missing) → partial request written.
- Doc-path error classification honored (`config_error`/`not_found`/`validation_error`).
- `ToQuery` normalization + `"query is required"` ordering for search-specs.
- `--family` post-filter with its own config reload.
- Mutex between `--request-file` and inline flags (including `flagWasSet(fs, "limit")` for search-specs).

## Validation

- `make ci` (fmt-check + docs-check + smoke-sqlite-vec + test + vet) green.
- `go test -race ./cmd/...` clean.

## Follow-up PRs (stacked)

1. This PR (helper + 2 commands)
2. `refactor/cmd-runcommand-batch-2` — analyze-impact, check-terminology, compare-specs
3. `refactor/cmd-runcommand-batch-3` — check-spec-freshness, check-overlap, review-spec
4. `refactor/cmd-runcommand-batch-4` — check-compliance

Projected savings once all four land: **-430 LOC across command bodies** (-170 net after the helper).

## Out of scope

- `fix`, `compile`, `canonicalize`, `migrate-config`, `explain-file` — custom request types, non-`app.X` executors, positional-as-primary-arg, or cross-cutting format/dry-run validation. They need additional runner hooks (e.g. `Normalize(format string, req)`, an `Execute` adapter for plain errors, an "exactly N positional" option). Deferred to later PRs.

## Test plan

- [ ] CI green on `refactor/cmd-runcommand-helper`
- [ ] `@claude review` passes or its findings are addressed
- [ ] All four stacked PRs rebase cleanly after this merges