### PR TITLE
Polish pass on the runCommand migrations

### DIFF
--- a/cmd/check_overlap.go
+++ b/cmd/check_overlap.go
@@ -34,9 +34,8 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 			Name:  "check-overlap",
 			Usage: "pituitary [--config PATH] check-overlap (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]",
 			Options: commandRunOptions{
-				RequestFile:    true,
-				ConfigForFile:  true,
-				ConfigForFlags: true,
+				RequestFile:   true,
+				ConfigForFile: true,
 			},
 			BindFlags: func(fs *flag.FlagSet) {
 				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
@@ -55,12 +54,24 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.OverlapRequest, error) {
+			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string) (analysis.OverlapRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)
 				trimmedRecord := strings.TrimSpace(specRecordFile)
 				if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRecord) > 1 {
-					return analysis.OverlapRequest{}, fmt.Errorf("exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed")
+					return analysis.OverlapRequest{}, fmt.Errorf("exactly one of --path, --spec-ref, or --spec-record-file is allowed")
+				}
+				var (
+					cfg           *config.Config
+					workspaceRoot string
+				)
+				if trimmedSpecPath != "" || trimmedRecord != "" {
+					loaded, cfgErr := config.Load(resolvedConfigPath)
+					if cfgErr != nil {
+						return analysis.OverlapRequest{}, configLoadError(cfgErr)
+					}
+					cfg = loaded
+					workspaceRoot = cfg.Workspace.RootPath
 				}
 				if trimmedSpecPath != "" {
 					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
@@ -69,7 +80,7 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 					}
 					trimmedSpecRef = resolved
 				}
-				return overlapRequestFromFlagsContext(cfg.Workspace.RootPath, trimmedSpecRef, trimmedRecord)
+				return overlapRequestFromFlagsContext(workspaceRoot, trimmedSpecRef, trimmedRecord)
 			},
 			Execute: func(ctx context.Context, cfgPath string, req analysis.OverlapRequest) (analysis.OverlapRequest, *analysis.OverlapResult, *app.Issue) {
 				op := app.CheckOverlap(ctx, cfgPath, req)

--- a/cmd/check_terminology.go
+++ b/cmd/check_terminology.go
@@ -55,8 +55,8 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 				fs.StringVar(&scope, "scope", "all", "artifact scope: all, docs, or specs")
 			},
 			InlineFlagsSet: func(fs *flag.FlagSet) bool {
-				return countNonEmptyStrings(terms) > 0 ||
-					countNonEmptyStrings(canonicalTerms) > 0 ||
+				return countNonEmptyStrings([]string(terms)) > 0 ||
+					countNonEmptyStrings([]string(canonicalTerms)) > 0 ||
 					strings.TrimSpace(specRef) != "" ||
 					strings.TrimSpace(specPath) != "" ||
 					flagWasSet(fs, "scope")

--- a/cmd/review_spec.go
+++ b/cmd/review_spec.go
@@ -29,9 +29,8 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 			Name:  "review-spec",
 			Usage: "pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]",
 			Options: commandRunOptions{
-				RequestFile:    true,
-				ConfigForFile:  true,
-				ConfigForFlags: true,
+				RequestFile:   true,
+				ConfigForFile: true,
 			},
 			BindFlags: func(fs *flag.FlagSet) {
 				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
@@ -50,12 +49,24 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.ReviewRequest, error) {
+			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string) (analysis.ReviewRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)
 				trimmedRecord := strings.TrimSpace(specRecordFile)
 				if nonEmptyCount(trimmedSpecRef, trimmedSpecPath, trimmedRecord) > 1 {
-					return analysis.ReviewRequest{}, fmt.Errorf("exactly one of --path, --spec-ref, --spec-record-file, or --request-file is allowed")
+					return analysis.ReviewRequest{}, fmt.Errorf("exactly one of --path, --spec-ref, or --spec-record-file is allowed")
+				}
+				var (
+					cfg           *config.Config
+					workspaceRoot string
+				)
+				if trimmedSpecPath != "" || trimmedRecord != "" {
+					loaded, cfgErr := config.Load(resolvedConfigPath)
+					if cfgErr != nil {
+						return analysis.ReviewRequest{}, configLoadError(cfgErr)
+					}
+					cfg = loaded
+					workspaceRoot = cfg.Workspace.RootPath
 				}
 				if trimmedSpecPath != "" {
 					resolved, err := resolveIndexedSpecRefWithConfigContext(ctx, cfg, trimmedSpecPath)
@@ -64,7 +75,7 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 					}
 					trimmedSpecRef = resolved
 				}
-				return reviewRequestFromFlags(cfg.Workspace.RootPath, trimmedSpecRef, trimmedRecord)
+				return reviewRequestFromFlags(workspaceRoot, trimmedSpecRef, trimmedRecord)
 			},
 			Execute: func(ctx context.Context, cfgPath string, req analysis.ReviewRequest) (analysis.ReviewRequest, *analysis.ReviewResult, *app.Issue) {
 				op := app.ReviewSpec(ctx, cfgPath, req)

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -96,6 +96,16 @@ func (e *cliIssueError) Error() string {
 	return e.issue.Message
 }
 
+// configLoadError wraps a config.Load failure surfaced from a BuildRequest
+// callback so the runner classifies it as a config_error rather than the
+// default validation_error.
+func configLoadError(err error) error {
+	return &cliIssueError{
+		issue:    cliIssue{Code: "config_error", Message: err.Error()},
+		exitCode: 2,
+	}
+}
+
 // asCliIssue unwraps a cliIssueError chain into its (issue, exitCode) pair.
 func asCliIssue(err error) (cliIssue, int, bool) {
 	var wrap *cliIssueError

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -83,7 +84,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 				requestLimit := queryArgs.Limit
 				req.Limit = &requestLimit
 				if req.Query == "" {
-					return req, fmt.Errorf("query is required")
+					return req, errors.New("query is required")
 				}
 				return req, nil
 			},


### PR DESCRIPTION
## Summary

Sweeps the residual non-blocking notes from the four review rounds on #325, #329, #330, and #328 into a single small PR. Nothing here is behaviour-changing on the happy path; the only intentional behaviour change is restoring the pre-refactor lazy config load for check-overlap and review-spec when no selector flag is set.

## What changes

- `cmd/search_specs.go` — `errors.New("query is required")` instead of `fmt.Errorf` (no format verbs were used).
- `cmd/check_terminology.go` — explicit `[]string(terms)` / `[]string(canonicalTerms)` casts in `InlineFlagsSet`, matching the casts already used in `BuildRequest` two lines below.
- `cmd/check_overlap.go` + `cmd/review_spec.go`:
  - BuildRequest mutex message drops the `--request-file` arm (the runner catches that conflict before BuildRequest runs, so the user can't reach this branch with `--request-file` set).
  - `ConfigForFlags: false` + lazy `config.Load` inside BuildRequest — config is only loaded when `--path` or `--spec-record-file` is set, matching pre-refactor behaviour. Users running `check-overlap` or `review-spec` with no flags (a straight-up validation error path) no longer pay a stat/read.
- `cmd/run_command.go` — adds a small `configLoadError` helper so BuildRequest callbacks can return a classified `config_error` through the standard `cliIssueError` channel without restating the wrapping boilerplate. Used by the two lazy-load paths above.

## Intentionally not touched

- **Unconditional `requestFile`/`timings` var declarations in `runCommand`.** Narrowing the scope would break later reads (`withCommandTimings` reads `timings` after the flag registration block). Zero values are correct when the flag isn't registered.
- **`compare_specs` wording: "exactly two --spec-ref or two --path" when the user passed --path.** Pre-existing behaviour; Claude flagged this as "no regression" on #329.

## Validation

- `make ci` green.
- `go test -race ./cmd/...` clean.

## Test plan

- [ ] CI green
- [ ] `@claude review` passes