### PR TITLE
Migrate check-compliance to runCommand[Req,Res]

### DIFF
--- a/cmd/check_compliance.go
+++ b/cmd/check_compliance.go
@@ -28,122 +28,65 @@ func runCheckCompliance(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckComplianceContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-compliance", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-compliance", "pituitary [--config PATH] check-compliance (--path PATH... | --diff-file PATH|- | --request-file PATH|-) [--format FORMAT] [--timings]")
-
 	var (
-		paths       compliancePathList
-		diffFile    string
-		requestFile string
-		format      string
-		configPath  string
-		atDate      string
-		timings     bool
+		paths         compliancePathList
+		diffFile      string
+		atDate        string
+		minConfidence string
 	)
-	fs.Var(&paths, "path", "workspace-relative or absolute file path; repeat to check multiple files")
-	fs.StringVar(&diffFile, "diff-file", "", "path to a unified diff file, or - for stdin")
-	fs.StringVar(&requestFile, "request-file", "", "path to compliance request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
-	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
-	var minConfidence string
-	fs.StringVar(&minConfidence, "min-confidence", "", "minimum confidence tier: extracted, inferred, or ambiguous")
-
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("check-compliance", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-
-	var request analysis.ComplianceRequest
-	switch {
-	case trimmedRequestFile != "" && (len(paths) > 0 || strings.TrimSpace(diffFile) != ""):
-		return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or the path/diff-file flags",
-		}, 2)
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.ComplianceRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		if request.DiffText == "" && strings.TrimSpace(request.DiffFile) != "" {
-			request.DiffText, err = loadComplianceDiffFile(cfg.Workspace.RootPath, request.DiffFile)
-			if err != nil {
-				return writeCLIError(stdout, stderr, format, "check-compliance", request, cliIssue{
-					Code:    "validation_error",
-					Message: err.Error(),
-				}, 2)
-			}
-		}
-	default:
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = complianceRequestFromFlags(cfg.Workspace.RootPath, []string(paths), strings.TrimSpace(diffFile))
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-compliance", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-
-	if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
-		request.AtDate = trimmedAt
-	}
-	if trimmedConf := strings.TrimSpace(minConfidence); trimmedConf != "" {
-		request.MinConfidence = trimmedConf
-	}
-	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
-
-	operation := app.CheckCompliance(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-compliance", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccessWithTimings(stdout, stderr, format, "check-compliance", operation.Request, operation.Result, nil, snapshotCommandTimings(tracker, started))
+	return runCommand[analysis.ComplianceRequest, analysis.ComplianceResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.ComplianceRequest, analysis.ComplianceResult]{
+			Name:  "check-compliance",
+			Usage: "pituitary [--config PATH] check-compliance (--path PATH... | --diff-file PATH|- | --request-file PATH|-) [--format FORMAT] [--timings]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				Timings:        true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.Var(&paths, "path", "workspace-relative or absolute file path; repeat to check multiple files")
+				fs.StringVar(&diffFile, "diff-file", "", "path to a unified diff file, or - for stdin")
+				fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
+				fs.StringVar(&minConfidence, "min-confidence", "", "minimum confidence tier: extracted, inferred, or ambiguous")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return len(paths) > 0 || strings.TrimSpace(diffFile) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.ComplianceRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.ComplianceRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				if req.DiffText == "" && strings.TrimSpace(req.DiffFile) != "" {
+					diffText, diffErr := loadComplianceDiffFile(cfg.Workspace.RootPath, req.DiffFile)
+					if diffErr != nil {
+						return &req, diffErr
+					}
+					req.DiffText = diffText
+				}
+				return &req, nil
+			},
+			BuildRequest: func(_ context.Context, cfg *config.Config, _ string) (analysis.ComplianceRequest, error) {
+				return complianceRequestFromFlags(cfg.Workspace.RootPath, []string(paths), strings.TrimSpace(diffFile))
+			},
+			Normalize: func(_ context.Context, req analysis.ComplianceRequest) (analysis.ComplianceRequest, error) {
+				if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
+					req.AtDate = trimmedAt
+				}
+				if trimmedConf := strings.TrimSpace(minConfidence); trimmedConf != "" {
+					req.MinConfidence = trimmedConf
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.ComplianceRequest) (analysis.ComplianceRequest, *analysis.ComplianceResult, *app.Issue) {
+				op := app.CheckCompliance(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func complianceRequestFromFlags(workspaceRoot string, paths []string, diffFile string) (analysis.ComplianceRequest, error) {

--- a/cmd/check_compliance_test.go
+++ b/cmd/check_compliance_test.go
@@ -457,6 +457,42 @@ func buildLimiter() {}
 	}
 }
 
+func TestRunCheckComplianceWithRequestFileDiffFileErrorJSON(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+	mustWriteJSONFileCmd(t, filepath.Join(repo, "compliance-request.json"), map[string]any{
+		"diff_file": "missing.patch",
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runCheckCompliance([]string{"--request-file", "compliance-request.json", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runCheckCompliance() exit code = %d, want 2", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCheckCompliance() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request struct {
+			DiffFile string `json:"diff_file"`
+		} `json:"request"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal compliance request-file diff error payload: %v", err)
+	}
+	if got, want := payload.Request.DiffFile, "missing.patch"; got != want {
+		t.Fatalf("request.diff_file = %q, want %q", got, want)
+	}
+	if len(payload.Errors) != 1 || !strings.Contains(payload.Errors[0].Message, "missing.patch") {
+		t.Fatalf("errors = %+v, want diff-file validation error", payload.Errors)
+	}
+}
+
 func TestRunCheckComplianceRejectsDiffFileOutsideWorkspace(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 	outside := filepath.Join(t.TempDir(), "change.diff")


### PR DESCRIPTION
## Summary

Fourth of a four-PR stack that collapses CLI command scaffolding onto the generic `runCommand[Req, Res]` helper landed in #325. This PR migrates the final fitting command in the analysis family:

- **check-compliance** — mirrors the check-doc-drift shape. `LoadRequestFile` parses the request JSON and resolves the nested `diff_file` reference against the workspace root when `DiffText` is empty, surfacing the partial request if diff-file resolution fails (preserves `TestRunCheckComplianceWithRequestFileDiffFileError`). `BuildRequest` delegates to `complianceRequestFromFlags`. `Normalize` applies the shared `--at`/`--min-confidence` fixups to both branches. `--timings` flows through.

## Remaining commands not in this stack

`fix`, `compile`, `canonicalize`, `migrate-config`, `explain-file`, `new`, `discover`, `init`, `index`, `status`, `version`, `schema`, `serve`, `preview-sources` — either use CLI-specific request types distinct from the app request, call `source.X`/`config.X` directly instead of `app.X`, take positional args as primary input, or have cross-cutting validation that wants `format` inside a callback. They need additional runner hooks (e.g. `Normalize(format string, req)`, a plain-error adapter for `Execute`, an "exactly N positional" option) and are deferred.

## Net delta

-57 LOC for check-compliance.

## Validation

- `make ci` green.
- `go test -race ./cmd/...` clean.

## Stacking

Base: `refactor/cmd-runcommand-batch-3`. Will rebase onto `main` after the earlier PRs in the stack merge.

## Test plan

- [ ] CI green on `refactor/cmd-runcommand-batch-4`
- [ ] `@claude review` passes or findings addressed
- [ ] Rebase onto `main` after dependencies merge