### PR TITLE
Migrate three more spec-centric commands to runCommand[Req,Res]

### DIFF
--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -54,13 +54,18 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 				return &req, nil
 			},
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.AnalyzeImpactRequest, error) {
+				trimmedSpecRef := strings.TrimSpace(specRef)
+				trimmedSpecPath := strings.TrimSpace(specPath)
 				req := analysis.AnalyzeImpactRequest{
 					ChangeType: strings.TrimSpace(changeType),
 					Summary:    summary,
-					SpecRef:    strings.TrimSpace(specRef),
+					SpecRef:    trimmedSpecRef,
 				}
-				if trimmedPath := strings.TrimSpace(specPath); trimmedPath != "" {
-					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
+				if trimmedSpecRef != "" && trimmedSpecPath != "" {
+					return req, fmt.Errorf("exactly one of --path or --spec-ref is allowed")
+				}
+				if trimmedSpecPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
 					if err != nil {
 						return req, specPathResolutionError(err)
 					}
@@ -81,9 +86,9 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 				op := app.AnalyzeImpact(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},
-			PostProcess: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest, res *analysis.AnalyzeImpactResult) (*analysis.AnalyzeImpactResult, *cliIssue) {
+			PostProcess: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest, res *analysis.AnalyzeImpactResult) (*analysis.AnalyzeImpactResult, *cliIssue, int) {
 				annotateCrossFamilyImpact(ctx, cfgPath, req.SpecRef, res)
-				return res, nil
+				return res, nil, 0
 			},
 		},
 	)

--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -18,121 +18,75 @@ func runAnalyzeImpact(args []string, stdout, stderr io.Writer) int {
 }
 
 func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("analyze-impact", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("analyze-impact", "pituitary [--config PATH] analyze-impact (--path PATH | --spec-ref REF | --request-file PATH|-) [--change-type TYPE] [--summary] [--format FORMAT]")
-
 	var (
-		specRef     string
-		specPath    string
-		requestFile string
-		changeType  string
-		summary     bool
-		format      string
-		configPath  string
-		atDate      string
+		specRef    string
+		specPath   string
+		changeType string
+		summary    bool
+		atDate     string
 	)
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
-	fs.StringVar(&requestFile, "request-file", "", "path to impact request JSON, or - for stdin")
-	fs.StringVar(&changeType, "change-type", "accepted", "change type: accepted, modified, or deprecated")
-	fs.BoolVar(&summary, "summary", false, "emit a concise ranked summary in text output and include summary metadata in JSON")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := analysis.AnalyzeImpactRequest{
-		ChangeType: strings.TrimSpace(changeType),
-		Summary:    summary,
-	}
-	if err := validateCLIFormat("analyze-impact", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedSpecRef := strings.TrimSpace(specRef)
-	trimmedSpecPath := strings.TrimSpace(specPath)
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRequestFile) > 1 {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --path, --spec-ref, or --request-file is allowed",
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	if trimmedSpecPath != "" {
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		trimmedSpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "analyze-impact", request, err)
-		}
-	}
-	switch {
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.AnalyzeImpactRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	default:
-		request.SpecRef = trimmedSpecRef
-		if request.SpecRef == "" {
-			return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-				Code:    "validation_error",
-				Message: "one of --path, --spec-ref, or --request-file is required",
-			}, 2)
-		}
-	}
-
-	if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
-		request.AtDate = trimmedAt
-	}
-	operation := app.AnalyzeImpact(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	// Annotate cross-family impact.
-	annotateCrossFamilyImpact(ctx, resolvedConfigPath, request.SpecRef, operation.Result)
-
-	return writeCLISuccess(stdout, stderr, format, "analyze-impact", operation.Request, operation.Result, nil)
+	return runCommand[analysis.AnalyzeImpactRequest, analysis.AnalyzeImpactResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.AnalyzeImpactRequest, analysis.AnalyzeImpactResult]{
+			Name:  "analyze-impact",
+			Usage: "pituitary [--config PATH] analyze-impact (--path PATH | --spec-ref REF | --request-file PATH|-) [--change-type TYPE] [--summary] [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
+				fs.StringVar(&changeType, "change-type", "accepted", "change type: accepted, modified, or deprecated")
+				fs.BoolVar(&summary, "summary", false, "emit a concise ranked summary in text output and include summary metadata in JSON")
+				fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return strings.TrimSpace(specRef) != "" || strings.TrimSpace(specPath) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.AnalyzeImpactRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.AnalyzeImpactRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.AnalyzeImpactRequest, error) {
+				req := analysis.AnalyzeImpactRequest{
+					ChangeType: strings.TrimSpace(changeType),
+					Summary:    summary,
+					SpecRef:    strings.TrimSpace(specRef),
+				}
+				if trimmedPath := strings.TrimSpace(specPath); trimmedPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
+					if err != nil {
+						return req, specPathResolutionError(err)
+					}
+					req.SpecRef = resolved
+				}
+				if req.SpecRef == "" {
+					return req, fmt.Errorf("one of --path, --spec-ref, or --request-file is required")
+				}
+				return req, nil
+			},
+			Normalize: func(_ context.Context, req analysis.AnalyzeImpactRequest) (analysis.AnalyzeImpactRequest, error) {
+				if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
+					req.AtDate = trimmedAt
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest) (analysis.AnalyzeImpactRequest, *analysis.AnalyzeImpactResult, *app.Issue) {
+				op := app.AnalyzeImpact(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+			PostProcess: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest, res *analysis.AnalyzeImpactResult) (*analysis.AnalyzeImpactResult, *cliIssue) {
+				annotateCrossFamilyImpact(ctx, cfgPath, req.SpecRef, res)
+				return res, nil
+			},
+		},
+	)
 }
 
 func annotateCrossFamilyImpact(ctx context.Context, configPath string, sourceRef string, result *analysis.AnalyzeImpactResult) {

--- a/cmd/check_doc_drift.go
+++ b/cmd/check_doc_drift.go
@@ -28,134 +28,77 @@ func runCheckDocDrift(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-doc-drift", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-doc-drift", "pituitary [--config PATH] check-doc-drift ([--doc-ref REF | --path PATH]... | [--scope all] | [--diff-file PATH|-]) [--request-file PATH|-] [--format FORMAT] [--timings]")
-
 	var (
-		docRefs     docRefList
-		docPaths    docRefList
-		scope       string
-		diffFile    string
-		requestFile string
-		format      string
-		configPath  string
-		atDate      string
-		timings     bool
+		docRefs       docRefList
+		docPaths      docRefList
+		scope         string
+		diffFile      string
+		atDate        string
+		minConfidence string
 	)
-	fs.Var(&docRefs, "doc-ref", "target doc ref; repeat to supply doc_refs")
-	fs.Var(&docPaths, "path", "workspace-relative or absolute path to an indexed doc; repeat to supply paths")
-	fs.StringVar(&scope, "scope", "", "scope selector; only \"all\" is valid")
-	fs.StringVar(&diffFile, "diff-file", "", "path to a unified diff file, or - for stdin")
-	fs.StringVar(&requestFile, "request-file", "", "path to doc drift request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
-	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
-	var minConfidence string
-	fs.StringVar(&minConfidence, "min-confidence", "", "minimum confidence tier: extracted, inferred, or ambiguous")
-
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("check-doc-drift", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-
-	var request analysis.DocDriftRequest
-	switch {
-	case trimmedRequestFile != "" && (len(docRefs) > 0 || len(docPaths) > 0 || strings.TrimSpace(scope) != "" || strings.TrimSpace(diffFile) != ""):
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or the doc-ref/path/scope/diff-file flags",
-		}, 2)
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.DocDriftRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		if request.DiffText == "" && strings.TrimSpace(request.DiffFile) != "" {
-			request.DiffText, err = loadComplianceDiffFile(cfg.Workspace.RootPath, request.DiffFile)
-			if err != nil {
-				return writeCLIError(stdout, stderr, format, "check-doc-drift", request, cliIssue{
-					Code:    "validation_error",
-					Message: err.Error(),
-				}, 2)
-			}
-		}
-	default:
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		resolvedDocRefs := append([]string(nil), docRefs...)
-		if len(docPaths) > 0 {
-			resolvedPaths, err := resolveIndexedDocRefsWithConfigContext(ctx, cfg, []string(docPaths))
-			if err != nil {
-				return writeDocPathResolutionError(stdout, stderr, format, "check-doc-drift", nil, err)
-			}
-			resolvedDocRefs = append(resolvedDocRefs, resolvedPaths...)
-		}
-		request, err = docDriftRequestFromFlags(cfg.Workspace.RootPath, resolvedDocRefs, strings.TrimSpace(scope), strings.TrimSpace(diffFile))
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-doc-drift", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-
-	if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
-		request.AtDate = trimmedAt
-	}
-	if trimmedConf := strings.TrimSpace(minConfidence); trimmedConf != "" {
-		request.MinConfidence = trimmedConf
-	}
-	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
-
-	operation := app.CheckDocDrift(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-doc-drift", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccessWithTimings(stdout, stderr, format, "check-doc-drift", operation.Request, operation.Result, nil, snapshotCommandTimings(tracker, started))
+	return runCommand[analysis.DocDriftRequest, analysis.DocDriftResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.DocDriftRequest, analysis.DocDriftResult]{
+			Name:  "check-doc-drift",
+			Usage: "pituitary [--config PATH] check-doc-drift ([--doc-ref REF | --path PATH]... | [--scope all] | [--diff-file PATH|-]) [--request-file PATH|-] [--format FORMAT] [--timings]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				Timings:        true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.Var(&docRefs, "doc-ref", "target doc ref; repeat to supply doc_refs")
+				fs.Var(&docPaths, "path", "workspace-relative or absolute path to an indexed doc; repeat to supply paths")
+				fs.StringVar(&scope, "scope", "", "scope selector; only \"all\" is valid")
+				fs.StringVar(&diffFile, "diff-file", "", "path to a unified diff file, or - for stdin")
+				fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
+				fs.StringVar(&minConfidence, "min-confidence", "", "minimum confidence tier: extracted, inferred, or ambiguous")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return len(docRefs) > 0 || len(docPaths) > 0 || strings.TrimSpace(scope) != "" || strings.TrimSpace(diffFile) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.DocDriftRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.DocDriftRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				if req.DiffText == "" && strings.TrimSpace(req.DiffFile) != "" {
+					diffText, diffErr := loadComplianceDiffFile(cfg.Workspace.RootPath, req.DiffFile)
+					if diffErr != nil {
+						return &req, diffErr
+					}
+					req.DiffText = diffText
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.DocDriftRequest, error) {
+				resolvedDocRefs := append([]string(nil), docRefs...)
+				if len(docPaths) > 0 {
+					resolvedPaths, err := resolveIndexedDocRefsWithConfigContext(ctx, cfg, []string(docPaths))
+					if err != nil {
+						return analysis.DocDriftRequest{}, docPathResolutionError(err)
+					}
+					resolvedDocRefs = append(resolvedDocRefs, resolvedPaths...)
+				}
+				return docDriftRequestFromFlags(cfg.Workspace.RootPath, resolvedDocRefs, strings.TrimSpace(scope), strings.TrimSpace(diffFile))
+			},
+			Normalize: func(_ context.Context, req analysis.DocDriftRequest) (analysis.DocDriftRequest, error) {
+				if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
+					req.AtDate = trimmedAt
+				}
+				if trimmedConf := strings.TrimSpace(minConfidence); trimmedConf != "" {
+					req.MinConfidence = trimmedConf
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.DocDriftRequest) (analysis.DocDriftRequest, *analysis.DocDriftResult, *app.Issue) {
+				op := app.CheckDocDrift(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func docDriftRequestFromFlags(workspaceRoot string, docRefs []string, scope, diffFile string) (analysis.DocDriftRequest, error) {

--- a/cmd/check_overlap.go
+++ b/cmd/check_overlap.go
@@ -22,111 +22,61 @@ func runCheckOverlap(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-overlap", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-overlap", "pituitary [--config PATH] check-overlap (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]")
-
 	var (
 		specRef        string
 		specPath       string
 		specRecordFile string
-		requestFile    string
-		format         string
-		configPath     string
 	)
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
-	fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
-	fs.StringVar(&requestFile, "request-file", "", "path to overlap request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("check-overlap", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedSpecRef := strings.TrimSpace(specRef)
-	trimmedSpecPath := strings.TrimSpace(specPath)
-	trimmedSpecRecordFile := strings.TrimSpace(specRecordFile)
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedSpecRecordFile, trimmedRequestFile) > 1 {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed",
-		}, 2)
-	}
-	var cfg *config.Config
-	if trimmedSpecPath != "" || trimmedSpecRecordFile != "" || trimmedRequestFile != "" {
-		cfg, err = config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-	if trimmedRequestFile != "" {
-		request, err := loadWorkspaceScopedJSONFile[analysis.OverlapRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		operation := app.CheckOverlap(ctx, resolvedConfigPath, request)
-		if operation.Issue != nil {
-			return writeCLIError(stdout, stderr, format, "check-overlap", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-		}
-		return writeCLISuccess(stdout, stderr, format, "check-overlap", operation.Request, operation.Result, nil)
-	}
-	if trimmedSpecPath != "" {
-		trimmedSpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "check-overlap", nil, err)
-		}
-	}
-	workspaceRoot := ""
-	if cfg != nil {
-		workspaceRoot = cfg.Workspace.RootPath
-	}
-	request, err := overlapRequestFromFlagsContext(workspaceRoot, trimmedSpecRef, trimmedSpecRecordFile)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	operation := app.CheckOverlap(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "check-overlap", operation.Request, operation.Result, nil)
+	return runCommand[analysis.OverlapRequest, analysis.OverlapResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.OverlapRequest, analysis.OverlapResult]{
+			Name:  "check-overlap",
+			Usage: "pituitary [--config PATH] check-overlap (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
+				fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return strings.TrimSpace(specRef) != "" ||
+					strings.TrimSpace(specPath) != "" ||
+					strings.TrimSpace(specRecordFile) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.OverlapRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.OverlapRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.OverlapRequest, error) {
+				trimmedSpecRef := strings.TrimSpace(specRef)
+				trimmedSpecPath := strings.TrimSpace(specPath)
+				trimmedRecord := strings.TrimSpace(specRecordFile)
+				if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRecord) > 1 {
+					return analysis.OverlapRequest{}, fmt.Errorf("exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed")
+				}
+				if trimmedSpecPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
+					if err != nil {
+						return analysis.OverlapRequest{}, specPathResolutionError(err)
+					}
+					trimmedSpecRef = resolved
+				}
+				return overlapRequestFromFlagsContext(cfg.Workspace.RootPath, trimmedSpecRef, trimmedRecord)
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.OverlapRequest) (analysis.OverlapRequest, *analysis.OverlapResult, *app.Issue) {
+				op := app.CheckOverlap(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func overlapRequestFromFlagsContext(workspaceRoot, specRef, specRecordFile string) (analysis.OverlapRequest, error) {

--- a/cmd/check_spec_freshness.go
+++ b/cmd/check_spec_freshness.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"strings"
 
@@ -50,7 +51,11 @@ func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, st
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.FreshnessRequest, error) {
 				req := analysis.FreshnessRequest{Scope: strings.TrimSpace(scope)}
 				resolvedSpecRef := strings.TrimSpace(specRef)
-				if trimmedPath := strings.TrimSpace(specPath); trimmedPath != "" {
+				trimmedPath := strings.TrimSpace(specPath)
+				if resolvedSpecRef != "" && trimmedPath != "" {
+					return req, fmt.Errorf("exactly one of --path or --spec-ref is allowed")
+				}
+				if trimmedPath != "" {
 					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
 					if err != nil {
 						return req, specPathResolutionError(err)

--- a/cmd/check_spec_freshness.go
+++ b/cmd/check_spec_freshness.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"flag"
-	"fmt"
 	"io"
 	"strings"
 
@@ -17,109 +16,57 @@ func runCheckSpecFreshness(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-spec-freshness", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-spec-freshness", "pituitary [--config PATH] check-spec-freshness [--spec-ref REF | --path PATH | --scope all | --request-file PATH|-] [--format FORMAT]")
-
 	var (
-		specRef     string
-		specPath    string
-		requestFile string
-		scope       string
-		format      string
-		configPath  string
+		specRef  string
+		specPath string
+		scope    string
 	)
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
-	fs.StringVar(&requestFile, "request-file", "", "path to request JSON, or - for stdin")
-	fs.StringVar(&scope, "scope", "all", "scope: all (default)")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := analysis.FreshnessRequest{
-		Scope: strings.TrimSpace(scope),
-	}
-	if err := validateCLIFormat("check-spec-freshness", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	trimmedSpecRef := strings.TrimSpace(specRef)
-	trimmedSpecPath := strings.TrimSpace(specPath)
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRequestFile) > 1 {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-			Code:    "validation_error",
-			Message: "at most one of --path, --spec-ref, or --request-file is allowed",
-		}, 2)
-	}
-
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	if trimmedSpecPath != "" {
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		trimmedSpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "check-spec-freshness", request, err)
-		}
-	}
-
-	switch {
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.FreshnessRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	case trimmedSpecRef != "":
-		request.SpecRef = trimmedSpecRef
-		request.Scope = ""
-	default:
-		// scope=all is the default
-	}
-
-	operation := app.CheckSpecFreshness(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "check-spec-freshness", operation.Request, operation.Result, nil)
+	return runCommand[analysis.FreshnessRequest, analysis.FreshnessResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.FreshnessRequest, analysis.FreshnessResult]{
+			Name:  "check-spec-freshness",
+			Usage: "pituitary [--config PATH] check-spec-freshness [--spec-ref REF | --path PATH | --scope all | --request-file PATH|-] [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
+				fs.StringVar(&scope, "scope", "all", "scope: all (default)")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return strings.TrimSpace(specRef) != "" || strings.TrimSpace(specPath) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.FreshnessRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.FreshnessRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.FreshnessRequest, error) {
+				req := analysis.FreshnessRequest{Scope: strings.TrimSpace(scope)}
+				resolvedSpecRef := strings.TrimSpace(specRef)
+				if trimmedPath := strings.TrimSpace(specPath); trimmedPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
+					if err != nil {
+						return req, specPathResolutionError(err)
+					}
+					resolvedSpecRef = resolved
+				}
+				if resolvedSpecRef != "" {
+					req.SpecRef = resolvedSpecRef
+					req.Scope = ""
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.FreshnessRequest) (analysis.FreshnessRequest, *analysis.FreshnessResult, *app.Issue) {
+				op := app.CheckSpecFreshness(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }

--- a/cmd/check_terminology.go
+++ b/cmd/check_terminology.go
@@ -28,118 +28,72 @@ func runCheckTerminology(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-terminology", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-terminology", "pituitary [--config PATH] check-terminology ([--term TERM]... [--canonical-term TERM]... [--spec-ref REF | --path PATH] [--scope SCOPE] | --request-file PATH|-) [--format FORMAT] [--timings]")
-
 	var (
 		terms          stringList
 		canonicalTerms stringList
 		specRef        string
 		specPath       string
 		scope          string
-		requestFile    string
-		format         string
-		configPath     string
-		timings        bool
 	)
-	fs.Var(&terms, "term", "displaced or governed term to audit; repeat to narrow a configured policy set or supply ad hoc terms")
-	fs.Var(&canonicalTerms, "canonical-term", "replacement or canonical term; repeat to supply multiple terms")
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref used to anchor the audit")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec used to anchor the audit")
-	fs.StringVar(&scope, "scope", "all", "artifact scope: all, docs, or specs")
-	fs.StringVar(&requestFile, "request-file", "", "path to terminology audit request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-terminology", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := analysis.TerminologyAuditRequest{
-		Terms:          []string(terms),
-		CanonicalTerms: []string(canonicalTerms),
-		SpecRef:        strings.TrimSpace(specRef),
-		Scope:          strings.TrimSpace(scope),
-	}
-	if err := validateCLIFormat("check-terminology", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if trimmedRequestFile != "" && (countNonEmptyStrings(request.Terms) > 0 || countNonEmptyStrings(request.CanonicalTerms) > 0 || request.SpecRef != "" || strings.TrimSpace(specPath) != "" || flagWasSet(fs, "scope")) {
-		return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or the terminology flags",
-		}, 2)
-	}
-	if trimmedRequestFile != "" {
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.TerminologyAuditRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-	trimmedPath := strings.TrimSpace(specPath)
-	if trimmedRequestFile == "" && request.SpecRef != "" && trimmedPath != "" {
-		return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --spec-ref or --path is allowed",
-		}, 2)
-	}
-	if trimmedRequestFile == "" && trimmedPath != "" {
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request.SpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "check-terminology", request, err)
-		}
-	}
-
-	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
-
-	operation := app.CheckTerminology(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccessWithTimings(stdout, stderr, format, "check-terminology", operation.Request, operation.Result, nil, snapshotCommandTimings(tracker, started))
+	return runCommand[analysis.TerminologyAuditRequest, analysis.TerminologyAuditResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.TerminologyAuditRequest, analysis.TerminologyAuditResult]{
+			Name:  "check-terminology",
+			Usage: "pituitary [--config PATH] check-terminology ([--term TERM]... [--canonical-term TERM]... [--spec-ref REF | --path PATH] [--scope SCOPE] | --request-file PATH|-) [--format FORMAT] [--timings]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				Timings:        true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.Var(&terms, "term", "displaced or governed term to audit; repeat to narrow a configured policy set or supply ad hoc terms")
+				fs.Var(&canonicalTerms, "canonical-term", "replacement or canonical term; repeat to supply multiple terms")
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref used to anchor the audit")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec used to anchor the audit")
+				fs.StringVar(&scope, "scope", "all", "artifact scope: all, docs, or specs")
+			},
+			InlineFlagsSet: func(fs *flag.FlagSet) bool {
+				return countNonEmptyStrings(terms) > 0 ||
+					countNonEmptyStrings(canonicalTerms) > 0 ||
+					strings.TrimSpace(specRef) != "" ||
+					strings.TrimSpace(specPath) != "" ||
+					flagWasSet(fs, "scope")
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.TerminologyAuditRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.TerminologyAuditRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.TerminologyAuditRequest, error) {
+				req := analysis.TerminologyAuditRequest{
+					Terms:          []string(terms),
+					CanonicalTerms: []string(canonicalTerms),
+					SpecRef:        strings.TrimSpace(specRef),
+					Scope:          strings.TrimSpace(scope),
+				}
+				trimmedPath := strings.TrimSpace(specPath)
+				if req.SpecRef != "" && trimmedPath != "" {
+					return req, fmt.Errorf("exactly one of --spec-ref or --path is allowed")
+				}
+				if trimmedPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
+					if err != nil {
+						return req, specPathResolutionError(err)
+					}
+					req.SpecRef = resolved
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.TerminologyAuditRequest) (analysis.TerminologyAuditRequest, *analysis.TerminologyAuditResult, *app.Issue) {
+				op := app.CheckTerminology(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func countNonEmptyStrings(values []string) int {

--- a/cmd/compare_specs.go
+++ b/cmd/compare_specs.go
@@ -28,113 +28,64 @@ func runCompareSpecs(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCompareSpecsContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("compare-specs", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("compare-specs", "pituitary [--config PATH] compare-specs (--spec-ref REF --spec-ref REF | --path PATH --path PATH | --request-file PATH|-) [--format FORMAT]")
-
 	var (
-		specRefs    compareSpecRefs
-		specPaths   compareSpecRefs
-		requestFile string
-		format      string
-		configPath  string
+		specRefs  compareSpecRefs
+		specPaths compareSpecRefs
 	)
-	fs.Var(&specRefs, "spec-ref", "indexed spec ref; pass exactly two to compare")
-	fs.Var(&specPaths, "path", "workspace-relative or absolute path to an indexed spec; pass exactly two to compare")
-	fs.StringVar(&requestFile, "request-file", "", "path to compare request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "compare-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := analysis.CompareRequest{}
-	if err := validateCLIFormat("compare-specs", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	switch {
-	case trimmedRequestFile != "" && (len(specRefs) > 0 || len(specPaths) > 0):
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or the path/spec-ref flags",
-		}, 2)
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.CompareRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	case len(specRefs) > 0 && len(specPaths) > 0:
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "use either two --spec-ref flags or two --path flags",
-		}, 2)
-	case len(specRefs) == 2:
-		request.SpecRefs = []string(specRefs)
-	case len(specPaths) == 2:
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request.SpecRefs, err = resolveIndexedSpecRefsWithConfigContext(ctx, cfg, []string(specPaths))
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "compare-specs", request, err)
-		}
-	default:
-		request.SpecRefs = []string(specRefs)
-	}
-	switch {
-	case request.SpecRecord == nil && len(request.SpecRefs) != 2:
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly two --spec-ref flags or two --path flags are required",
-		}, 2)
-	case request.SpecRecord != nil && len(request.SpecRefs) != 1:
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "request files with spec_record require exactly one indexed spec_ref",
-		}, 2)
-	}
-
-	operation := app.CompareSpecs(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "compare-specs", operation.Request, operation.Result, nil)
+	return runCommand[analysis.CompareRequest, analysis.CompareResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.CompareRequest, analysis.CompareResult]{
+			Name:  "compare-specs",
+			Usage: "pituitary [--config PATH] compare-specs (--spec-ref REF --spec-ref REF | --path PATH --path PATH | --request-file PATH|-) [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.Var(&specRefs, "spec-ref", "indexed spec ref; pass exactly two to compare")
+				fs.Var(&specPaths, "path", "workspace-relative or absolute path to an indexed spec; pass exactly two to compare")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return len(specRefs) > 0 || len(specPaths) > 0
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.CompareRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.CompareRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.CompareRequest, error) {
+				req := analysis.CompareRequest{}
+				switch {
+				case len(specRefs) > 0 && len(specPaths) > 0:
+					return req, fmt.Errorf("use either two --spec-ref flags or two --path flags")
+				case len(specRefs) > 0:
+					req.SpecRefs = []string(specRefs)
+				case len(specPaths) > 0:
+					resolved, err := resolveIndexedSpecRefsWithConfigContext(ctx, cfg, []string(specPaths))
+					if err != nil {
+						return req, specPathResolutionError(err)
+					}
+					req.SpecRefs = resolved
+				}
+				return req, nil
+			},
+			Normalize: func(_ context.Context, req analysis.CompareRequest) (analysis.CompareRequest, error) {
+				switch {
+				case req.SpecRecord == nil && len(req.SpecRefs) != 2:
+					return req, fmt.Errorf("exactly two --spec-ref flags or two --path flags are required")
+				case req.SpecRecord != nil && len(req.SpecRefs) != 1:
+					return req, fmt.Errorf("request files with spec_record require exactly one indexed spec_ref")
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.CompareRequest) (analysis.CompareRequest, *analysis.CompareResult, *app.Issue) {
+				op := app.CompareSpecs(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }

--- a/cmd/doc_path.go
+++ b/cmd/doc_path.go
@@ -17,6 +17,13 @@ func resolveIndexedDocRefsWithConfigContext(ctx context.Context, cfg *config.Con
 }
 
 func writeDocPathResolutionError(stdout, stderr io.Writer, format, command string, request any, err error) int {
+	issue := docPathResolutionIssue(err)
+	return writeCLIError(stdout, stderr, format, command, request, issue, 2)
+}
+
+// docPathResolutionIssue classifies a doc-path resolution error into the
+// cliIssue code previously emitted by writeDocPathResolutionError.
+func docPathResolutionIssue(err error) cliIssue {
 	code := "validation_error"
 	switch {
 	case index.IsMissingIndex(err):
@@ -24,8 +31,11 @@ func writeDocPathResolutionError(stdout, stderr io.Writer, format, command strin
 	case index.IsDocPathNotFound(err):
 		code = "not_found"
 	}
-	return writeCLIError(stdout, stderr, format, command, request, cliIssue{
-		Code:    code,
-		Message: err.Error(),
-	}, 2)
+	return cliIssue{Code: code, Message: err.Error()}
+}
+
+// docPathResolutionError wraps a doc-path resolution error in a cliIssueError
+// so runCommand's BuildRequest callback can surface the classified code.
+func docPathResolutionError(err error) error {
+	return &cliIssueError{issue: docPathResolutionIssue(err), exitCode: 2}
 }

--- a/cmd/review_spec.go
+++ b/cmd/review_spec.go
@@ -17,111 +17,61 @@ func runReviewSpec(args []string, stdout, stderr io.Writer) int {
 }
 
 func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("review-spec", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("review-spec", "pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]")
-
 	var (
 		specRef        string
 		specPath       string
 		specRecordFile string
-		requestFile    string
-		format         string
-		configPath     string
 	)
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
-	fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
-	fs.StringVar(&requestFile, "request-file", "", "path to review request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("review-spec", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedSpecRef := strings.TrimSpace(specRef)
-	trimmedSpecPath := strings.TrimSpace(specPath)
-	trimmedSpecRecordFile := strings.TrimSpace(specRecordFile)
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedSpecRecordFile, trimmedRequestFile) > 1 {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed",
-		}, 2)
-	}
-	var cfg *config.Config
-	if trimmedSpecPath != "" || trimmedSpecRecordFile != "" || trimmedRequestFile != "" {
-		cfg, err = config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-	if trimmedRequestFile != "" {
-		request, err := loadWorkspaceScopedJSONFile[analysis.ReviewRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		operation := app.ReviewSpec(ctx, resolvedConfigPath, request)
-		if operation.Issue != nil {
-			return writeCLIError(stdout, stderr, format, "review-spec", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-		}
-		return writeCLISuccess(stdout, stderr, format, "review-spec", operation.Request, operation.Result, nil)
-	}
-	if trimmedSpecPath != "" {
-		trimmedSpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "review-spec", nil, err)
-		}
-	}
-	workspaceRoot := ""
-	if cfg != nil {
-		workspaceRoot = cfg.Workspace.RootPath
-	}
-	request, err := reviewRequestFromFlags(workspaceRoot, trimmedSpecRef, trimmedSpecRecordFile)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	operation := app.ReviewSpec(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "review-spec", operation.Request, operation.Result, nil)
+	return runCommand[analysis.ReviewRequest, analysis.ReviewResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.ReviewRequest, analysis.ReviewResult]{
+			Name:  "review-spec",
+			Usage: "pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
+				fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return strings.TrimSpace(specRef) != "" ||
+					strings.TrimSpace(specPath) != "" ||
+					strings.TrimSpace(specRecordFile) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.ReviewRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.ReviewRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.ReviewRequest, error) {
+				trimmedSpecRef := strings.TrimSpace(specRef)
+				trimmedSpecPath := strings.TrimSpace(specPath)
+				trimmedRecord := strings.TrimSpace(specRecordFile)
+				if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRecord) > 1 {
+					return analysis.ReviewRequest{}, fmt.Errorf("exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed")
+				}
+				if trimmedSpecPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
+					if err != nil {
+						return analysis.ReviewRequest{}, specPathResolutionError(err)
+					}
+					trimmedSpecRef = resolved
+				}
+				return reviewRequestFromFlags(cfg.Workspace.RootPath, trimmedSpecRef, trimmedRecord)
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.ReviewRequest) (analysis.ReviewRequest, *analysis.ReviewResult, *app.Issue) {
+				op := app.ReviewSpec(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func reviewRequestFromFlags(workspaceRoot, specRef, specRecordFile string) (analysis.ReviewRequest, error) {

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -46,7 +46,8 @@ type commandRun[Req any, Res any] struct {
 	// iff Options.ConfigForFlags is true. Required.
 	BuildRequest func(ctx context.Context, cfg *config.Config, resolvedConfigPath string) (Req, error)
 
-	// Normalize (optional) runs after the request is composed, before Execute.
+	// Normalize (optional) runs after the request is composed, before Execute,
+	// and fires for both the --request-file path and the inline-flags path.
 	// On error, the runner writes the returned Req into the envelope, so
 	// Normalize can return a pre- or post-normalize request as appropriate.
 	Normalize func(ctx context.Context, req Req) (Req, error)
@@ -54,8 +55,11 @@ type commandRun[Req any, Res any] struct {
 	// Execute calls the app layer. Required.
 	Execute func(ctx context.Context, resolvedConfigPath string, req Req) (Req, *Res, *app.Issue)
 
-	// PostProcess (optional) runs after Execute succeeds.
-	PostProcess func(ctx context.Context, resolvedConfigPath string, req Req, res *Res) (*Res, *cliIssue)
+	// PostProcess (optional) runs after Execute succeeds. When it returns a
+	// non-nil cliIssue, the runner writes it with the returned exit code. An
+	// exit code of 0 is treated as the default 2 so the common "validation
+	// error" case stays terse at the call site.
+	PostProcess func(ctx context.Context, resolvedConfigPath string, req Req, res *Res) (*Res, *cliIssue, int)
 }
 
 // commandRunOptions toggles the shared flags and config-loading behavior the
@@ -84,9 +88,6 @@ type cliIssueError struct {
 }
 
 func (e *cliIssueError) Error() string {
-	if e == nil {
-		return ""
-	}
 	return e.issue.Message
 }
 
@@ -111,6 +112,15 @@ func runCommand[Req any, Res any](
 	stdout, stderr io.Writer,
 	plan commandRun[Req, Res],
 ) int {
+	if plan.BuildRequest == nil {
+		panic("commandRun.BuildRequest is required for " + plan.Name)
+	}
+	if plan.Execute == nil {
+		panic("commandRun.Execute is required for " + plan.Name)
+	}
+	if plan.Options.RequestFile && (plan.LoadRequestFile == nil || plan.InlineFlagsSet == nil) {
+		panic("commandRun.LoadRequestFile and InlineFlagsSet are required when RequestFile is enabled for " + plan.Name)
+	}
 	fs := flag.NewFlagSet(plan.Name, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	help := newCommandHelp(plan.Name, plan.Usage)
@@ -247,9 +257,12 @@ func runCommand[Req any, Res any](
 	}
 
 	if plan.PostProcess != nil {
-		postResult, postIssue := plan.PostProcess(execCtx, resolvedConfigPath, enrichedReq, result)
+		postResult, postIssue, postExit := plan.PostProcess(execCtx, resolvedConfigPath, enrichedReq, result)
 		if postIssue != nil {
-			return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, *postIssue, 2)
+			if postExit == 0 {
+				postExit = 2
+			}
+			return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, *postIssue, postExit)
 		}
 		result = postResult
 	}

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/app"
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+// commandRun describes a CLI command's lifecycle for runCommand. It collapses
+// the shared parse → validate → resolve-config → branch-on-request-file →
+// build-request → normalize → execute → post-process → write pipeline that
+// every command in this package reproduces.
+//
+// Type parameters: Req is the command's request DTO; Res is the result value
+// type held by app.Response (the runner receives *Res from the app layer and
+// passes it to the renderer as-is).
+type commandRun[Req any, Res any] struct {
+	Name  string
+	Usage string
+
+	Options commandRunOptions
+
+	// BindFlags registers command-specific flags on fs. The runner pre-registers
+	// --config, --format, optionally --timings and --request-file per Options.
+	BindFlags func(fs *flag.FlagSet)
+
+	// InlineFlagsSet reports whether any fine-grained inline flag is set, used
+	// to reject combinations with --request-file. Required when
+	// Options.RequestFile is true.
+	InlineFlagsSet func(fs *flag.FlagSet) bool
+
+	// LoadRequestFile parses the request JSON and may run follow-up reads. It
+	// returns a pointer to the parsed request: nil means no request should
+	// surface in the error envelope (e.g., JSON parse failure); non-nil means
+	// write the pointee into the envelope. Required when Options.RequestFile
+	// is true.
+	LoadRequestFile func(ctx context.Context, cfg *config.Config, trimmedPath string) (*Req, error)
+
+	// BuildRequest builds the request from the inline flags. cfg is non-nil
+	// iff Options.ConfigForFlags is true. Required.
+	BuildRequest func(ctx context.Context, cfg *config.Config, resolvedConfigPath string) (Req, error)
+
+	// Normalize (optional) runs after the request is composed, before Execute.
+	// On error, the runner writes the returned Req into the envelope, so
+	// Normalize can return a pre- or post-normalize request as appropriate.
+	Normalize func(ctx context.Context, req Req) (Req, error)
+
+	// Execute calls the app layer. Required.
+	Execute func(ctx context.Context, resolvedConfigPath string, req Req) (Req, *Res, *app.Issue)
+
+	// PostProcess (optional) runs after Execute succeeds.
+	PostProcess func(ctx context.Context, resolvedConfigPath string, req Req, res *Res) (*Res, *cliIssue)
+}
+
+// commandRunOptions toggles the shared flags and config-loading behavior the
+// runner itself controls.
+type commandRunOptions struct {
+	// RequestFile enables the --request-file flag and the mutual-exclusion
+	// branch. Requires LoadRequestFile and InlineFlagsSet.
+	RequestFile bool
+	// Timings enables the --timings flag (JSON-only timing metadata).
+	Timings bool
+	// AcceptsPositional, when false (default), rejects fs.NArg() != 0.
+	AcceptsPositional bool
+	// ConfigForFlags loads config before calling BuildRequest.
+	ConfigForFlags bool
+	// ConfigForFile loads config before calling LoadRequestFile.
+	ConfigForFile bool
+}
+
+// cliIssueError lets BuildRequest/LoadRequestFile/Normalize callbacks surface a
+// classified cliIssue (Code/Message/Details/ExitCode) through the standard
+// error channel. The runner unwraps it via errors.As and writes the embedded
+// issue directly, rather than defaulting to validation_error/exit 2.
+type cliIssueError struct {
+	issue    cliIssue
+	exitCode int
+}
+
+func (e *cliIssueError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.issue.Message
+}
+
+// asCliIssue unwraps a cliIssueError chain into its (issue, exitCode) pair.
+func asCliIssue(err error) (cliIssue, int, bool) {
+	var wrap *cliIssueError
+	if errors.As(err, &wrap) && wrap != nil {
+		exitCode := wrap.exitCode
+		if exitCode == 0 {
+			exitCode = 2
+		}
+		return wrap.issue, exitCode, true
+	}
+	return cliIssue{}, 0, false
+}
+
+// runCommand executes the described CLI command lifecycle and returns the
+// process exit code.
+func runCommand[Req any, Res any](
+	ctx context.Context,
+	args []string,
+	stdout, stderr io.Writer,
+	plan commandRun[Req, Res],
+) int {
+	fs := flag.NewFlagSet(plan.Name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	help := newCommandHelp(plan.Name, plan.Usage)
+
+	var (
+		configPath  string
+		format      string
+		timings     bool
+		requestFile string
+	)
+	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
+	fs.StringVar(&configPath, "config", "", "path to workspace config")
+	if plan.Options.Timings {
+		fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
+	}
+	if plan.Options.RequestFile {
+		fs.StringVar(&requestFile, "request-file", "", "path to request JSON, or - for stdin")
+	}
+	if plan.BindFlags != nil {
+		plan.BindFlags(fs)
+	}
+
+	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	} else if handled {
+		return 0
+	}
+
+	if !plan.Options.AcceptsPositional && fs.NArg() != 0 {
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "validation_error",
+			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
+		}, 2)
+	}
+
+	if err := validateCLIFormat(plan.Name, format); err != nil {
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "validation_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	if err != nil {
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "config_error",
+			Message: err.Error(),
+		}, 2)
+	}
+
+	trimmedRequestFile := strings.TrimSpace(requestFile)
+	var request Req
+	switch {
+	case plan.Options.RequestFile && trimmedRequestFile != "" && plan.InlineFlagsSet != nil && plan.InlineFlagsSet(fs):
+		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+			Code:    "validation_error",
+			Message: "use either --request-file or the fine-grained flags",
+		}, 2)
+	case plan.Options.RequestFile && trimmedRequestFile != "":
+		var cfg *config.Config
+		if plan.Options.ConfigForFile {
+			loaded, cfgErr := config.Load(resolvedConfigPath)
+			if cfgErr != nil {
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+					Code:    "config_error",
+					Message: cfgErr.Error(),
+				}, 2)
+			}
+			cfg = loaded
+		}
+		loaded, loadErr := plan.LoadRequestFile(ctx, cfg, trimmedRequestFile)
+		if loadErr != nil {
+			var envelopeReq any
+			if loaded != nil {
+				envelopeReq = *loaded
+			}
+			if issue, exitCode, ok := asCliIssue(loadErr); ok {
+				return writeCLIError(stdout, stderr, format, plan.Name, envelopeReq, issue, exitCode)
+			}
+			return writeCLIError(stdout, stderr, format, plan.Name, envelopeReq, cliIssue{
+				Code:    "validation_error",
+				Message: loadErr.Error(),
+			}, 2)
+		}
+		if loaded != nil {
+			request = *loaded
+		}
+	default:
+		var cfg *config.Config
+		if plan.Options.ConfigForFlags {
+			loaded, cfgErr := config.Load(resolvedConfigPath)
+			if cfgErr != nil {
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+					Code:    "config_error",
+					Message: cfgErr.Error(),
+				}, 2)
+			}
+			cfg = loaded
+		}
+		request, err = plan.BuildRequest(ctx, cfg, resolvedConfigPath)
+		if err != nil {
+			if issue, exitCode, ok := asCliIssue(err); ok {
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, issue, exitCode)
+			}
+			return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+				Code:    "validation_error",
+				Message: err.Error(),
+			}, 2)
+		}
+	}
+
+	if plan.Normalize != nil {
+		normalized, normErr := plan.Normalize(ctx, request)
+		if normErr != nil {
+			if issue, exitCode, ok := asCliIssue(normErr); ok {
+				return writeCLIError(stdout, stderr, format, plan.Name, normalized, issue, exitCode)
+			}
+			return writeCLIError(stdout, stderr, format, plan.Name, normalized, cliIssue{
+				Code:    "validation_error",
+				Message: normErr.Error(),
+			}, 2)
+		}
+		request = normalized
+	}
+
+	execCtx, tracker, started := withCommandTimings(ctx, plan.Options.Timings && timings && format == commandFormatJSON)
+
+	enrichedReq, result, issue := plan.Execute(execCtx, resolvedConfigPath, request)
+	if issue != nil {
+		return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, cliIssueFromAppIssue(issue), issue.ExitCode)
+	}
+
+	if plan.PostProcess != nil {
+		postResult, postIssue := plan.PostProcess(execCtx, resolvedConfigPath, enrichedReq, result)
+		if postIssue != nil {
+			return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, *postIssue, 2)
+		}
+		result = postResult
+	}
+
+	return writeCLISuccessWithTimings(stdout, stderr, format, plan.Name, enrichedReq, result, nil, snapshotCommandTimings(tracker, started))
+}

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -91,23 +91,23 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 				op := app.SearchSpecs(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},
-			PostProcess: func(ctx context.Context, cfgPath string, _ index.SearchSpecRequest, res *index.SearchSpecResult) (*index.SearchSpecResult, *cliIssue) {
+			PostProcess: func(ctx context.Context, cfgPath string, _ index.SearchSpecRequest, res *index.SearchSpecResult) (*index.SearchSpecResult, *cliIssue, int) {
 				if familyID < 0 || res == nil {
-					return res, nil
+					return res, nil, 0
 				}
 				cfg, cfgErr := config.Load(cfgPath)
 				if cfgErr != nil {
 					return res, &cliIssue{
 						Code:    "config_error",
 						Message: fmt.Sprintf("failed to load config for --family filtering: %v", cfgErr),
-					}
+					}, 2
 				}
 				familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
 				if famErr != nil {
 					return res, &cliIssue{
 						Code:    "internal_error",
 						Message: fmt.Sprintf("failed to compute families for --family filtering: %v", famErr),
-					}
+					}, 2
 				}
 				familyMembers := make(map[string]bool)
 				for _, a := range familyResult.Assignments {
@@ -122,7 +122,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 					}
 				}
 				res.Matches = filtered
-				return res, nil
+				return res, nil, 0
 			},
 		},
 	)

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -28,145 +28,102 @@ func runSearchSpecs(args []string, stdout, stderr io.Writer) int {
 }
 
 func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("search-specs", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("search-specs", "pituitary [--config PATH] search-specs (--query TEXT | --request-file PATH|-) [--domain VALUE] [--status VALUE]... [--limit N] [--format FORMAT]")
-
 	var (
-		query       string
-		requestFile string
-		format      string
-		domain      string
-		configPath  string
-		statuses    searchSpecsFlagList
-		limit       int
-		familyID    int
+		query    string
+		domain   string
+		statuses searchSpecsFlagList
+		limit    int
+		familyID int
 	)
-	fs.StringVar(&query, "query", "", "semantic query")
-	fs.StringVar(&requestFile, "request-file", "", "path to search request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format (text, json, table)")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.StringVar(&domain, "domain", "", "filter by domain")
-	fs.Var(&statuses, "status", "filter by status; repeat to set multiple statuses")
-	fs.IntVar(&limit, "limit", 10, "maximum matches to return")
-	fs.IntVar(&familyID, "family", -1, "filter results to specs in the given family ID")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("search-specs", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	var request index.SearchSpecRequest
-	switch {
-	case trimmedRequestFile != "" && (strings.TrimSpace(query) != "" || strings.TrimSpace(domain) != "" || len(statuses) > 0 || flagWasSet(fs, "limit")):
-		return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or fine-grained search flags",
-		}, 2)
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[index.SearchSpecRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "search-specs", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	default:
-		request = index.SearchSpecRequest{
-			Query: strings.TrimSpace(query),
-			Filters: index.SearchSpecFilters{
-				Domain:   strings.TrimSpace(domain),
-				Statuses: []string(statuses),
+	return runCommand[index.SearchSpecRequest, index.SearchSpecResult](
+		ctx, args, stdout, stderr,
+		commandRun[index.SearchSpecRequest, index.SearchSpecResult]{
+			Name:  "search-specs",
+			Usage: "pituitary [--config PATH] search-specs (--query TEXT | --request-file PATH|-) [--domain VALUE] [--status VALUE]... [--limit N] [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:   true,
+				ConfigForFile: true,
 			},
-			Limit: &limit,
-		}
-	}
-	queryArgs, err := request.ToQuery()
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	request.Filters.Statuses = queryArgs.Statuses
-	request.Query = queryArgs.Query
-	request.Filters.Domain = queryArgs.Domain
-	requestLimit := queryArgs.Limit
-	request.Limit = &requestLimit
-	if request.Query == "" {
-		return writeCLIError(stdout, stderr, format, "search-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "query is required",
-		}, 2)
-	}
-
-	operation := app.SearchSpecs(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	// Post-filter by family if --family was specified.
-	if familyID >= 0 && operation.Result != nil {
-		cfg, cfgErr := config.Load(resolvedConfigPath)
-		if cfgErr != nil {
-			return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssue{
-				Code:    "config_error",
-				Message: fmt.Sprintf("failed to load config for --family filtering: %v", cfgErr),
-			}, 2)
-		}
-		familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
-		if famErr != nil {
-			return writeCLIError(stdout, stderr, format, "search-specs", operation.Request, cliIssue{
-				Code:    "internal_error",
-				Message: fmt.Sprintf("failed to compute families for --family filtering: %v", famErr),
-			}, 2)
-		}
-		familyMembers := make(map[string]bool)
-		for _, a := range familyResult.Assignments {
-			if a.FamilyID == familyID {
-				familyMembers[a.Ref] = true
-			}
-		}
-		var filtered []index.SearchSpecMatch
-		for _, m := range operation.Result.Matches {
-			if familyMembers[m.Ref] {
-				filtered = append(filtered, m)
-			}
-		}
-		operation.Result.Matches = filtered
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "search-specs", operation.Request, operation.Result, nil)
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&query, "query", "", "semantic query")
+				fs.StringVar(&domain, "domain", "", "filter by domain")
+				fs.Var(&statuses, "status", "filter by status; repeat to set multiple statuses")
+				fs.IntVar(&limit, "limit", 10, "maximum matches to return")
+				fs.IntVar(&familyID, "family", -1, "filter results to specs in the given family ID")
+			},
+			InlineFlagsSet: func(fs *flag.FlagSet) bool {
+				return strings.TrimSpace(query) != "" || strings.TrimSpace(domain) != "" || len(statuses) > 0 || flagWasSet(fs, "limit")
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*index.SearchSpecRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[index.SearchSpecRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(_ context.Context, _ *config.Config, _ string) (index.SearchSpecRequest, error) {
+				return index.SearchSpecRequest{
+					Query: strings.TrimSpace(query),
+					Filters: index.SearchSpecFilters{
+						Domain:   strings.TrimSpace(domain),
+						Statuses: []string(statuses),
+					},
+					Limit: &limit,
+				}, nil
+			},
+			Normalize: func(_ context.Context, req index.SearchSpecRequest) (index.SearchSpecRequest, error) {
+				queryArgs, err := req.ToQuery()
+				if err != nil {
+					return req, err
+				}
+				req.Filters.Statuses = queryArgs.Statuses
+				req.Query = queryArgs.Query
+				req.Filters.Domain = queryArgs.Domain
+				requestLimit := queryArgs.Limit
+				req.Limit = &requestLimit
+				if req.Query == "" {
+					return req, fmt.Errorf("query is required")
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req index.SearchSpecRequest) (index.SearchSpecRequest, *index.SearchSpecResult, *app.Issue) {
+				op := app.SearchSpecs(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+			PostProcess: func(ctx context.Context, cfgPath string, _ index.SearchSpecRequest, res *index.SearchSpecResult) (*index.SearchSpecResult, *cliIssue) {
+				if familyID < 0 || res == nil {
+					return res, nil
+				}
+				cfg, cfgErr := config.Load(cfgPath)
+				if cfgErr != nil {
+					return res, &cliIssue{
+						Code:    "config_error",
+						Message: fmt.Sprintf("failed to load config for --family filtering: %v", cfgErr),
+					}
+				}
+				familyResult, famErr := index.DiscoverFamiliesContext(ctx, cfg.Workspace.ResolvedIndexPath)
+				if famErr != nil {
+					return res, &cliIssue{
+						Code:    "internal_error",
+						Message: fmt.Sprintf("failed to compute families for --family filtering: %v", famErr),
+					}
+				}
+				familyMembers := make(map[string]bool)
+				for _, a := range familyResult.Assignments {
+					if a.FamilyID == familyID {
+						familyMembers[a.Ref] = true
+					}
+				}
+				var filtered []index.SearchSpecMatch
+				for _, m := range res.Matches {
+					if familyMembers[m.Ref] {
+						filtered = append(filtered, m)
+					}
+				}
+				res.Matches = filtered
+				return res, nil
+			},
+		},
+	)
 }

--- a/cmd/spec_path.go
+++ b/cmd/spec_path.go
@@ -18,6 +18,13 @@ func resolveIndexedSpecRefsWithConfigContext(ctx context.Context, cfg *config.Co
 }
 
 func writeSpecPathResolutionError(stdout, stderr io.Writer, format, command string, request any, err error) int {
+	issue := specPathResolutionIssue(err)
+	return writeCLIError(stdout, stderr, format, command, request, issue, 2)
+}
+
+// specPathResolutionIssue classifies a spec-path resolution error into the
+// cliIssue code previously emitted by writeSpecPathResolutionError.
+func specPathResolutionIssue(err error) cliIssue {
 	code := "validation_error"
 	switch {
 	case index.IsMissingIndex(err):
@@ -25,10 +32,14 @@ func writeSpecPathResolutionError(stdout, stderr io.Writer, format, command stri
 	case index.IsSpecPathNotFound(err):
 		code = "not_found"
 	}
-	return writeCLIError(stdout, stderr, format, command, request, cliIssue{
-		Code:    code,
-		Message: err.Error(),
-	}, 2)
+	return cliIssue{Code: code, Message: err.Error()}
+}
+
+// specPathResolutionError wraps a spec-path resolution error in a
+// cliIssueError so runCommand's BuildRequest callback can surface the
+// classified code through the standard error channel.
+func specPathResolutionError(err error) error {
+	return &cliIssueError{issue: specPathResolutionIssue(err), exitCode: 2}
 }
 
 func nonEmptyCount(values ...string) int {


### PR DESCRIPTION
## Summary

Third of a four-PR stack that collapses CLI command scaffolding onto the generic `runCommand[Req, Res]` helper landed in #325. This PR migrates three more commands:

- **check-spec-freshness** — `--spec-ref`/`--path`/`--request-file` mutex with a default `scope=all`. When an explicit spec is provided the scope field is cleared so app-layer semantics stay identical to the pre-refactor behavior.
- **check-overlap** — 4-way inline mutex (`--path`/`--spec-ref`/`--spec-record-file`/`--request-file`). `BuildRequest` resolves `--path` via spec-path, enforces the "exactly one" check, and delegates to `overlapRequestFromFlagsContext` which still owns the `spec-record-file` branch.
- **review-spec** — identical 4-way mutex shape to check-overlap; reuses the same spec-record-file loader through `reviewRequestFromFlags`.

## Net delta

-153 LOC across the three command files.

## Validation

- `make ci` green.
- `go test -race ./cmd/...` clean.

## Stacking

Base: `refactor/cmd-runcommand-batch-2`. Will rebase onto `main` after #325 and the batch-2 PR merge.

## Test plan

- [ ] CI green on `refactor/cmd-runcommand-batch-3`
- [ ] `@claude review` passes or findings addressed
- [ ] Rebase onto `main` after dependencies merge