### PR TITLE
Migrate three analysis commands to runCommand[Req,Res]

### DIFF
--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -54,13 +54,18 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 				return &req, nil
 			},
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.AnalyzeImpactRequest, error) {
+				trimmedSpecRef := strings.TrimSpace(specRef)
+				trimmedSpecPath := strings.TrimSpace(specPath)
 				req := analysis.AnalyzeImpactRequest{
 					ChangeType: strings.TrimSpace(changeType),
 					Summary:    summary,
-					SpecRef:    strings.TrimSpace(specRef),
+					SpecRef:    trimmedSpecRef,
 				}
-				if trimmedPath := strings.TrimSpace(specPath); trimmedPath != "" {
-					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
+				if trimmedSpecRef != "" && trimmedSpecPath != "" {
+					return req, fmt.Errorf("exactly one of --path or --spec-ref is allowed")
+				}
+				if trimmedSpecPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
 					if err != nil {
 						return req, specPathResolutionError(err)
 					}
@@ -81,9 +86,9 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 				op := app.AnalyzeImpact(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},
-			PostProcess: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest, res *analysis.AnalyzeImpactResult) (*analysis.AnalyzeImpactResult, *cliIssue) {
+			PostProcess: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest, res *analysis.AnalyzeImpactResult) (*analysis.AnalyzeImpactResult, *cliIssue, int) {
 				annotateCrossFamilyImpact(ctx, cfgPath, req.SpecRef, res)
-				return res, nil
+				return res, nil, 0
 			},
 		},
 	)

--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -18,121 +18,75 @@ func runAnalyzeImpact(args []string, stdout, stderr io.Writer) int {
 }
 
 func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("analyze-impact", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("analyze-impact", "pituitary [--config PATH] analyze-impact (--path PATH | --spec-ref REF | --request-file PATH|-) [--change-type TYPE] [--summary] [--format FORMAT]")
-
 	var (
-		specRef     string
-		specPath    string
-		requestFile string
-		changeType  string
-		summary     bool
-		format      string
-		configPath  string
-		atDate      string
+		specRef    string
+		specPath   string
+		changeType string
+		summary    bool
+		atDate     string
 	)
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
-	fs.StringVar(&requestFile, "request-file", "", "path to impact request JSON, or - for stdin")
-	fs.StringVar(&changeType, "change-type", "accepted", "change type: accepted, modified, or deprecated")
-	fs.BoolVar(&summary, "summary", false, "emit a concise ranked summary in text output and include summary metadata in JSON")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := analysis.AnalyzeImpactRequest{
-		ChangeType: strings.TrimSpace(changeType),
-		Summary:    summary,
-	}
-	if err := validateCLIFormat("analyze-impact", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedSpecRef := strings.TrimSpace(specRef)
-	trimmedSpecPath := strings.TrimSpace(specPath)
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRequestFile) > 1 {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --path, --spec-ref, or --request-file is allowed",
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	if trimmedSpecPath != "" {
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		trimmedSpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "analyze-impact", request, err)
-		}
-	}
-	switch {
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.AnalyzeImpactRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	default:
-		request.SpecRef = trimmedSpecRef
-		if request.SpecRef == "" {
-			return writeCLIError(stdout, stderr, format, "analyze-impact", request, cliIssue{
-				Code:    "validation_error",
-				Message: "one of --path, --spec-ref, or --request-file is required",
-			}, 2)
-		}
-	}
-
-	if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
-		request.AtDate = trimmedAt
-	}
-	operation := app.AnalyzeImpact(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "analyze-impact", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	// Annotate cross-family impact.
-	annotateCrossFamilyImpact(ctx, resolvedConfigPath, request.SpecRef, operation.Result)
-
-	return writeCLISuccess(stdout, stderr, format, "analyze-impact", operation.Request, operation.Result, nil)
+	return runCommand[analysis.AnalyzeImpactRequest, analysis.AnalyzeImpactResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.AnalyzeImpactRequest, analysis.AnalyzeImpactResult]{
+			Name:  "analyze-impact",
+			Usage: "pituitary [--config PATH] analyze-impact (--path PATH | --spec-ref REF | --request-file PATH|-) [--change-type TYPE] [--summary] [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
+				fs.StringVar(&changeType, "change-type", "accepted", "change type: accepted, modified, or deprecated")
+				fs.BoolVar(&summary, "summary", false, "emit a concise ranked summary in text output and include summary metadata in JSON")
+				fs.StringVar(&atDate, "at", "", "ISO date for point-in-time governance query (e.g. 2025-03-15)")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return strings.TrimSpace(specRef) != "" || strings.TrimSpace(specPath) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.AnalyzeImpactRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.AnalyzeImpactRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.AnalyzeImpactRequest, error) {
+				req := analysis.AnalyzeImpactRequest{
+					ChangeType: strings.TrimSpace(changeType),
+					Summary:    summary,
+					SpecRef:    strings.TrimSpace(specRef),
+				}
+				if trimmedPath := strings.TrimSpace(specPath); trimmedPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
+					if err != nil {
+						return req, specPathResolutionError(err)
+					}
+					req.SpecRef = resolved
+				}
+				if req.SpecRef == "" {
+					return req, fmt.Errorf("one of --path, --spec-ref, or --request-file is required")
+				}
+				return req, nil
+			},
+			Normalize: func(_ context.Context, req analysis.AnalyzeImpactRequest) (analysis.AnalyzeImpactRequest, error) {
+				if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
+					req.AtDate = trimmedAt
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest) (analysis.AnalyzeImpactRequest, *analysis.AnalyzeImpactResult, *app.Issue) {
+				op := app.AnalyzeImpact(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+			PostProcess: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest, res *analysis.AnalyzeImpactResult) (*analysis.AnalyzeImpactResult, *cliIssue) {
+				annotateCrossFamilyImpact(ctx, cfgPath, req.SpecRef, res)
+				return res, nil
+			},
+		},
+	)
 }
 
 func annotateCrossFamilyImpact(ctx context.Context, configPath string, sourceRef string, result *analysis.AnalyzeImpactResult) {

--- a/cmd/check_terminology.go
+++ b/cmd/check_terminology.go
@@ -28,118 +28,72 @@ func runCheckTerminology(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-terminology", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-terminology", "pituitary [--config PATH] check-terminology ([--term TERM]... [--canonical-term TERM]... [--spec-ref REF | --path PATH] [--scope SCOPE] | --request-file PATH|-) [--format FORMAT] [--timings]")
-
 	var (
 		terms          stringList
 		canonicalTerms stringList
 		specRef        string
 		specPath       string
 		scope          string
-		requestFile    string
-		format         string
-		configPath     string
-		timings        bool
 	)
-	fs.Var(&terms, "term", "displaced or governed term to audit; repeat to narrow a configured policy set or supply ad hoc terms")
-	fs.Var(&canonicalTerms, "canonical-term", "replacement or canonical term; repeat to supply multiple terms")
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref used to anchor the audit")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec used to anchor the audit")
-	fs.StringVar(&scope, "scope", "all", "artifact scope: all, docs, or specs")
-	fs.StringVar(&requestFile, "request-file", "", "path to terminology audit request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-terminology", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := analysis.TerminologyAuditRequest{
-		Terms:          []string(terms),
-		CanonicalTerms: []string(canonicalTerms),
-		SpecRef:        strings.TrimSpace(specRef),
-		Scope:          strings.TrimSpace(scope),
-	}
-	if err := validateCLIFormat("check-terminology", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if trimmedRequestFile != "" && (countNonEmptyStrings(request.Terms) > 0 || countNonEmptyStrings(request.CanonicalTerms) > 0 || request.SpecRef != "" || strings.TrimSpace(specPath) != "" || flagWasSet(fs, "scope")) {
-		return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or the terminology flags",
-		}, 2)
-	}
-	if trimmedRequestFile != "" {
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.TerminologyAuditRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-	trimmedPath := strings.TrimSpace(specPath)
-	if trimmedRequestFile == "" && request.SpecRef != "" && trimmedPath != "" {
-		return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --spec-ref or --path is allowed",
-		}, 2)
-	}
-	if trimmedRequestFile == "" && trimmedPath != "" {
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-terminology", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request.SpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "check-terminology", request, err)
-		}
-	}
-
-	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
-
-	operation := app.CheckTerminology(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-terminology", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccessWithTimings(stdout, stderr, format, "check-terminology", operation.Request, operation.Result, nil, snapshotCommandTimings(tracker, started))
+	return runCommand[analysis.TerminologyAuditRequest, analysis.TerminologyAuditResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.TerminologyAuditRequest, analysis.TerminologyAuditResult]{
+			Name:  "check-terminology",
+			Usage: "pituitary [--config PATH] check-terminology ([--term TERM]... [--canonical-term TERM]... [--spec-ref REF | --path PATH] [--scope SCOPE] | --request-file PATH|-) [--format FORMAT] [--timings]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				Timings:        true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.Var(&terms, "term", "displaced or governed term to audit; repeat to narrow a configured policy set or supply ad hoc terms")
+				fs.Var(&canonicalTerms, "canonical-term", "replacement or canonical term; repeat to supply multiple terms")
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref used to anchor the audit")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec used to anchor the audit")
+				fs.StringVar(&scope, "scope", "all", "artifact scope: all, docs, or specs")
+			},
+			InlineFlagsSet: func(fs *flag.FlagSet) bool {
+				return countNonEmptyStrings(terms) > 0 ||
+					countNonEmptyStrings(canonicalTerms) > 0 ||
+					strings.TrimSpace(specRef) != "" ||
+					strings.TrimSpace(specPath) != "" ||
+					flagWasSet(fs, "scope")
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.TerminologyAuditRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.TerminologyAuditRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.TerminologyAuditRequest, error) {
+				req := analysis.TerminologyAuditRequest{
+					Terms:          []string(terms),
+					CanonicalTerms: []string(canonicalTerms),
+					SpecRef:        strings.TrimSpace(specRef),
+					Scope:          strings.TrimSpace(scope),
+				}
+				trimmedPath := strings.TrimSpace(specPath)
+				if req.SpecRef != "" && trimmedPath != "" {
+					return req, fmt.Errorf("exactly one of --spec-ref or --path is allowed")
+				}
+				if trimmedPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
+					if err != nil {
+						return req, specPathResolutionError(err)
+					}
+					req.SpecRef = resolved
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.TerminologyAuditRequest) (analysis.TerminologyAuditRequest, *analysis.TerminologyAuditResult, *app.Issue) {
+				op := app.CheckTerminology(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func countNonEmptyStrings(values []string) int {

--- a/cmd/compare_specs.go
+++ b/cmd/compare_specs.go
@@ -28,113 +28,64 @@ func runCompareSpecs(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCompareSpecsContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("compare-specs", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("compare-specs", "pituitary [--config PATH] compare-specs (--spec-ref REF --spec-ref REF | --path PATH --path PATH | --request-file PATH|-) [--format FORMAT]")
-
 	var (
-		specRefs    compareSpecRefs
-		specPaths   compareSpecRefs
-		requestFile string
-		format      string
-		configPath  string
+		specRefs  compareSpecRefs
+		specPaths compareSpecRefs
 	)
-	fs.Var(&specRefs, "spec-ref", "indexed spec ref; pass exactly two to compare")
-	fs.Var(&specPaths, "path", "workspace-relative or absolute path to an indexed spec; pass exactly two to compare")
-	fs.StringVar(&requestFile, "request-file", "", "path to compare request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "compare-specs", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := analysis.CompareRequest{}
-	if err := validateCLIFormat("compare-specs", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	switch {
-	case trimmedRequestFile != "" && (len(specRefs) > 0 || len(specPaths) > 0):
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "use either --request-file or the path/spec-ref flags",
-		}, 2)
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.CompareRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	case len(specRefs) > 0 && len(specPaths) > 0:
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "use either two --spec-ref flags or two --path flags",
-		}, 2)
-	case len(specRefs) == 2:
-		request.SpecRefs = []string(specRefs)
-	case len(specPaths) == 2:
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request.SpecRefs, err = resolveIndexedSpecRefsWithConfigContext(ctx, cfg, []string(specPaths))
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "compare-specs", request, err)
-		}
-	default:
-		request.SpecRefs = []string(specRefs)
-	}
-	switch {
-	case request.SpecRecord == nil && len(request.SpecRefs) != 2:
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly two --spec-ref flags or two --path flags are required",
-		}, 2)
-	case request.SpecRecord != nil && len(request.SpecRefs) != 1:
-		return writeCLIError(stdout, stderr, format, "compare-specs", request, cliIssue{
-			Code:    "validation_error",
-			Message: "request files with spec_record require exactly one indexed spec_ref",
-		}, 2)
-	}
-
-	operation := app.CompareSpecs(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "compare-specs", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "compare-specs", operation.Request, operation.Result, nil)
+	return runCommand[analysis.CompareRequest, analysis.CompareResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.CompareRequest, analysis.CompareResult]{
+			Name:  "compare-specs",
+			Usage: "pituitary [--config PATH] compare-specs (--spec-ref REF --spec-ref REF | --path PATH --path PATH | --request-file PATH|-) [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.Var(&specRefs, "spec-ref", "indexed spec ref; pass exactly two to compare")
+				fs.Var(&specPaths, "path", "workspace-relative or absolute path to an indexed spec; pass exactly two to compare")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return len(specRefs) > 0 || len(specPaths) > 0
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.CompareRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.CompareRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.CompareRequest, error) {
+				req := analysis.CompareRequest{}
+				switch {
+				case len(specRefs) > 0 && len(specPaths) > 0:
+					return req, fmt.Errorf("use either two --spec-ref flags or two --path flags")
+				case len(specRefs) > 0:
+					req.SpecRefs = []string(specRefs)
+				case len(specPaths) > 0:
+					resolved, err := resolveIndexedSpecRefsWithConfigContext(ctx, cfg, []string(specPaths))
+					if err != nil {
+						return req, specPathResolutionError(err)
+					}
+					req.SpecRefs = resolved
+				}
+				return req, nil
+			},
+			Normalize: func(_ context.Context, req analysis.CompareRequest) (analysis.CompareRequest, error) {
+				switch {
+				case req.SpecRecord == nil && len(req.SpecRefs) != 2:
+					return req, fmt.Errorf("exactly two --spec-ref flags or two --path flags are required")
+				case req.SpecRecord != nil && len(req.SpecRefs) != 1:
+					return req, fmt.Errorf("request files with spec_record require exactly one indexed spec_ref")
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.CompareRequest) (analysis.CompareRequest, *analysis.CompareResult, *app.Issue) {
+				op := app.CompareSpecs(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }

--- a/cmd/spec_path.go
+++ b/cmd/spec_path.go
@@ -18,6 +18,13 @@ func resolveIndexedSpecRefsWithConfigContext(ctx context.Context, cfg *config.Co
 }
 
 func writeSpecPathResolutionError(stdout, stderr io.Writer, format, command string, request any, err error) int {
+	issue := specPathResolutionIssue(err)
+	return writeCLIError(stdout, stderr, format, command, request, issue, 2)
+}
+
+// specPathResolutionIssue classifies a spec-path resolution error into the
+// cliIssue code previously emitted by writeSpecPathResolutionError.
+func specPathResolutionIssue(err error) cliIssue {
 	code := "validation_error"
 	switch {
 	case index.IsMissingIndex(err):
@@ -25,10 +32,14 @@ func writeSpecPathResolutionError(stdout, stderr io.Writer, format, command stri
 	case index.IsSpecPathNotFound(err):
 		code = "not_found"
 	}
-	return writeCLIError(stdout, stderr, format, command, request, cliIssue{
-		Code:    code,
-		Message: err.Error(),
-	}, 2)
+	return cliIssue{Code: code, Message: err.Error()}
+}
+
+// specPathResolutionError wraps a spec-path resolution error in a
+// cliIssueError so runCommand's BuildRequest callback can surface the
+// classified code through the standard error channel.
+func specPathResolutionError(err error) error {
+	return &cliIssueError{issue: specPathResolutionIssue(err), exitCode: 2}
 }
 
 func nonEmptyCount(values ...string) int {


### PR DESCRIPTION
## Summary

Second in the runCommand migration series (after #325, merged). Moves three analysis commands onto the generic helper:

- **analyze-impact** — `--path`/`--spec-ref`/`--request-file` mutex with a BuildRequest-level \`--path` + `--spec-ref\` guard (matches pre-refactor `nonEmptyCount` behaviour), `--at` normalize, `annotateCrossFamilyImpact` as a PostProcess hook.
- **check-terminology** — terms/canonical/scope/spec-ref/spec-path inline set (including `flagWasSet("scope")`), `--timings` support.
- **compare-specs** — two-of-each mutex with post-Normalize "exactly two refs" / "spec_record + 1 ref" count validation.

Adds `specPathResolutionError` to `cmd/spec_path.go` so BuildRequest callbacks can surface the `config_error`/`not_found`/`validation_error` classification through the runner's `cliIssueError` channel, matching `writeSpecPathResolutionError`.

## Addressing prior review

This PR replaces the auto-closed #326 (original base branch was deleted on merge of #325). All review feedback was already addressed in the branch before the retarget:

- **Copilot/Claude:** missing `--path` + `--spec-ref` mutex in analyze-impact → fixed explicitly in BuildRequest.
- **PostProcess signature:** updated to match the helper's new `(*Res, *cliIssue, int)` contract landed in #325.

## Validation

- `make ci` green.
- `go test -race ./cmd/...` clean.

## Net delta

-130 LOC across the three commands.

## Test plan

- [ ] CI green
- [ ] `@claude review` passes or findings are addressed