### PR TITLE
Extract autoLoadWorkspaceRequest helper for trivial LoadRequestFile callbacks

### DIFF
--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -46,13 +46,7 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 			InlineFlagsSet: func(_ *flag.FlagSet) bool {
 				return strings.TrimSpace(specRef) != "" || strings.TrimSpace(specPath) != ""
 			},
-			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.AnalyzeImpactRequest, error) {
-				req, err := loadWorkspaceScopedJSONFile[analysis.AnalyzeImpactRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
-				if err != nil {
-					return nil, err
-				}
-				return &req, nil
-			},
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.AnalyzeImpactRequest](),
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.AnalyzeImpactRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)

--- a/cmd/analyze_impact.go
+++ b/cmd/analyze_impact.go
@@ -46,7 +46,7 @@ func runAnalyzeImpactContext(ctx context.Context, args []string, stdout, stderr 
 			InlineFlagsSet: func(_ *flag.FlagSet) bool {
 				return strings.TrimSpace(specRef) != "" || strings.TrimSpace(specPath) != ""
 			},
-			LoadRequestFile: autoLoadWorkspaceRequest[analysis.AnalyzeImpactRequest](),
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.AnalyzeImpactRequest],
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.AnalyzeImpactRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)

--- a/cmd/check_overlap.go
+++ b/cmd/check_overlap.go
@@ -47,7 +47,7 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 					strings.TrimSpace(specPath) != "" ||
 					strings.TrimSpace(specRecordFile) != ""
 			},
-			LoadRequestFile: autoLoadWorkspaceRequest[analysis.OverlapRequest](),
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.OverlapRequest],
 			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string, _ []string) (analysis.OverlapRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)

--- a/cmd/check_overlap.go
+++ b/cmd/check_overlap.go
@@ -47,13 +47,7 @@ func runCheckOverlapContext(ctx context.Context, args []string, stdout, stderr i
 					strings.TrimSpace(specPath) != "" ||
 					strings.TrimSpace(specRecordFile) != ""
 			},
-			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.OverlapRequest, error) {
-				req, err := loadWorkspaceScopedJSONFile[analysis.OverlapRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
-				if err != nil {
-					return nil, err
-				}
-				return &req, nil
-			},
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.OverlapRequest](),
 			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string, _ []string) (analysis.OverlapRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)

--- a/cmd/check_spec_freshness.go
+++ b/cmd/check_spec_freshness.go
@@ -41,7 +41,7 @@ func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, st
 			InlineFlagsSet: func(_ *flag.FlagSet) bool {
 				return strings.TrimSpace(specRef) != "" || strings.TrimSpace(specPath) != ""
 			},
-			LoadRequestFile: autoLoadWorkspaceRequest[analysis.FreshnessRequest](),
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.FreshnessRequest],
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.FreshnessRequest, error) {
 				req := analysis.FreshnessRequest{Scope: strings.TrimSpace(scope)}
 				resolvedSpecRef := strings.TrimSpace(specRef)

--- a/cmd/check_spec_freshness.go
+++ b/cmd/check_spec_freshness.go
@@ -41,13 +41,7 @@ func runCheckSpecFreshnessContext(ctx context.Context, args []string, stdout, st
 			InlineFlagsSet: func(_ *flag.FlagSet) bool {
 				return strings.TrimSpace(specRef) != "" || strings.TrimSpace(specPath) != ""
 			},
-			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.FreshnessRequest, error) {
-				req, err := loadWorkspaceScopedJSONFile[analysis.FreshnessRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
-				if err != nil {
-					return nil, err
-				}
-				return &req, nil
-			},
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.FreshnessRequest](),
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.FreshnessRequest, error) {
 				req := analysis.FreshnessRequest{Scope: strings.TrimSpace(scope)}
 				resolvedSpecRef := strings.TrimSpace(specRef)

--- a/cmd/check_terminology.go
+++ b/cmd/check_terminology.go
@@ -61,13 +61,7 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 					strings.TrimSpace(specPath) != "" ||
 					flagWasSet(fs, "scope")
 			},
-			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.TerminologyAuditRequest, error) {
-				req, err := loadWorkspaceScopedJSONFile[analysis.TerminologyAuditRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
-				if err != nil {
-					return nil, err
-				}
-				return &req, nil
-			},
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.TerminologyAuditRequest](),
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.TerminologyAuditRequest, error) {
 				req := analysis.TerminologyAuditRequest{
 					Terms:          []string(terms),

--- a/cmd/check_terminology.go
+++ b/cmd/check_terminology.go
@@ -61,7 +61,7 @@ func runCheckTerminologyContext(ctx context.Context, args []string, stdout, stde
 					strings.TrimSpace(specPath) != "" ||
 					flagWasSet(fs, "scope")
 			},
-			LoadRequestFile: autoLoadWorkspaceRequest[analysis.TerminologyAuditRequest](),
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.TerminologyAuditRequest],
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.TerminologyAuditRequest, error) {
 				req := analysis.TerminologyAuditRequest{
 					Terms:          []string(terms),

--- a/cmd/compare_specs.go
+++ b/cmd/compare_specs.go
@@ -50,7 +50,7 @@ func runCompareSpecsContext(ctx context.Context, args []string, stdout, stderr i
 			InlineFlagsSet: func(_ *flag.FlagSet) bool {
 				return len(specRefs) > 0 || len(specPaths) > 0
 			},
-			LoadRequestFile: autoLoadWorkspaceRequest[analysis.CompareRequest](),
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.CompareRequest],
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.CompareRequest, error) {
 				req := analysis.CompareRequest{}
 				switch {

--- a/cmd/compare_specs.go
+++ b/cmd/compare_specs.go
@@ -50,13 +50,7 @@ func runCompareSpecsContext(ctx context.Context, args []string, stdout, stderr i
 			InlineFlagsSet: func(_ *flag.FlagSet) bool {
 				return len(specRefs) > 0 || len(specPaths) > 0
 			},
-			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.CompareRequest, error) {
-				req, err := loadWorkspaceScopedJSONFile[analysis.CompareRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
-				if err != nil {
-					return nil, err
-				}
-				return &req, nil
-			},
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.CompareRequest](),
 			BuildRequest: func(ctx context.Context, cfg *config.Config, _ string, _ []string) (analysis.CompareRequest, error) {
 				req := analysis.CompareRequest{}
 				switch {

--- a/cmd/request_file.go
+++ b/cmd/request_file.go
@@ -56,8 +56,16 @@ func readBoundedRequestFile(absPath, label string) ([]byte, error) {
 // that need additional resolution after the JSON parse (e.g. resolving a
 // diff-file reference inside the parsed request) should keep their own
 // callback rather than reaching for this helper.
+//
+// The helper needs a non-nil *config.Config to resolve workspace-scoped paths,
+// so callers must set Options.ConfigForFile = true. A nil cfg returns a clear
+// error rather than nil-panicking, so a future misconfiguration surfaces as a
+// classified CLI error instead of crashing.
 func autoLoadWorkspaceRequest[Req any]() func(context.Context, *config.Config, string) (*Req, error) {
 	return func(_ context.Context, cfg *config.Config, trimmedPath string) (*Req, error) {
+		if cfg == nil {
+			return nil, fmt.Errorf("autoLoadWorkspaceRequest requires Options.ConfigForFile = true; cfg was nil")
+		}
 		req, err := loadWorkspaceScopedJSONFile[Req](cfg.Workspace.RootPath, trimmedPath, "request file")
 		if err != nil {
 			return nil, err

--- a/cmd/request_file.go
+++ b/cmd/request_file.go
@@ -50,28 +50,29 @@ func readBoundedRequestFile(absPath, label string) ([]byte, error) {
 	return data, nil
 }
 
-// autoLoadWorkspaceRequest returns a LoadRequestFile callback for commands
-// whose --request-file contents are a bare workspace-scoped JSON document
-// that unmarshals directly into Req, with no post-load enrichment. Commands
-// that need additional resolution after the JSON parse (e.g. resolving a
-// diff-file reference inside the parsed request) should keep their own
-// callback rather than reaching for this helper.
+// autoLoadWorkspaceRequest is a LoadRequestFile callback for commands whose
+// --request-file contents are a bare workspace-scoped JSON document that
+// unmarshals directly into Req, with no post-load enrichment. Commands that
+// need additional resolution after the JSON parse (e.g. resolving a diff-file
+// reference inside the parsed request) should keep their own callback rather
+// than reaching for this helper.
+//
+// Use by taking the instantiated value: `LoadRequestFile:
+// autoLoadWorkspaceRequest[analysis.OverlapRequest]`.
 //
 // The helper needs a non-nil *config.Config to resolve workspace-scoped paths,
 // so callers must set Options.ConfigForFile = true. A nil cfg returns a clear
 // error rather than nil-panicking, so a future misconfiguration surfaces as a
 // classified CLI error instead of crashing.
-func autoLoadWorkspaceRequest[Req any]() func(context.Context, *config.Config, string) (*Req, error) {
-	return func(_ context.Context, cfg *config.Config, trimmedPath string) (*Req, error) {
-		if cfg == nil {
-			return nil, fmt.Errorf("autoLoadWorkspaceRequest requires Options.ConfigForFile = true; cfg was nil")
-		}
-		req, err := loadWorkspaceScopedJSONFile[Req](cfg.Workspace.RootPath, trimmedPath, "request file")
-		if err != nil {
-			return nil, err
-		}
-		return &req, nil
+func autoLoadWorkspaceRequest[Req any](_ context.Context, cfg *config.Config, trimmedPath string) (*Req, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("autoLoadWorkspaceRequest requires Options.ConfigForFile = true; cfg was nil")
 	}
+	req, err := loadWorkspaceScopedJSONFile[Req](cfg.Workspace.RootPath, trimmedPath, "request file")
+	if err != nil {
+		return nil, err
+	}
+	return &req, nil
 }
 
 func loadWorkspaceScopedJSONFile[T any](workspaceRoot, rawPath, label string) (T, error) {

--- a/cmd/request_file.go
+++ b/cmd/request_file.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/dusk-network/pituitary/internal/config"
 )
 
 // maxCLIRequestBytes caps how much a CLI command will buffer from a request
@@ -45,6 +48,22 @@ func readBoundedRequestFile(absPath, label string) ([]byte, error) {
 		return nil, fmt.Errorf("%s file %q exceeds %d-byte size limit", label, absPath, maxCLIRequestBytes)
 	}
 	return data, nil
+}
+
+// autoLoadWorkspaceRequest returns a LoadRequestFile callback for commands
+// whose --request-file contents are a bare workspace-scoped JSON document
+// that unmarshals directly into Req, with no post-load enrichment. Commands
+// that need additional resolution after the JSON parse (e.g. resolving a
+// diff-file reference inside the parsed request) should keep their own
+// callback rather than reaching for this helper.
+func autoLoadWorkspaceRequest[Req any]() func(context.Context, *config.Config, string) (*Req, error) {
+	return func(_ context.Context, cfg *config.Config, trimmedPath string) (*Req, error) {
+		req, err := loadWorkspaceScopedJSONFile[Req](cfg.Workspace.RootPath, trimmedPath, "request file")
+		if err != nil {
+			return nil, err
+		}
+		return &req, nil
+	}
 }
 
 func loadWorkspaceScopedJSONFile[T any](workspaceRoot, rawPath, label string) (T, error) {

--- a/cmd/review_spec.go
+++ b/cmd/review_spec.go
@@ -42,7 +42,7 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 					strings.TrimSpace(specPath) != "" ||
 					strings.TrimSpace(specRecordFile) != ""
 			},
-			LoadRequestFile: autoLoadWorkspaceRequest[analysis.ReviewRequest](),
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.ReviewRequest],
 			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string, _ []string) (analysis.ReviewRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)

--- a/cmd/review_spec.go
+++ b/cmd/review_spec.go
@@ -42,13 +42,7 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 					strings.TrimSpace(specPath) != "" ||
 					strings.TrimSpace(specRecordFile) != ""
 			},
-			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*analysis.ReviewRequest, error) {
-				req, err := loadWorkspaceScopedJSONFile[analysis.ReviewRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
-				if err != nil {
-					return nil, err
-				}
-				return &req, nil
-			},
+			LoadRequestFile: autoLoadWorkspaceRequest[analysis.ReviewRequest](),
 			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string, _ []string) (analysis.ReviewRequest, error) {
 				trimmedSpecRef := strings.TrimSpace(specRef)
 				trimmedSpecPath := strings.TrimSpace(specPath)

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -56,7 +56,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 			InlineFlagsSet: func(fs *flag.FlagSet) bool {
 				return strings.TrimSpace(query) != "" || strings.TrimSpace(domain) != "" || len(statuses) > 0 || flagWasSet(fs, "limit")
 			},
-			LoadRequestFile: autoLoadWorkspaceRequest[index.SearchSpecRequest](),
+			LoadRequestFile: autoLoadWorkspaceRequest[index.SearchSpecRequest],
 			BuildRequest: func(_ context.Context, _ *config.Config, _ string, _ []string) (index.SearchSpecRequest, error) {
 				return index.SearchSpecRequest{
 					Query: strings.TrimSpace(query),

--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -56,13 +56,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 			InlineFlagsSet: func(fs *flag.FlagSet) bool {
 				return strings.TrimSpace(query) != "" || strings.TrimSpace(domain) != "" || len(statuses) > 0 || flagWasSet(fs, "limit")
 			},
-			LoadRequestFile: func(_ context.Context, cfg *config.Config, trimmedPath string) (*index.SearchSpecRequest, error) {
-				req, err := loadWorkspaceScopedJSONFile[index.SearchSpecRequest](cfg.Workspace.RootPath, trimmedPath, "request file")
-				if err != nil {
-					return nil, err
-				}
-				return &req, nil
-			},
+			LoadRequestFile: autoLoadWorkspaceRequest[index.SearchSpecRequest](),
 			BuildRequest: func(_ context.Context, _ *config.Config, _ string, _ []string) (index.SearchSpecRequest, error) {
 				return index.SearchSpecRequest{
 					Query: strings.TrimSpace(query),


### PR DESCRIPTION
## Summary

7 of the 9 `LoadRequestFile` callsites had literally identical 7-line bodies that dispatched to `loadWorkspaceScopedJSONFile[T]` and returned the result. Extract the pattern into a generic helper so each callsite becomes one line.

- `check-overlap`, `check-spec-freshness`, `check-terminology`, `compare-specs`, `analyze-impact`, `review-spec`, `search-specs`: use the helper.
- `check-compliance`, `check-doc-drift`: keep their explicit callbacks because they perform post-load enrichment (resolving `DiffFile` → `DiffText`). The helper's doc comment calls out this boundary.

Runner API is unchanged — this is a plain helper, not a new `commandRunOptions` field. That was a deliberate choice over a runner-level `AutoLoadRequestFile` flag (which would have coupled to `ConfigForFile` and left Class B escaping the abstraction anyway).

Net: -23 lines across 8 files.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/...` passes
- [x] `go test -race ./cmd/...` passes
- [x] `make fmt` idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)