### PR TITLE
Extend runCommand helper and migrate compile + canonicalize

### DIFF
--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -53,7 +53,7 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.AnalyzeImpactRequest, error) {
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.AnalyzeImpactRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)
 				req := analysis.AnalyzeImpactRequest{
@@ -76,13 +76,13 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 				}
 				return req, nil
 			},
-			Normalize: func(_ context.Context, req analysis.AnalyzeImpactRequest) (analysis.AnalyzeImpactRequest, error) {
+			Normalize: func(_ context.Context, req analysis.AnalyzeImpactRequest, _ string) (analysis.AnalyzeImpactRequest, error) {
 				if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
 					req.AtDate = trimmedAt
 				}
 				return req, nil
 			},
-			Execute: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest) (analysis.AnalyzeImpactRequest, *analysis.AnalyzeImpactResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req analysis.AnalyzeImpactRequest, _ string) (analysis.AnalyzeImpactRequest, *analysis.AnalyzeImpactResult, *app.Issue) {
 				op := app.AnalyzeImpact(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},

--- a/cmd/canonicalize.go
+++ b/cmd/canonicalize.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/analysis"
+	"github.com/dusk-network/pituitary/internal/app"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
 )
@@ -25,76 +26,52 @@ func runCanonicalize(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCanonicalizeContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("canonicalize", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newStandaloneCommandHelp("canonicalize", "pituitary canonicalize --path PATH [--bundle-dir PATH] [--write] [--format FORMAT]")
-
 	var (
 		path      string
 		bundleDir string
 		write     bool
-		format    string
 	)
-	fs.StringVar(&path, "path", "", "workspace-relative or absolute path to a markdown contract")
-	fs.StringVar(&bundleDir, "bundle-dir", "", "bundle directory to preview or write")
-	fs.BoolVar(&write, "write", false, "write the generated bundle")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "canonicalize", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "canonicalize", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-	if err := validateCLIFormat("canonicalize", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "canonicalize", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	if strings.TrimSpace(path) == "" {
-		return writeCLIError(stdout, stderr, format, "canonicalize", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "--path is required",
-		}, 2)
-	}
+	return runCommand[canonicalizeRequest, source.CanonicalizeResult](
+		ctx, args, stdout, stderr,
+		commandRun[canonicalizeRequest, source.CanonicalizeResult]{
+			Name:  "canonicalize",
+			Usage: "pituitary canonicalize --path PATH [--bundle-dir PATH] [--write] [--format FORMAT]",
+			Options: commandRunOptions{
+				Standalone: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&path, "path", "", "workspace-relative or absolute path to a markdown contract")
+				fs.StringVar(&bundleDir, "bundle-dir", "", "bundle directory to preview or write")
+				fs.BoolVar(&write, "write", false, "write the generated bundle")
+			},
+			BuildRequest: func(_ context.Context, _ *config.Config, _ string, _ []string) (canonicalizeRequest, error) {
+				if strings.TrimSpace(path) == "" {
+					return canonicalizeRequest{}, fmt.Errorf("--path is required")
+				}
+				return canonicalizeRequest{
+					Path:      path,
+					BundleDir: strings.TrimSpace(bundleDir),
+					Write:     write,
+				}, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req canonicalizeRequest, _ string) (canonicalizeRequest, *source.CanonicalizeResult, *app.Issue) {
+				// Run semantic metadata inference if runtime.analysis is configured.
+				var metadataInference *source.CanonicalizeInference
+				if cfg, err := config.Load(cfgPath); err == nil {
+					metadataInference = runCanonicalizeInference(ctx, cfg, req.Path)
+				}
 
-	request := canonicalizeRequest{
-		Path:      path,
-		BundleDir: strings.TrimSpace(bundleDir),
-		Write:     write,
-	}
-
-	// Run semantic metadata inference if runtime.analysis is configured.
-	var metadataInference *source.CanonicalizeInference
-	if configPath, err := resolveCommandConfigPath(ctx, ""); err == nil {
-		if cfg, err := config.Load(configPath); err == nil {
-			metadataInference = runCanonicalizeInference(ctx, cfg, request.Path)
-		}
-	}
-
-	result, err := source.CanonicalizeMarkdownContract(source.CanonicalizeOptions{
-		Path:              request.Path,
-		BundleDir:         request.BundleDir,
-		Write:             request.Write,
-		MetadataInference: metadataInference,
-	})
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "canonicalize", request, cliIssue{
-			Code:    "canonicalize_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "canonicalize", request, result, nil)
+				result, err := source.CanonicalizeMarkdownContract(source.CanonicalizeOptions{
+					Path:              req.Path,
+					BundleDir:         req.BundleDir,
+					Write:             req.Write,
+					MetadataInference: metadataInference,
+				})
+				return req, result, plainIssue(err, "canonicalize_error")
+			},
+		},
+	)
 }
 
 // runCanonicalizeInference calls the analysis runtime to infer metadata from

--- a/cmd/check_compliance.go
+++ b/cmd/check_compliance.go
@@ -69,10 +69,10 @@ func runCheckComplianceContext(ctx context.Context, args []string, stdout, stder
 				}
 				return &req, nil
 			},
-			BuildRequest: func(_ context.Context, cfg *config.Config, _ string) (analysis.ComplianceRequest, error) {
+			BuildRequest: func(_ context.Context, cfg *config.Config, _ string, _ []string) (analysis.ComplianceRequest, error) {
 				return complianceRequestFromFlags(cfg.Workspace.RootPath, []string(paths), strings.TrimSpace(diffFile))
 			},
-			Normalize: func(_ context.Context, req analysis.ComplianceRequest) (analysis.ComplianceRequest, error) {
+			Normalize: func(_ context.Context, req analysis.ComplianceRequest, _ string) (analysis.ComplianceRequest, error) {
 				if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
 					req.AtDate = trimmedAt
 				}
@@ -81,7 +81,7 @@ func runCheckComplianceContext(ctx context.Context, args []string, stdout, stder
 				}
 				return req, nil
 			},
-			Execute: func(ctx context.Context, cfgPath string, req analysis.ComplianceRequest) (analysis.ComplianceRequest, *analysis.ComplianceResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req analysis.ComplianceRequest, _ string) (analysis.ComplianceRequest, *analysis.ComplianceResult, *app.Issue) {
 				op := app.CheckCompliance(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},

--- a/cmd/check_doc_drift.go
+++ b/cmd/check_doc_drift.go
@@ -73,7 +73,7 @@ func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr 
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.DocDriftRequest, error) {
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.DocDriftRequest, error) {
 				resolvedDocRefs := append([]string(nil), docRefs...)
 				if len(docPaths) > 0 {
 					resolvedPaths, err := resolveIndexedDocRefsWithConfigContext(ctx, cfg, []string(docPaths))
@@ -84,7 +84,7 @@ func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr 
 				}
 				return docDriftRequestFromFlags(cfg.Workspace.RootPath, resolvedDocRefs, strings.TrimSpace(scope), strings.TrimSpace(diffFile))
 			},
-			Normalize: func(_ context.Context, req analysis.DocDriftRequest) (analysis.DocDriftRequest, error) {
+			Normalize: func(_ context.Context, req analysis.DocDriftRequest, _ string) (analysis.DocDriftRequest, error) {
 				if trimmedAt := strings.TrimSpace(atDate); trimmedAt != "" {
 					req.AtDate = trimmedAt
 				}
@@ -93,7 +93,7 @@ func runCheckDocDriftContext(ctx context.Context, args []string, stdout, stderr 
 				}
 				return req, nil
 			},
-			Execute: func(ctx context.Context, cfgPath string, req analysis.DocDriftRequest) (analysis.DocDriftRequest, *analysis.DocDriftResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req analysis.DocDriftRequest, _ string) (analysis.DocDriftRequest, *analysis.DocDriftResult, *app.Issue) {
 				op := app.CheckDocDrift(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},

--- a/cmd/check_overlap.go
+++ b/cmd/check_overlap.go
@@ -54,7 +54,7 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string) (analysis.OverlapRequest, error) {
+			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string, _ []string) (analysis.OverlapRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)
 				trimmedRecord := strings.TrimSpace(specRecordFile)
@@ -82,7 +82,7 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 				}
 				return overlapRequestFromFlagsContext(workspaceRoot, trimmedSpecRef, trimmedRecord)
 			},
-			Execute: func(ctx context.Context, cfgPath string, req analysis.OverlapRequest) (analysis.OverlapRequest, *analysis.OverlapResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req analysis.OverlapRequest, _ string) (analysis.OverlapRequest, *analysis.OverlapResult, *app.Issue) {
 				op := app.CheckOverlap(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},

--- a/cmd/check_spec_freshness.go
+++ b/cmd/check_spec_freshness.go
@@ -48,7 +48,7 @@ func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, st
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.FreshnessRequest, error) {
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.FreshnessRequest, error) {
 				req := analysis.FreshnessRequest{Scope: strings.TrimSpace(scope)}
 				resolvedSpecRef := strings.TrimSpace(specRef)
 				trimmedPath := strings.TrimSpace(specPath)
@@ -68,7 +68,7 @@ func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, st
 				}
 				return req, nil
 			},
-			Execute: func(ctx context.Context, cfgPath string, req analysis.FreshnessRequest) (analysis.FreshnessRequest, *analysis.FreshnessResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req analysis.FreshnessRequest, _ string) (analysis.FreshnessRequest, *analysis.FreshnessResult, *app.Issue) {
 				op := app.CheckSpecFreshness(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},

--- a/cmd/check_terminology.go
+++ b/cmd/check_terminology.go
@@ -68,7 +68,7 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.TerminologyAuditRequest, error) {
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.TerminologyAuditRequest, error) {
 				req := analysis.TerminologyAuditRequest{
 					Terms:          []string(terms),
 					CanonicalTerms: []string(canonicalTerms),
@@ -88,7 +88,7 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 				}
 				return req, nil
 			},
-			Execute: func(ctx context.Context, cfgPath string, req analysis.TerminologyAuditRequest) (analysis.TerminologyAuditRequest, *analysis.TerminologyAuditResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req analysis.TerminologyAuditRequest, _ string) (analysis.TerminologyAuditRequest, *analysis.TerminologyAuditResult, *app.Issue) {
 				op := app.CheckTerminology(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},

--- a/cmd/compare_specs.go
+++ b/cmd/compare_specs.go
@@ -57,7 +57,7 @@ func runCompareSpecsContext(ctx context.Context, args []string, stdout, stderr i
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string) (analysis.CompareRequest, error) {
+			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.CompareRequest, error) {
 				req := analysis.CompareRequest{}
 				switch {
 				case len(specRefs) > 0 && len(specPaths) > 0:
@@ -73,7 +73,7 @@ func runCompareSpecsContext(ctx context.Context, args []string, stdout, stderr i
 				}
 				return req, nil
 			},
-			Normalize: func(_ context.Context, req analysis.CompareRequest) (analysis.CompareRequest, error) {
+			Normalize: func(_ context.Context, req analysis.CompareRequest, _ string) (analysis.CompareRequest, error) {
 				switch {
 				case req.SpecRecord == nil && len(req.SpecRefs) != 2:
 					return req, fmt.Errorf("exactly two --spec-ref flags or two --path flags are required")
@@ -82,7 +82,7 @@ func runCompareSpecsContext(ctx context.Context, args []string, stdout, stderr i
 				}
 				return req, nil
 			},
-			Execute: func(ctx context.Context, cfgPath string, req analysis.CompareRequest) (analysis.CompareRequest, *analysis.CompareResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req analysis.CompareRequest, _ string) (analysis.CompareRequest, *analysis.CompareResult, *app.Issue) {
 				op := app.CompareSpecs(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},

--- a/cmd/compile.go
+++ b/cmd/compile.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/app"
+	"github.com/dusk-network/pituitary/internal/config"
 )
 
 type compileCLIRequest struct {
-	Scope   string `json:"scope,omitempty"`
-	DryRun  bool   `json:"dry_run,omitempty"`
-	Yes     bool   `json:"yes,omitempty"`
-	Timings bool   `json:"timings,omitempty"`
+	Scope  string `json:"scope,omitempty"`
+	DryRun bool   `json:"dry_run,omitempty"`
+	Yes    bool   `json:"yes,omitempty"`
 }
 
 func runCompile(args []string, stdout, stderr io.Writer) int {
@@ -22,97 +22,58 @@ func runCompile(args []string, stdout, stderr io.Writer) int {
 }
 
 func runCompileContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("compile", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("compile", "pituitary [--config PATH] compile --scope SCOPE [--dry-run] [--yes] [--format FORMAT] [--timings]")
-
 	var (
-		scope      string
-		dryRun     bool
-		yes        bool
-		format     string
-		configPath string
-		timings    bool
+		scope  string
+		dryRun bool
+		yes    bool
 	)
-	fs.StringVar(&scope, "scope", "", "target scope: accepted spec ref or all")
-	fs.BoolVar(&dryRun, "dry-run", false, "plan deterministic edits without writing files")
-	fs.BoolVar(&yes, "yes", false, "apply all planned edits without prompting")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-	fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "compile", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "compile", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-
-	request := compileCLIRequest{
-		Scope:   strings.TrimSpace(scope),
-		DryRun:  dryRun,
-		Yes:     yes,
-		Timings: timings,
-	}
-	if err := validateCLIFormat("compile", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	if request.Scope == "" {
-		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
-			Code:    "validation_error",
-			Message: "--scope is required",
-		}, 2)
-	}
-
-	if format != commandFormatText && !request.DryRun && !request.Yes {
-		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
-			Code:    "validation_error",
-			Message: "non-text compile runs require either --dry-run or --yes",
-		}, 2)
-	}
-
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	apply := request.Yes && !request.DryRun
-
-	// In text mode without --dry-run or --yes, default to dry-run behavior with a hint.
-	if format == commandFormatText && !request.DryRun && !request.Yes {
-		apply = false
-	}
-
-	ctx, tracker, started := withCommandTimings(ctx, timings && format == commandFormatJSON)
-
-	response := app.CompileTerminology(ctx, resolvedConfigPath, app.CompileRequest{
-		Scope: request.Scope,
-		Apply: apply,
-	})
-	if response.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "compile", request, cliIssue{
-			Code:    response.Issue.Code,
-			Message: response.Issue.Message,
-		}, response.Issue.ExitCode)
-	}
-
-	if format == commandFormatText && !request.DryRun && !request.Yes && response.Result != nil {
-		response.Result.Guidance = append(response.Result.Guidance, "Showing planned edits (dry-run). Re-run with --yes to apply.")
-	}
-
-	return writeCLISuccessWithTimings(stdout, stderr, format, "compile", request, response.Result, nil, snapshotCommandTimings(tracker, started))
+	return runCommand[compileCLIRequest, app.CompileResult](
+		ctx, args, stdout, stderr,
+		commandRun[compileCLIRequest, app.CompileResult]{
+			Name:  "compile",
+			Usage: "pituitary [--config PATH] compile --scope SCOPE [--dry-run] [--yes] [--format FORMAT] [--timings]",
+			Options: commandRunOptions{
+				Timings: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&scope, "scope", "", "target scope: accepted spec ref or all")
+				fs.BoolVar(&dryRun, "dry-run", false, "plan deterministic edits without writing files")
+				fs.BoolVar(&yes, "yes", false, "apply all planned edits without prompting")
+			},
+			BuildRequest: func(_ context.Context, _ *config.Config, _ string, _ []string) (compileCLIRequest, error) {
+				req := compileCLIRequest{
+					Scope:  strings.TrimSpace(scope),
+					DryRun: dryRun,
+					Yes:    yes,
+				}
+				if req.Scope == "" {
+					return req, fmt.Errorf("--scope is required")
+				}
+				return req, nil
+			},
+			Normalize: func(_ context.Context, req compileCLIRequest, format string) (compileCLIRequest, error) {
+				if format != commandFormatText && !req.DryRun && !req.Yes {
+					return req, fmt.Errorf("non-text compile runs require either --dry-run or --yes")
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req compileCLIRequest, format string) (compileCLIRequest, *app.CompileResult, *app.Issue) {
+				apply := req.Yes && !req.DryRun
+				// In text mode without --dry-run or --yes, default to dry-run behavior with a hint.
+				if format == commandFormatText && !req.DryRun && !req.Yes {
+					apply = false
+				}
+				response := app.CompileTerminology(ctx, cfgPath, app.CompileRequest{
+					Scope: req.Scope,
+					Apply: apply,
+				})
+				result := response.Result
+				if response.Issue == nil && format == commandFormatText && !req.DryRun && !req.Yes && result != nil {
+					result.Guidance = append(result.Guidance, "Showing planned edits (dry-run). Re-run with --yes to apply.")
+				}
+				return req, result, response.Issue
+			},
+		},
+	)
 }

--- a/cmd/compile.go
+++ b/cmd/compile.go
@@ -59,11 +59,9 @@ func runCompileContext(ctx context.Context, args []string, stdout, stderr io.Wri
 				return req, nil
 			},
 			Execute: func(ctx context.Context, cfgPath string, req compileCLIRequest, format string) (compileCLIRequest, *app.CompileResult, *app.Issue) {
+				// Normalize already gates non-text runs that lack both flags,
+				// so text-mode without --yes is the dry-run default.
 				apply := req.Yes && !req.DryRun
-				// In text mode without --dry-run or --yes, default to dry-run behavior with a hint.
-				if format == commandFormatText && !req.DryRun && !req.Yes {
-					apply = false
-				}
 				response := app.CompileTerminology(ctx, cfgPath, app.CompileRequest{
 					Scope: req.Scope,
 					Apply: apply,

--- a/cmd/compile_test.go
+++ b/cmd/compile_test.go
@@ -313,9 +313,6 @@ func TestRunCompileJSONIncludesTimings(t *testing.T) {
 	}
 
 	var payload struct {
-		Request struct {
-			Timings bool `json:"timings"`
-		} `json:"request"`
 		Timings struct {
 			TotalMS        int64 `json:"total_ms"`
 			IndexingMS     int64 `json:"indexing_ms"`
@@ -328,9 +325,6 @@ func TestRunCompileJSONIncludesTimings(t *testing.T) {
 	}
 	if len(payload.Errors) != 0 {
 		t.Fatalf("errors = %+v, want none", payload.Errors)
-	}
-	if !payload.Request.Timings {
-		t.Fatalf("request.timings = false, want true")
 	}
 	if payload.Timings.TotalMS <= 0 || payload.Timings.IndexingMS <= 0 {
 		t.Fatalf("timings = %+v, want total/indexing timing metadata", payload.Timings)

--- a/cmd/review_spec.go
+++ b/cmd/review_spec.go
@@ -49,7 +49,7 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 				}
 				return &req, nil
 			},
-			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string) (analysis.ReviewRequest, error) {
+			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string, _ []string) (analysis.ReviewRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)
 				trimmedRecord := strings.TrimSpace(specRecordFile)
@@ -77,7 +77,7 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 				}
 				return reviewRequestFromFlags(workspaceRoot, trimmedSpecRef, trimmedRecord)
 			},
-			Execute: func(ctx context.Context, cfgPath string, req analysis.ReviewRequest) (analysis.ReviewRequest, *analysis.ReviewResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req analysis.ReviewRequest, _ string) (analysis.ReviewRequest, *analysis.ReviewResult, *app.Issue) {
 				op := app.ReviewSpec(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -48,17 +48,22 @@ type commandRun[Req any, Res any] struct {
 	LoadRequestFile func(ctx context.Context, cfg *config.Config, trimmedPath string) (*Req, error)
 
 	// BuildRequest builds the request from the inline flags. cfg is non-nil
-	// iff Options.ConfigForFlags is true. Required.
-	BuildRequest func(ctx context.Context, cfg *config.Config, resolvedConfigPath string) (Req, error)
+	// iff Options.ConfigForFlags is true. positional holds any positional args
+	// captured under Options.ExactPositional. Required.
+	BuildRequest func(ctx context.Context, cfg *config.Config, resolvedConfigPath string, positional []string) (Req, error)
 
 	// Normalize (optional) runs after the request is composed, before Execute,
 	// and fires for both the --request-file path and the inline-flags path.
-	// On error, the runner writes the returned Req into the envelope, so
-	// Normalize can return a pre- or post-normalize request as appropriate.
-	Normalize func(ctx context.Context, req Req) (Req, error)
+	// format is the resolved output format so Normalize can reject
+	// format-incompatible request shapes. On error, the runner writes the
+	// returned Req into the envelope, so Normalize can return a pre- or
+	// post-normalize request as appropriate.
+	Normalize func(ctx context.Context, req Req, format string) (Req, error)
 
-	// Execute calls the app layer. Required.
-	Execute func(ctx context.Context, resolvedConfigPath string, req Req) (Req, *Res, *app.Issue)
+	// Execute calls the app layer. format is the resolved output format so
+	// Execute can dispatch on it (e.g. for interactive text-mode paths).
+	// Required.
+	Execute func(ctx context.Context, resolvedConfigPath string, req Req, format string) (Req, *Res, *app.Issue)
 
 	// PostProcess (optional) runs after Execute succeeds. When it returns a
 	// non-nil cliIssue, the runner writes it with the returned exit code. An
@@ -75,8 +80,18 @@ type commandRunOptions struct {
 	RequestFile bool
 	// Timings enables the --timings flag (JSON-only timing metadata).
 	Timings bool
-	// AcceptsPositional, when false (default), rejects fs.NArg() != 0.
+	// AcceptsPositional, when false (default), rejects fs.NArg() != 0 unless
+	// ExactPositional is set.
 	AcceptsPositional bool
+	// ExactPositional, when > 0, requires exactly that many positional
+	// arguments. Mutually exclusive with AcceptsPositional; takes precedence
+	// when both are set. The captured args are passed to BuildRequest.
+	ExactPositional int
+	// Standalone, when true, disables the shared --config flag and omits the
+	// "shared config resolution" help line. The resolved config path is still
+	// computed from the project default, so Execute callbacks can load a
+	// config opportunistically when present.
+	Standalone bool
 	// ConfigForFlags loads config before calling BuildRequest.
 	ConfigForFlags bool
 	// ConfigForFile loads config before calling LoadRequestFile.
@@ -103,6 +118,20 @@ func configLoadError(err error) error {
 	return &cliIssueError{
 		issue:    cliIssue{Code: "config_error", Message: err.Error()},
 		exitCode: 2,
+	}
+}
+
+// plainIssue wraps a bare error as an *app.Issue with the given code and a
+// default exit code of 2. Returns nil when err is nil, so Execute callbacks
+// can pipe `return req, nil, plainIssue(err, "foo_error")` without a branch.
+func plainIssue(err error, code string) *app.Issue {
+	if err == nil {
+		return nil
+	}
+	return &app.Issue{
+		Code:     code,
+		Message:  err.Error(),
+		ExitCode: 2,
 	}
 }
 
@@ -138,7 +167,12 @@ func runCommand[Req any, Res any](
 	}
 	fs := flag.NewFlagSet(plan.Name, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	help := newCommandHelp(plan.Name, plan.Usage)
+	var help commandHelp
+	if plan.Options.Standalone {
+		help = newStandaloneCommandHelp(plan.Name, plan.Usage)
+	} else {
+		help = newCommandHelp(plan.Name, plan.Usage)
+	}
 
 	var (
 		configPath  string
@@ -147,7 +181,9 @@ func runCommand[Req any, Res any](
 		requestFile string
 	)
 	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
+	if !plan.Options.Standalone {
+		fs.StringVar(&configPath, "config", "", "path to workspace config")
+	}
 	if plan.Options.Timings {
 		fs.BoolVar(&timings, "timings", false, "include timing metadata in JSON output")
 	}
@@ -167,12 +203,23 @@ func runCommand[Req any, Res any](
 		return 0
 	}
 
-	if !plan.Options.AcceptsPositional && fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
+	switch {
+	case plan.Options.ExactPositional > 0:
+		if fs.NArg() != plan.Options.ExactPositional {
+			return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+				Code:    "validation_error",
+				Message: fmt.Sprintf("exactly %d positional argument(s) required", plan.Options.ExactPositional),
+			}, 2)
+		}
+	case !plan.Options.AcceptsPositional:
+		if fs.NArg() != 0 {
+			return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+				Code:    "validation_error",
+				Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
+			}, 2)
+		}
 	}
+	positional := fs.Args()
 
 	if err := validateCLIFormat(plan.Name, format); err != nil {
 		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
@@ -183,10 +230,15 @@ func runCommand[Req any, Res any](
 
 	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
 	if err != nil {
-		return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
+		// Standalone commands tolerate a missing workspace config; callbacks
+		// that can opportunistically use a config must handle an empty path.
+		if !plan.Options.Standalone {
+			return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
+				Code:    "config_error",
+				Message: err.Error(),
+			}, 2)
+		}
+		resolvedConfigPath = ""
 	}
 
 	trimmedRequestFile := strings.TrimSpace(requestFile)
@@ -245,7 +297,7 @@ func runCommand[Req any, Res any](
 			}
 			cfg = loaded
 		}
-		request, err = plan.BuildRequest(ctx, cfg, resolvedConfigPath)
+		request, err = plan.BuildRequest(ctx, cfg, resolvedConfigPath, positional)
 		if err != nil {
 			if issue, exitCode, ok := asCliIssue(err); ok {
 				return writeCLIError(stdout, stderr, format, plan.Name, nil, issue, exitCode)
@@ -258,7 +310,7 @@ func runCommand[Req any, Res any](
 	}
 
 	if plan.Normalize != nil {
-		normalized, normErr := plan.Normalize(ctx, request)
+		normalized, normErr := plan.Normalize(ctx, request, format)
 		if normErr != nil {
 			if issue, exitCode, ok := asCliIssue(normErr); ok {
 				return writeCLIError(stdout, stderr, format, plan.Name, normalized, issue, exitCode)
@@ -273,7 +325,7 @@ func runCommand[Req any, Res any](
 
 	execCtx, tracker, started := withCommandTimings(ctx, plan.Options.Timings && timings && format == commandFormatJSON)
 
-	enrichedReq, result, issue := plan.Execute(execCtx, resolvedConfigPath, request)
+	enrichedReq, result, issue := plan.Execute(execCtx, resolvedConfigPath, request, format)
 	if issue != nil {
 		return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, cliIssueFromAppIssue(issue), issue.ExitCode)
 	}

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -48,8 +48,10 @@ type commandRun[Req any, Res any] struct {
 	LoadRequestFile func(ctx context.Context, cfg *config.Config, trimmedPath string) (*Req, error)
 
 	// BuildRequest builds the request from the inline flags. cfg is non-nil
-	// iff Options.ConfigForFlags is true. positional holds any positional args
-	// captured under Options.ExactPositional. Required.
+	// iff Options.ConfigForFlags is true. positional holds all remaining
+	// positional args after flag parsing; Options.ExactPositional and
+	// Options.AcceptsPositional only constrain how many are allowed.
+	// Required.
 	BuildRequest func(ctx context.Context, cfg *config.Config, resolvedConfigPath string, positional []string) (Req, error)
 
 	// Normalize (optional) runs after the request is composed, before Execute,
@@ -84,8 +86,8 @@ type commandRunOptions struct {
 	// ExactPositional is set.
 	AcceptsPositional bool
 	// ExactPositional, when > 0, requires exactly that many positional
-	// arguments. Mutually exclusive with AcceptsPositional; takes precedence
-	// when both are set. The captured args are passed to BuildRequest.
+	// arguments and takes precedence over AcceptsPositional when both are
+	// set. The captured args are passed to BuildRequest.
 	ExactPositional int
 	// Standalone, when true, disables the shared --config flag and omits the
 	// "shared config resolution" help line. The resolved config path is still

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -63,7 +63,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 				}
 				return &req, nil
 			},
-			BuildRequest: func(_ context.Context, _ *config.Config, _ string) (index.SearchSpecRequest, error) {
+			BuildRequest: func(_ context.Context, _ *config.Config, _ string, _ []string) (index.SearchSpecRequest, error) {
 				return index.SearchSpecRequest{
 					Query: strings.TrimSpace(query),
 					Filters: index.SearchSpecFilters{
@@ -73,7 +73,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 					Limit: &limit,
 				}, nil
 			},
-			Normalize: func(_ context.Context, req index.SearchSpecRequest) (index.SearchSpecRequest, error) {
+			Normalize: func(_ context.Context, req index.SearchSpecRequest, _ string) (index.SearchSpecRequest, error) {
 				queryArgs, err := req.ToQuery()
 				if err != nil {
 					return req, err
@@ -88,7 +88,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 				}
 				return req, nil
 			},
-			Execute: func(ctx context.Context, cfgPath string, req index.SearchSpecRequest) (index.SearchSpecRequest, *index.SearchSpecResult, *app.Issue) {
+			Execute: func(ctx context.Context, cfgPath string, req index.SearchSpecRequest, _ string) (index.SearchSpecRequest, *index.SearchSpecResult, *app.Issue) {
 				op := app.SearchSpecs(ctx, cfgPath, req)
 				return op.Request, op.Result, op.Issue
 			},


### PR DESCRIPTION
## Summary
- Extend `runCommand` with three capabilities needed by the remaining CLI migrations: format-aware `Normalize`/`Execute`, an `ExactPositional` count, and a `Standalone` mode that skips the shared `--config` flag.
- Add a `plainIssue(err, code)` helper so `Execute` can surface bare errors as classified `*app.Issue` values without a branch.
- Migrate `compile` onto the runner — format-aware validation now lives in `Normalize`.
- Migrate `canonicalize` onto the runner in `Standalone` mode via `plainIssue`.

All 9 existing call sites gain `_ []string` / `_ string` placeholders to match the new hook signatures; no behavioral change for them.

The `Timings` field is removed from the `compile` request envelope (the runner owns `--timings` and emits the top-level `timings` block directly, matching every other migrated command).

## Test plan
- [x] `make fmt`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./cmd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)