### PR TITLE
Polish runCommand tests: nil-plan render + runner-option enforcement

### DIFF
--- a/cmd/canonicalize_test.go
+++ b/cmd/canonicalize_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -92,16 +93,16 @@ func TestRunCanonicalizeWriteProducesBundle(t *testing.T) {
 // not register the shared --config flag: passing it must fail with a
 // validation_error from the flag parser, not silently accept it.
 //
-// Note: flag parsing fails before --format is processed, so the error is
-// emitted in the default (text) format to stderr.
+// Flag parsing fails before --format is processed, so the error is emitted
+// in the default format. PITUITARY_FORMAT is cleared so the default is
+// deterministically text (routed to stderr) rather than whatever the host
+// environment sets.
 func TestRunCanonicalizeRejectsConfigFlag(t *testing.T) {
-	repo := writeDiscoveryWorkspace(t)
+	t.Setenv("PITUITARY_FORMAT", "")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	exitCode := withWorkingDir(t, repo, func() int {
-		return runCanonicalize([]string{"--config", "pituitary.toml", "--path", "rfcs/service-sla.md"}, &stdout, &stderr)
-	})
+	exitCode := runCanonicalize([]string{"--config", "pituitary.toml", "--path", "note.md"}, &stdout, &stderr)
 	if exitCode != 2 {
 		t.Fatalf("runCanonicalize(--config) exit code = %d, want 2", exitCode)
 	}
@@ -127,6 +128,12 @@ func TestRunCanonicalizeToleratesMissingConfig(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	exitCode := withWorkingDir(t, repo, func() int {
+		// Precondition: prove resolveCommandConfigPath actually fails here,
+		// so we know the success below exercises the Standalone tolerance
+		// branch and not an accidentally-discovered config.
+		if _, err := resolveCommandConfigPath(context.Background(), ""); err == nil {
+			t.Fatalf("resolveCommandConfigPath() err = nil, want error to exercise Standalone tolerance branch")
+		}
 		return runCanonicalize([]string{"--path", "note.md", "--format", "json"}, &stdout, &stderr)
 	})
 	if exitCode != 0 {

--- a/cmd/canonicalize_test.go
+++ b/cmd/canonicalize_test.go
@@ -88,6 +88,65 @@ func TestRunCanonicalizeWriteProducesBundle(t *testing.T) {
 	}
 }
 
+// TestRunCanonicalizeRejectsConfigFlag verifies that Standalone commands do
+// not register the shared --config flag: passing it must fail with a
+// validation_error from the flag parser, not silently accept it.
+//
+// Note: flag parsing fails before --format is processed, so the error is
+// emitted in the default (text) format to stderr.
+func TestRunCanonicalizeRejectsConfigFlag(t *testing.T) {
+	repo := writeDiscoveryWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runCanonicalize([]string{"--config", "pituitary.toml", "--path", "rfcs/service-sla.md"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runCanonicalize(--config) exit code = %d, want 2", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("runCanonicalize(--config) wrote unexpected stdout: %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "flag provided but not defined: -config") {
+		t.Fatalf("stderr = %q, want flag-not-defined message mentioning -config", got)
+	}
+}
+
+// TestRunCanonicalizeToleratesMissingConfig verifies that Standalone commands
+// tolerate an unresolvable workspace config: when resolveCommandConfigPath
+// fails (no pituitary.toml discoverable and PITUITARY_CONFIG unset), the
+// runner passes an empty cfgPath to Execute rather than aborting with
+// config_error, so canonicalize can still process the markdown file.
+func TestRunCanonicalizeToleratesMissingConfig(t *testing.T) {
+	t.Setenv("PITUITARY_CONFIG", "")
+
+	repo := t.TempDir()
+	mustWriteFileCmd(t, filepath.Join(repo, "note.md"), "# Note\n\nBody paragraph.\n")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runCanonicalize([]string{"--path", "note.md", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runCanonicalize() exit code = %d, want 0 (stderr: %q, stdout: %q)", exitCode, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runCanonicalize() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal canonicalize payload: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
 func TestRunCanonicalizeHelpDoesNotAdvertiseConfigResolution(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/cmd/explain_file_test.go
+++ b/cmd/explain_file_test.go
@@ -350,6 +350,43 @@ func TestRunExplainFileRejectsMissingPath(t *testing.T) {
 	if len(payload.Errors) != 1 || payload.Errors[0].Code != "validation_error" {
 		t.Fatalf("errors = %+v, want one validation_error", payload.Errors)
 	}
+	if got := payload.Errors[0].Message; !strings.Contains(got, "exactly 1 positional argument(s) required") {
+		t.Fatalf("error message = %q, want ExactPositional enforcement message", got)
+	}
+}
+
+// TestRunExplainFileRejectsExtraPositional verifies the ExactPositional=1
+// upper bound: supplying more than one positional argument must fail with
+// validation_error exit 2 from the runCommand helper, not drop the extras
+// silently into BuildRequest.
+func TestRunExplainFileRejectsExtraPositional(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runExplainFile([]string{"first.md", "second.md", "--format", "json"}, &stdout, &stderr)
+	if exitCode != 2 {
+		t.Fatalf("runExplainFile() exit code = %d, want 2", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runExplainFile() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Result any        `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal explain error payload: %v", err)
+	}
+	if payload.Result != nil {
+		t.Fatalf("result = %#v, want nil", payload.Result)
+	}
+	if len(payload.Errors) != 1 || payload.Errors[0].Code != "validation_error" {
+		t.Fatalf("errors = %+v, want one validation_error", payload.Errors)
+	}
+	if got := payload.Errors[0].Message; !strings.Contains(got, "exactly 1 positional argument(s) required") {
+		t.Fatalf("error message = %q, want ExactPositional enforcement message", got)
+	}
 }
 
 func TestResolveExplainPathResolvesRelativePathFromCWD(t *testing.T) {

--- a/cmd/fix_test.go
+++ b/cmd/fix_test.go
@@ -7,7 +7,27 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dusk-network/pituitary/internal/app"
 )
+
+// TestRenderFixResultNilPlanFallback protects the contract that cmd/fix.go's
+// nil-plan branch relies on: when the interactive planner returns a nil plan
+// with no issue, fix.go substitutes an empty *FixResult so renderFixResult
+// emits the "no deterministic doc-drift edits available" line instead of
+// panicking on a typed-nil result.
+func TestRenderFixResultNilPlanFallback(t *testing.T) {
+	var buf bytes.Buffer
+	renderFixResult(&buf, &app.FixResult{})
+
+	out := buf.String()
+	if !strings.Contains(out, "no deterministic doc-drift edits available") {
+		t.Fatalf("renderFixResult(&FixResult{}) output %q does not contain fallback guidance", out)
+	}
+	if !strings.Contains(out, "━━◈ fix") {
+		t.Fatalf("renderFixResult(&FixResult{}) output %q does not contain fix header", out)
+	}
+}
 
 func TestRunFixDryRunJSONPlansDeterministicEdits(t *testing.T) {
 	repo := writeSearchWorkspace(t)


### PR DESCRIPTION
## Summary

Follow-up tests for the runCommand surfaces landed in PRs #332/#334 that lacked direct coverage. No production code changes.

- **Fix nil-plan render contract** (`cmd/fix.go:96`): `renderFixResult(&FixResult{})` emits "no deterministic doc-drift edits available" and the fix header. Pins the rendering contract the defensive branch relies on.
- **ExactPositional enforcement**: strengthen the too-few assertion to match the runner's `"exactly N positional argument(s) required"` message, and add a too-many test that passes two paths to `explain-file`.
- **Standalone enforcement**: verify `--config` is rejected (flag not registered) and that an unresolvable workspace config (no `pituitary.toml`, `PITUITARY_CONFIG` unset) is tolerated with an empty `cfgPath` handed to Execute.

## Test plan

- [x] `go test ./cmd/...` passes
- [x] `go test -race ./cmd/...` passes
- [x] `go vet ./...` clean
- [x] `make fmt` idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)