### PR TITLE
Migrate fix to runCommand

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -50,7 +50,10 @@ func runFixContext(ctx context.Context, args []string, stdout, stderr io.Writer)
 					DryRun: dryRun,
 					Yes:    yes,
 				}
-				if (req.Path == "") == (req.Scope == "") {
+				if req.Path == "" && req.Scope == "" {
+					return req, fmt.Errorf("exactly one of --path or --scope is required")
+				}
+				if req.Path != "" && req.Scope != "" {
 					return req, fmt.Errorf("exactly one of --path or --scope is required")
 				}
 				return req, nil
@@ -91,8 +94,10 @@ func runFixContext(ctx context.Context, args []string, stdout, stderr io.Writer)
 				}
 				plan := planResponse.Result
 				if plan == nil {
-					// Preserve the original "return 0 with no output" outcome
-					// without crashing the typed-nil renderer branch.
+					// Return an empty result to avoid crashing the typed-nil
+					// renderer branch; the "no deterministic doc-drift edits
+					// available" line is the strict edge-case improvement
+					// over the original silent zero exit.
 					return req, &app.FixResult{}, nil
 				}
 

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/app"
+	"github.com/dusk-network/pituitary/internal/config"
 )
 
 type fixCLIRequest struct {
@@ -24,151 +25,104 @@ func runFix(args []string, stdout, stderr io.Writer) int {
 }
 
 func runFixContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("fix", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	help := newCommandHelp("fix", "pituitary [--config PATH] fix (--path PATH | --scope VALUE) [--dry-run] [--yes] [--format FORMAT]")
-
 	var (
-		path       string
-		scope      string
-		dryRun     bool
-		yes        bool
-		format     string
-		configPath string
+		path   string
+		scope  string
+		dryRun bool
+		yes    bool
 	)
-	fs.StringVar(&path, "path", "", "target doc path to remediate")
-	fs.StringVar(&scope, "scope", "", "target scope: accepted spec ref or all")
-	fs.BoolVar(&dryRun, "dry-run", false, "plan deterministic edits without writing files")
-	fs.BoolVar(&yes, "yes", false, "apply all planned edits without prompting")
-	fs.StringVar(&format, "format", defaultCommandFormatForWriter(stdout, commandFormatText), "output format")
-	fs.StringVar(&configPath, "config", "", "path to workspace config")
 
-	if handled, err := parseCommandFlags(fs, args, stdout, help); err != nil {
-		return writeCLIError(stdout, stderr, format, "fix", nil, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	} else if handled {
-		return 0
-	}
-	if fs.NArg() != 0 {
-		return writeCLIError(stdout, stderr, format, "fix", nil, cliIssue{
-			Code:    "validation_error",
-			Message: fmt.Sprintf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")),
-		}, 2)
-	}
+	return runCommand[fixCLIRequest, app.FixResult](
+		ctx, args, stdout, stderr,
+		commandRun[fixCLIRequest, app.FixResult]{
+			Name:  "fix",
+			Usage: "pituitary [--config PATH] fix (--path PATH | --scope VALUE) [--dry-run] [--yes] [--format FORMAT]",
+			BindFlags: func(fs *flag.FlagSet) {
+				fs.StringVar(&path, "path", "", "target doc path to remediate")
+				fs.StringVar(&scope, "scope", "", "target scope: accepted spec ref or all")
+				fs.BoolVar(&dryRun, "dry-run", false, "plan deterministic edits without writing files")
+				fs.BoolVar(&yes, "yes", false, "apply all planned edits without prompting")
+			},
+			BuildRequest: func(_ context.Context, _ *config.Config, _ string, _ []string) (fixCLIRequest, error) {
+				req := fixCLIRequest{
+					Path:   strings.TrimSpace(path),
+					Scope:  strings.TrimSpace(scope),
+					DryRun: dryRun,
+					Yes:    yes,
+				}
+				if (req.Path == "") == (req.Scope == "") {
+					return req, fmt.Errorf("exactly one of --path or --scope is required")
+				}
+				return req, nil
+			},
+			Normalize: func(_ context.Context, req fixCLIRequest, format string) (fixCLIRequest, error) {
+				if format != commandFormatText && !req.DryRun && !req.Yes {
+					return req, fmt.Errorf("non-text fix runs require either --dry-run or --yes")
+				}
+				return req, nil
+			},
+			Execute: func(ctx context.Context, cfgPath string, req fixCLIRequest, format string) (fixCLIRequest, *app.FixResult, *app.Issue) {
+				// Non-interactive path: a single FixDocDrift call carries the run.
+				if req.DryRun || req.Yes || format != commandFormatText {
+					response := app.FixDocDrift(ctx, cfgPath, app.FixRequest{
+						Path:  req.Path,
+						Scope: req.Scope,
+						Apply: req.Yes && !req.DryRun,
+					})
+					return req, response.Result, response.Issue
+				}
 
-	request := fixCLIRequest{
-		Path:   strings.TrimSpace(path),
-		Scope:  strings.TrimSpace(scope),
-		DryRun: dryRun,
-		Yes:    yes,
-	}
-	if err := validateCLIFormat("fix", format); err != nil {
-		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-			Code:    "validation_error",
-			Message: err.Error(),
-		}, 2)
-	}
-	if request.Path == "" && request.Scope == "" {
-		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --path or --scope is required",
-		}, 2)
-	}
-	if request.Path != "" && request.Scope != "" {
-		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-			Code:    "validation_error",
-			Message: "exactly one of --path or --scope is required",
-		}, 2)
-	}
+				// Interactive text path: plan → prompt per file → apply selected.
+				if !stdinIsTTY() {
+					return req, nil, &app.Issue{
+						Code:     "validation_error",
+						Message:  "interactive fix confirmation requires a TTY; rerun with --yes or --dry-run",
+						ExitCode: 2,
+					}
+				}
 
-	if format != commandFormatText && !request.DryRun && !request.Yes {
-		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-			Code:    "validation_error",
-			Message: "non-text fix runs require either --dry-run or --yes",
-		}, 2)
-	}
+				planResponse := app.FixDocDrift(ctx, cfgPath, app.FixRequest{
+					Path:  req.Path,
+					Scope: req.Scope,
+					Apply: false,
+				})
+				if planResponse.Issue != nil {
+					return req, nil, planResponse.Issue
+				}
+				plan := planResponse.Result
+				if plan == nil {
+					// Preserve the original "return 0 with no output" outcome
+					// without crashing the typed-nil renderer branch.
+					return req, &app.FixResult{}, nil
+				}
 
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
-	if err != nil {
-		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
-	}
+				selectedDocRefs := make([]string, 0, len(plan.Files))
+				for _, file := range plan.Files {
+					renderFixPromptFile(stdout, plan.Selector, file)
+					applyFile, err := promptFixConfirmation(stdout, func() {
+						fmt.Fprintln(stdout)
+						renderFixPromptFile(stdout, plan.Selector, file)
+					})
+					if err != nil {
+						return req, nil, plainIssue(err, "validation_error")
+					}
+					if applyFile {
+						selectedDocRefs = append(selectedDocRefs, file.DocRef)
+					}
+				}
+				if len(selectedDocRefs) == 0 {
+					plan.Guidance = append(plan.Guidance, "No files selected; nothing was changed.")
+					return req, plan, nil
+				}
 
-	if request.DryRun || request.Yes || format != commandFormatText {
-		response := app.FixDocDrift(ctx, resolvedConfigPath, app.FixRequest{
-			Path:  request.Path,
-			Scope: request.Scope,
-			Apply: request.Yes && !request.DryRun,
-		})
-		if response.Issue != nil {
-			return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-				Code:    response.Issue.Code,
-				Message: response.Issue.Message,
-			}, response.Issue.ExitCode)
-		}
-		return writeCLISuccess(stdout, stderr, format, "fix", request, response.Result, nil)
-	}
-
-	if !stdinIsTTY() {
-		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-			Code:    "validation_error",
-			Message: "interactive fix confirmation requires a TTY; rerun with --yes or --dry-run",
-		}, 2)
-	}
-
-	planResponse := app.FixDocDrift(ctx, resolvedConfigPath, app.FixRequest{
-		Path:  request.Path,
-		Scope: request.Scope,
-		Apply: false,
-	})
-	if planResponse.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-			Code:    planResponse.Issue.Code,
-			Message: planResponse.Issue.Message,
-		}, planResponse.Issue.ExitCode)
-	}
-	plan := planResponse.Result
-	if plan == nil {
-		return 0
-	}
-
-	selectedDocRefs := make([]string, 0, len(plan.Files))
-	for _, file := range plan.Files {
-		renderFixPromptFile(stdout, plan.Selector, file)
-		applyFile, err := promptFixConfirmation(stdout, func() {
-			fmt.Fprintln(stdout)
-			renderFixPromptFile(stdout, plan.Selector, file)
-		})
-		if err != nil {
-			return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-				Code:    "validation_error",
-				Message: err.Error(),
-			}, 2)
-		}
-		if applyFile {
-			selectedDocRefs = append(selectedDocRefs, file.DocRef)
-		}
-	}
-	if len(selectedDocRefs) == 0 {
-		plan.Guidance = append(plan.Guidance, "No files selected; nothing was changed.")
-		return writeCLISuccess(stdout, stderr, format, "fix", request, plan, nil)
-	}
-
-	applyResponse := app.FixDocDrift(ctx, resolvedConfigPath, app.FixRequest{
-		DocRefs: selectedDocRefs,
-		Apply:   true,
-	})
-	if applyResponse.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "fix", request, cliIssue{
-			Code:    applyResponse.Issue.Code,
-			Message: applyResponse.Issue.Message,
-		}, applyResponse.Issue.ExitCode)
-	}
-	return writeCLISuccess(stdout, stderr, format, "fix", request, applyResponse.Result, nil)
+				applyResponse := app.FixDocDrift(ctx, cfgPath, app.FixRequest{
+					DocRefs: selectedDocRefs,
+					Apply:   true,
+				})
+				return req, applyResponse.Result, applyResponse.Issue
+			},
+		},
+	)
 }
 
 func stdinIsTTY() bool {


### PR DESCRIPTION
## Summary
- Migrate `fix` onto the shared runner, completing the five-command migration plan (PRs #328, #329, #330, #331, #332, #333).
- The interactive TTY path is the delicate case: plan → per-file prompt on stdout → apply selected. The `Execute` callback is defined inline so it closes over `stdout`/`stderr` and performs the full loop while still reporting through the runner's `(request, *result, *issue)` contract.
- Non-interactive paths (`--dry-run`, `--yes`, or non-text format) collapse to a single `FixDocDrift` call.
- Format-aware "non-text fix runs require either --dry-run or --yes" check moves into `Normalize`.
- TTY rejection surfaces as an `*app.Issue` so the runner writes "requires a TTY" guidance to stderr in text mode, preserving existing behavior.
- One edge-case improvement: when a successful plan returns `nil` (no issue, no result), the callback now returns an empty `&app.FixResult{}` rather than `nil` — the typed-nil interface would otherwise crash the renderer. The rendered "no deterministic doc-drift edits available" line is a strict improvement over the original silent-zero exit in that branch.

142 lines removed, 96 added.

## Test plan
- [x] `make fmt`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./cmd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)