### PR TITLE
Migrate three more spec-centric commands to runCommand[Req,Res]

### DIFF
--- a/cmd/check_overlap.go
+++ b/cmd/check_overlap.go
@@ -22,111 +22,61 @@ func runCheckOverlap(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-overlap", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-overlap", "pituitary [--config PATH] check-overlap (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]")
-
 	var (
 		specRef        string
 		specPath       string
 		specRecordFile string
-		requestFile    string
-		format         string
-		configPath     string
 	)
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
-	fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
-	fs.StringVar(&requestFile, "request-file", "", "path to overlap request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("check-overlap", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedSpecRef := strings.TrimSpace(specRef)
-	trimmedSpecPath := strings.TrimSpace(specPath)
-	trimmedSpecRecordFile := strings.TrimSpace(specRecordFile)
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedSpecRecordFile, trimmedRequestFile) > 1 {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed",
-		}, 2)
-	}
-	var cfg *config.Config
-	if trimmedSpecPath != "" || trimmedSpecRecordFile != "" || trimmedRequestFile != "" {
-		cfg, err = config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-	if trimmedRequestFile != "" {
-		request, err := loadWorkspaceScopedJSONFile[analysis.OverlapRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		operation := app.CheckOverlap(ctx, resolvedConfigPath, request)
-		if operation.Issue != nil {
-			return writeCLIError(stdout, stderr, format, "check-overlap", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-		}
-		return writeCLISuccess(stdout, stderr, format, "check-overlap", operation.Request, operation.Result, nil)
-	}
-	if trimmedSpecPath != "" {
-		trimmedSpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "check-overlap", nil, err)
-		}
-	}
-	workspaceRoot := ""
-	if cfg != nil {
-		workspaceRoot = cfg.Workspace.RootPath
-	}
-	request, err := overlapRequestFromFlagsContext(workspaceRoot, trimmedSpecRef, trimmedSpecRecordFile)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	operation := app.CheckOverlap(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-overlap", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "check-overlap", operation.Request, operation.Result, nil)
+	return runCommand[analysis.OverlapRequest, analysis.OverlapResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.OverlapRequest, analysis.OverlapResult]{
+			Name:  "check-overlap",
+			Usage: "pituitary [--config PATH] check-overlap (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
+				fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return strings.TrimSpace(specRef) != "" ||
+					strings.TrimSpace(specPath) != "" ||
+					strings.TrimSpace(specRecordFile) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.OverlapRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.OverlapRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.OverlapRequest, error) {
+				trimmedSpecRef := strings.TrimSpace(specRef)
+				trimmedSpecPath := strings.TrimSpace(specPath)
+				trimmedRecord := strings.TrimSpace(specRecordFile)
+				if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRecord) > 1 {
+					return analysis.OverlapRequest{}, fmt.Errorf("exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed")
+				}
+				if trimmedSpecPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
+					if err != nil {
+						return analysis.OverlapRequest{}, specPathResolutionError(err)
+					}
+					trimmedSpecRef = resolved
+				}
+				return overlapRequestFromFlagsContext(cfg.Workspace.RootPath, trimmedSpecRef, trimmedRecord)
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.OverlapRequest) (analysis.OverlapRequest, *analysis.OverlapResult, *app.Issue) {
+				op := app.CheckOverlap(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func overlapRequestFromFlagsContext(workspaceRoot, specRef, specRecordFile string) (analysis.OverlapRequest, error) {

--- a/cmd/check_overlap_test.go
+++ b/cmd/check_overlap_test.go
@@ -11,6 +11,37 @@ import (
 	"github.com/dusk-network/pituitary/internal/model"
 )
 
+func TestRunCheckOverlapRejectsSpecRefAndPath(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runCheckOverlap([]string{
+			"--spec-ref", "SPEC-042",
+			"--path", "some/spec.toml",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runCheckOverlap() exit code = %d, want 2", exitCode)
+	}
+
+	var payload struct {
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal mutex payload: %v", err)
+	}
+	if len(payload.Errors) != 1 || payload.Errors[0].Code != "validation_error" {
+		t.Fatalf("errors = %+v, want one validation_error", payload.Errors)
+	}
+	if !strings.Contains(payload.Errors[0].Message, "exactly one of --path, --spec-ref") {
+		t.Fatalf("errors[0].message = %q, want mutex guard message", payload.Errors[0].Message)
+	}
+}
+
 func TestRunCheckOverlapWithSpecRefJSON(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 

--- a/cmd/check_spec_freshness.go
+++ b/cmd/check_spec_freshness.go
@@ -53,7 +53,7 @@ func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, st
 				resolvedSpecRef := strings.TrimSpace(specRef)
 				trimmedPath := strings.TrimSpace(specPath)
 				if resolvedSpecRef != "" && trimmedPath != "" {
-					return req, fmt.Errorf("exactly one of --path or --spec-ref is allowed")
+					return req, fmt.Errorf("at most one of --path or --spec-ref may be specified")
 				}
 				if trimmedPath != "" {
 					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)

--- a/cmd/check_spec_freshness.go
+++ b/cmd/check_spec_freshness.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"strings"
 
@@ -50,7 +51,11 @@ func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, st
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.FreshnessRequest, error) {
 				req := analysis.FreshnessRequest{Scope: strings.TrimSpace(scope)}
 				resolvedSpecRef := strings.TrimSpace(specRef)
-				if trimmedPath := strings.TrimSpace(specPath); trimmedPath != "" {
+				trimmedPath := strings.TrimSpace(specPath)
+				if resolvedSpecRef != "" && trimmedPath != "" {
+					return req, fmt.Errorf("exactly one of --path or --spec-ref is allowed")
+				}
+				if trimmedPath != "" {
 					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
 					if err != nil {
 						return req, specPathResolutionError(err)

--- a/cmd/check_spec_freshness.go
+++ b/cmd/check_spec_freshness.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"flag"
-	"fmt"
 	"io"
 	"strings"
 
@@ -17,109 +16,57 @@ func runCheckSpecFreshness(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("check-spec-freshness", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("check-spec-freshness", "pituitary [--config PATH] check-spec-freshness [--spec-ref REF | --path PATH | --scope all | --request-file PATH|-] [--format FORMAT]")
-
 	var (
-		specRef     string
-		specPath    string
-		requestFile string
-		scope       string
-		format      string
-		configPath  string
+		specRef  string
+		specPath string
+		scope    string
 	)
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
-	fs.StringVar(&requestFile, "request-file", "", "path to request JSON, or - for stdin")
-	fs.StringVar(&scope, "scope", "all", "scope: all (default)")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := analysis.FreshnessRequest{
-		Scope: strings.TrimSpace(scope),
-	}
-	if err := validateCLIFormat("check-spec-freshness", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	trimmedSpecRef := strings.TrimSpace(specRef)
-	trimmedSpecPath := strings.TrimSpace(specPath)
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRequestFile) > 1 {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-			Code:    "validation_error",
-			Message: "at most one of --path, --spec-ref, or --request-file is allowed",
-		}, 2)
-	}
-
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	if trimmedSpecPath != "" {
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		trimmedSpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "check-spec-freshness", request, err)
-		}
-	}
-
-	switch {
-	case trimmedRequestFile != "":
-		cfg, err := config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		request, err = loadWorkspaceScopedJSONFile[analysis.FreshnessRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "check-spec-freshness", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	case trimmedSpecRef != "":
-		request.SpecRef = trimmedSpecRef
-		request.Scope = ""
-	default:
-		// scope=all is the default
-	}
-
-	operation := app.CheckSpecFreshness(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "check-spec-freshness", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "check-spec-freshness", operation.Request, operation.Result, nil)
+	return runCommand[analysis.FreshnessRequest, analysis.FreshnessResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.FreshnessRequest, analysis.FreshnessResult]{
+			Name:  "check-spec-freshness",
+			Usage: "pituitary [--config PATH] check-spec-freshness [--spec-ref REF | --path PATH | --scope all | --request-file PATH|-] [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
+				fs.StringVar(&scope, "scope", "all", "scope: all (default)")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return strings.TrimSpace(specRef) != "" || strings.TrimSpace(specPath) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.FreshnessRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.FreshnessRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.FreshnessRequest, error) {
+				req := analysis.FreshnessRequest{Scope: strings.TrimSpace(scope)}
+				resolvedSpecRef := strings.TrimSpace(specRef)
+				if trimmedPath := strings.TrimSpace(specPath); trimmedPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedPath)
+					if err != nil {
+						return req, specPathResolutionError(err)
+					}
+					resolvedSpecRef = resolved
+				}
+				if resolvedSpecRef != "" {
+					req.SpecRef = resolvedSpecRef
+					req.Scope = ""
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.FreshnessRequest) (analysis.FreshnessRequest, *analysis.FreshnessResult, *app.Issue) {
+				op := app.CheckSpecFreshness(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }

--- a/cmd/check_spec_freshness_test.go
+++ b/cmd/check_spec_freshness_test.go
@@ -80,6 +80,37 @@ func TestRunCheckSpecFreshnessText(t *testing.T) {
 	}
 }
 
+func TestRunCheckSpecFreshnessRejectsPathAndSpecRef(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runCheckSpecFreshness([]string{
+			"--path", "some/path.md",
+			"--spec-ref", "SPEC-042",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runCheckSpecFreshness() exit code = %d, want 2", exitCode)
+	}
+
+	var payload struct {
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal mutex payload: %v", err)
+	}
+	if len(payload.Errors) != 1 || payload.Errors[0].Code != "validation_error" {
+		t.Fatalf("errors = %+v, want one validation_error", payload.Errors)
+	}
+	if payload.Errors[0].Message != "at most one of --path or --spec-ref may be specified" {
+		t.Fatalf("errors[0].message = %q, want mutex guard message", payload.Errors[0].Message)
+	}
+}
+
 func TestRunCheckSpecFreshnessHelpFlag(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/cmd/review_spec.go
+++ b/cmd/review_spec.go
@@ -17,111 +17,61 @@ func runReviewSpec(args []string, stdout, stderr io.Writer) int {
 }
 
 func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("review-spec", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("review-spec", "pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]")
-
 	var (
 		specRef        string
 		specPath       string
 		specRecordFile string
-		requestFile    string
-		format         string
-		configPath     string
 	)
-	fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
-	fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
-	fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
-	fs.StringVar(&requestFile, "request-file", "", "path to review request JSON, or - for stdin")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	if err := validateCLIFormat("review-spec", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	trimmedSpecRef := strings.TrimSpace(specRef)
-	trimmedSpecPath := strings.TrimSpace(specPath)
-	trimmedSpecRecordFile := strings.TrimSpace(specRecordFile)
-	trimmedRequestFile := strings.TrimSpace(requestFile)
-	if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedSpecRecordFile, trimmedRequestFile) > 1 {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed",
-		}, 2)
-	}
-	var cfg *config.Config
-	if trimmedSpecPath != "" || trimmedSpecRecordFile != "" || trimmedRequestFile != "" {
-		cfg, err = config.Load(resolvedConfigPath)
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
-		}
-	}
-	if trimmedRequestFile != "" {
-		request, err := loadWorkspaceScopedJSONFile[analysis.ReviewRequest](cfg.Workspace.RootPath, trimmedRequestFile, "request file")
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		operation := app.ReviewSpec(ctx, resolvedConfigPath, request)
-		if operation.Issue != nil {
-			return writeCLIError(stdout, stderr, format, "review-spec", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-		}
-		return writeCLISuccess(stdout, stderr, format, "review-spec", operation.Request, operation.Result, nil)
-	}
-	if trimmedSpecPath != "" {
-		trimmedSpecRef, err = resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
-		if err != nil {
-			return writeSpecPathResolutionError(stdout, stderr, format, "review-spec", nil, err)
-		}
-	}
-	workspaceRoot := ""
-	if cfg != nil {
-		workspaceRoot = cfg.Workspace.RootPath
-	}
-	request, err := reviewRequestFromFlags(workspaceRoot, trimmedSpecRef, trimmedSpecRecordFile)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	operation := app.ReviewSpec(ctx, resolvedConfigPath, request)
-	if operation.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "review-spec", operation.Request, cliIssueFromAppIssue(operation.Issue), operation.Issue.ExitCode)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "review-spec", operation.Request, operation.Result, nil)
+	return runCommand[analysis.ReviewRequest, analysis.ReviewResult](
+		ctx, args, stdout, stderr,
+		commandRun[analysis.ReviewRequest, analysis.ReviewResult]{
+			Name:  "review-spec",
+			Usage: "pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]",
+			Options: commandRunOptions{
+				RequestFile:    true,
+				ConfigForFile:  true,
+				ConfigForFlags: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
+				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
+				fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
+			},
+			InlineFlagsSet: func(_ *flag.FlagSet) bool {
+				return strings.TrimSpace(specRef) != "" ||
+					strings.TrimSpace(specPath) != "" ||
+					strings.TrimSpace(specRecordFile) != ""
+			},
+			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.ReviewRequest, error) {
+				req, err := loadWorkspaceScopedJSONFile[analysis.ReviewRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
+				if err != nil {
+					return nil, err
+				}
+				return &req, nil
+			},
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.ReviewRequest, error) {
+				trimmedSpecRef := strings.TrimSpace(specRef)
+				trimmedSpecPath := strings.TrimSpace(specPath)
+				trimmedRecord := strings.TrimSpace(specRecordFile)
+				if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRecord) > 1 {
+					return analysis.ReviewRequest{}, fmt.Errorf("exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed")
+				}
+				if trimmedSpecPath != "" {
+					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
+					if err != nil {
+						return analysis.ReviewRequest{}, specPathResolutionError(err)
+					}
+					trimmedSpecRef = resolved
+				}
+				return reviewRequestFromFlags(cfg.Workspace.RootPath, trimmedSpecRef, trimmedRecord)
+			},
+			Execute: func(ctx context.Context, cfgPath string, req analysis.ReviewRequest) (analysis.ReviewRequest, *analysis.ReviewResult, *app.Issue) {
+				op := app.ReviewSpec(ctx, cfgPath, req)
+				return op.Request, op.Result, op.Issue
+			},
+		},
+	)
 }
 
 func reviewRequestFromFlags(workspaceRoot, specRef, specRecordFile string) (analysis.ReviewRequest, error) {

--- a/cmd/review_spec_test.go
+++ b/cmd/review_spec_test.go
@@ -11,6 +11,37 @@ import (
 	"github.com/dusk-network/pituitary/internal/model"
 )
 
+func TestRunReviewSpecRejectsSpecRefAndPath(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runReviewSpec([]string{
+			"--spec-ref", "SPEC-042",
+			"--path", "some/spec.toml",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runReviewSpec() exit code = %d, want 2", exitCode)
+	}
+
+	var payload struct {
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal mutex payload: %v", err)
+	}
+	if len(payload.Errors) != 1 || payload.Errors[0].Code != "validation_error" {
+		t.Fatalf("errors = %+v, want one validation_error", payload.Errors)
+	}
+	if !strings.Contains(payload.Errors[0].Message, "exactly one of --path, --spec-ref") {
+		t.Fatalf("errors[0].message = %q, want mutex guard message", payload.Errors[0].Message)
+	}
+}
+
 func TestRunReviewSpecWithSpecRefJSON(t *testing.T) {
 	repo := writeSearchWorkspace(t)
 


### PR DESCRIPTION
## Summary

Third in the runCommand migration series (after #325 and #329, both merged). Moves three more commands onto the generic helper:

- **check-spec-freshness** — `--spec-ref`/`--path`/`--request-file` mutex with a BuildRequest-level `--path` + `--spec-ref` guard, default `scope=all`, scope cleared when a specific spec is targeted.
- **check-overlap** — 4-way inline mutex (`--path`/`--spec-ref`/`--spec-record-file`/`--request-file`). BuildRequest resolves `--path` via spec-path, enforces the "exactly one" check via `nonEmptyCount`, and delegates to `overlapRequestFromFlagsContext` for the spec-record-file branch.
- **review-spec** — identical 4-way mutex shape to check-overlap; reuses the same spec-record-file loader through `reviewRequestFromFlags`.

## Addressing prior review

This PR replaces the auto-closed #327 (original base branch was deleted on merge of #329). The review feedback from that round is already in the branch:

- **Copilot/Claude:** missing `--path` + `--spec-ref` mutex in check-spec-freshness → fixed explicitly in BuildRequest.

## Validation

- `make ci` green on top of current main.
- `go test -race ./cmd/...` clean.

## Net delta

-153 LOC across the three commands.

## Test plan

- [ ] CI green
- [ ] `@claude review` passes or findings addressed