### PR TITLE
Migrate migrate-config and explain-file to runCommand

### DIFF
--- a/cmd/explain_file.go
+++ b/cmd/explain_file.go
@@ -29,7 +29,6 @@ func runExplainFileContext(ctx context.Context, args []string, stdout, stderr io
 			Usage: "pituitary [--config PATH] explain-file PATH [--format FORMAT]",
 			Options: commandRunOptions{
 				ExactPositional: 1,
-				ConfigForFlags:  true,
 			},
 			BuildRequest: func(_ context.Context, _ *config.Config, _ string, positional []string) (explainFileRequest, error) {
 				return explainFileRequest{Path: positional[0]}, nil

--- a/cmd/explain_file.go
+++ b/cmd/explain_file.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/dusk-network/pituitary/internal/app"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
 )
@@ -22,75 +22,43 @@ func runExplainFile(args []string, stdout, stderr io.Writer) int {
 }
 
 func runExplainFileContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	args = reorderExplainFileArgs(args)
-
-	fs := flag.NewFlagSet("explain-file", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("explain-file", "pituitary [--config PATH] explain-file PATH [--format FORMAT]")
-
-	var (
-		format     string
-		configPath string
+	return runCommand[explainFileRequest, source.ExplainFileResult](
+		ctx, reorderExplainFileArgs(args), stdout, stderr,
+		commandRun[explainFileRequest, source.ExplainFileResult]{
+			Name:  "explain-file",
+			Usage: "pituitary [--config PATH] explain-file PATH [--format FORMAT]",
+			Options: commandRunOptions{
+				ExactPositional: 1,
+				ConfigForFlags:  true,
+			},
+			BuildRequest: func(_ context.Context, _ *config.Config, _ string, positional []string) (explainFileRequest, error) {
+				return explainFileRequest{Path: positional[0]}, nil
+			},
+			Execute: func(_ context.Context, cfgPath string, req explainFileRequest, _ string) (explainFileRequest, *source.ExplainFileResult, *app.Issue) {
+				cfg, err := config.Load(cfgPath)
+				if err != nil {
+					return req, nil, &app.Issue{
+						Code:     "config_error",
+						Message:  "invalid config:\n" + err.Error(),
+						ExitCode: 2,
+					}
+				}
+				targetPath, err := resolveExplainPath(cfg, req.Path)
+				if err != nil {
+					return req, nil, plainIssue(err, "validation_error")
+				}
+				result, err := source.ExplainFile(cfg, targetPath)
+				if err != nil {
+					return req, nil, &app.Issue{
+						Code:     "source_error",
+						Message:  "file explanation failed:\n" + err.Error(),
+						ExitCode: 2,
+					}
+				}
+				return req, result, nil
+			},
+		},
 	)
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
-
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "explain-file", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if err := validateCLIFormat("explain-file", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "explain-file", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	if fs.NArg() != 1 {
-		return writeCLIError(stdout, stderr, format, "explain-file", nil, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one file path is required",
-		}, 2)
-	}
-
-	request := explainFileRequest{Path: fs.Arg(0)}
-
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "explain-file", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	cfg, err := config.Load(resolvedConfigPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "explain-file", request, cliIssue{
-			Code:    "config_error",
-			Message: "invalid config:\n" + err.Error(),
-		}, 2)
-	}
-
-	targetPath, err := resolveExplainPath(cfg, request.Path)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "explain-file", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	result, err := source.ExplainFile(cfg, targetPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "explain-file", request, cliIssue{
-			Code:    "source_error",
-			Message: "file explanation failed:\n" + err.Error(),
-		}, 2)
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "explain-file", request, result, nil)
 }
 
 func reorderExplainFileArgs(args []string) []string {

--- a/cmd/migrate_config.go
+++ b/cmd/migrate_config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dusk-network/pituitary/internal/app"
 	"github.com/dusk-network/pituitary/internal/config"
 )
 
@@ -29,80 +30,58 @@ func runMigrateConfig(args []string, stdout, stderr io.Writer) int {
 	return runMigrateConfigContext(context.Background(), args, stdout, stderr)
 }
 
-func runMigrateConfigContext(_ context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("migrate-config", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newStandaloneCommandHelp("migrate-config", "pituitary migrate-config [--path PATH] [--write] [--format FORMAT]")
-
+func runMigrateConfigContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	var (
-		path   string
-		write  bool
-		format string
+		path  string
+		write bool
 	)
-	fs.StringVar(&path, "path", defaultConfigName, "path to the config file to migrate")
-	fs.BoolVar(&write, "write", false, "rewrite the config in place")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "migrate-config", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "migrate-config", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
-	if err := validateCLIFormat("migrate-config", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "migrate-config", migrateConfigRequest{Path: path, Write: write}, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	request := migrateConfigRequest{
-		Path:  strings.TrimSpace(path),
-		Write: write,
-	}
-	if request.Path == "" {
-		request.Path = defaultConfigName
-	}
-
-	migration, err := config.MigrateFile(request.Path)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "migrate-config", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	rendered, err := config.Render(migration.Config)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "migrate-config", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
-
-	if write {
-		// #nosec G306 -- migrated config files are normal repo files intended to remain readable by standard tooling.
-		if err := os.WriteFile(migration.Config.ConfigPath, []byte(rendered), 0o644); err != nil {
-			return writeCLIError(stdout, stderr, format, "migrate-config", request, cliIssue{
-				Code:    "config_error",
-				Message: fmt.Sprintf("write migrated config: %v", err),
-			}, 2)
-		}
-	}
-
-	return writeCLISuccess(stdout, stderr, format, "migrate-config", request, &migrateConfigResult{
-		ConfigPath:          migration.Config.ConfigPath,
-		DetectedSchema:      migration.DetectedSchema,
-		TargetSchemaVersion: config.CurrentSchemaVersion,
-		WroteConfig:         write,
-		Notes:               migration.Notes,
-		Config:              rendered,
-	}, nil)
+	return runCommand[migrateConfigRequest, migrateConfigResult](
+		ctx, args, stdout, stderr,
+		commandRun[migrateConfigRequest, migrateConfigResult]{
+			Name:  "migrate-config",
+			Usage: "pituitary migrate-config [--path PATH] [--write] [--format FORMAT]",
+			Options: commandRunOptions{
+				Standalone: true,
+			},
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&path, "path", defaultConfigName, "path to the config file to migrate")
+				fs.BoolVar(&write, "write", false, "rewrite the config in place")
+			},
+			BuildRequest: func(_ context.Context, _ *config.Config, _ string, _ []string) (migrateConfigRequest, error) {
+				trimmedPath := strings.TrimSpace(path)
+				if trimmedPath == "" {
+					trimmedPath = defaultConfigName
+				}
+				return migrateConfigRequest{
+					Path:  trimmedPath,
+					Write: write,
+				}, nil
+			},
+			Execute: func(_ context.Context, _ string, req migrateConfigRequest, _ string) (migrateConfigRequest, *migrateConfigResult, *app.Issue) {
+				migration, err := config.MigrateFile(req.Path)
+				if err != nil {
+					return req, nil, plainIssue(err, "config_error")
+				}
+				rendered, err := config.Render(migration.Config)
+				if err != nil {
+					return req, nil, plainIssue(err, "config_error")
+				}
+				if req.Write {
+					// #nosec G306 -- migrated config files are normal repo files intended to remain readable by standard tooling.
+					if err := os.WriteFile(migration.Config.ConfigPath, []byte(rendered), 0o644); err != nil {
+						return req, nil, plainIssue(fmt.Errorf("write migrated config: %w", err), "config_error")
+					}
+				}
+				return req, &migrateConfigResult{
+					ConfigPath:          migration.Config.ConfigPath,
+					DetectedSchema:      migration.DetectedSchema,
+					TargetSchemaVersion: config.CurrentSchemaVersion,
+					WroteConfig:         req.Write,
+					Notes:               migration.Notes,
+					Config:              rendered,
+				}, nil
+			},
+		},
+	)
 }


### PR DESCRIPTION
## Summary
- Migrate `migrate-config` onto the shared runner using `Standalone` mode. Bare `config.MigrateFile` / `config.Render` / `os.WriteFile` errors surface through `plainIssue("config_error")`.
- Migrate `explain-file` onto the shared runner using `ExactPositional: 1` for the required path argument. `reorderExplainFileArgs` is preserved verbatim so the positional can appear in any order relative to flags.

Behavior preserved. The runner now owns flag parsing, help rendering, format validation, and config-path resolution for both; callbacks handle only the migration/explain work.

## Test plan
- [x] `make fmt`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./cmd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)