### PR TITLE
Upgrade stroma dependency to v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,22 +4,22 @@ go 1.25.9
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/asg017/sqlite-vec-go-bindings v0.1.6
-	github.com/dusk-network/stroma v0.4.0
+	github.com/dusk-network/stroma/v2 v2.0.0
 	github.com/google/go-github/v79 v79.0.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/mark3labs/mcp-go v0.45.0
-	github.com/ncruces/go-sqlite3 v0.21.3
 	github.com/odvcencio/gotreesitter v0.13.4
 	golang.org/x/sync v0.20.0
 )
 
 require (
+	github.com/asg017/sqlite-vec-go-bindings v0.1.6 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/ncruces/go-sqlite3 v0.21.3 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,14 +8,8 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196 h1:1TULfQD0OA8zpd7+4QaXpNcoosAkytPKkI+Xld2cTZs=
-github.com/dusk-network/stroma v0.0.0-20260413071551-6bc4ec2ab196/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
-github.com/dusk-network/stroma v0.0.0-20260413131144-770dfc81a8dc h1:4dPfDz6tAihHfnj89G+qSKJSvm0SVbBcuPtA6IVqrDw=
-github.com/dusk-network/stroma v0.0.0-20260413131144-770dfc81a8dc/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
-github.com/dusk-network/stroma v0.2.0 h1:Un+D0j4J4LPIVkyX/p+FcLfU0sBl/T5EGCvQTliqdK8=
-github.com/dusk-network/stroma v0.2.0/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
-github.com/dusk-network/stroma v0.4.0 h1:LuGuy/dvE8K420Q2/y2bkB+i7PtWqf0ci+lSaHQynIs=
-github.com/dusk-network/stroma v0.4.0/go.mod h1:UwRj67hOS0jF+9C7EgqnI/kLv+OOs423rerS71LdBm0=
+github.com/dusk-network/stroma/v2 v2.0.0 h1:OgMq5s8E0HxstmEbLj6GH5S7//FotlrG9WMQD6LZ+aA=
+github.com/dusk-network/stroma/v2 v2.0.0/go.mod h1:n2Gf3cvgh8QuvJzQD/rkQMzXmq81dxu2hvpApFYLRwg=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -15,7 +15,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 const (

--- a/internal/analysis/repository.go
+++ b/internal/analysis/repository.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 type analysisRepository struct {

--- a/internal/analysis/repository_similarity.go
+++ b/internal/analysis/repository_similarity.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/ranking"
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 const (

--- a/internal/analysis/semantic_terminology.go
+++ b/internal/analysis/semantic_terminology.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 const (

--- a/internal/chunk/markdown.go
+++ b/internal/chunk/markdown.go
@@ -1,6 +1,6 @@
 package chunk
 
-import stchunk "github.com/dusk-network/stroma/chunk"
+import stchunk "github.com/dusk-network/stroma/v2/chunk"
 
 // Section is one heading-aware Markdown chunk.
 type Section = stchunk.Section

--- a/internal/index/corpus_snapshot.go
+++ b/internal/index/corpus_snapshot.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 const stromaSnapshotPathKey = "stroma_snapshot_path"

--- a/internal/index/embedder.go
+++ b/internal/index/embedder.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/config"
-	stembed "github.com/dusk-network/stroma/embed"
+	stembed "github.com/dusk-network/stroma/v2/embed"
 )
 
 // DependencyUnavailableError indicates that a required runtime dependency

--- a/internal/index/openai_embedder.go
+++ b/internal/index/openai_embedder.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/openaicompat"
-	stembed "github.com/dusk-network/stroma/embed"
+	stembed "github.com/dusk-network/stroma/v2/embed"
 )
 
 const (

--- a/internal/index/openai_embedder_test.go
+++ b/internal/index/openai_embedder_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/dusk-network/pituitary/internal/config"
-	stembed "github.com/dusk-network/stroma/embed"
+	stembed "github.com/dusk-network/stroma/v2/embed"
 )
 
 func TestOpenAICompatibleEmbedderUsesNomicSearchPrefixes(t *testing.T) {

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -18,8 +18,8 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
-	stcorpus "github.com/dusk-network/stroma/corpus"
-	stindex "github.com/dusk-network/stroma/index"
+	stcorpus "github.com/dusk-network/stroma/v2/corpus"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 const schemaVersion = 10
@@ -253,7 +253,7 @@ func corpusRecordFromSpec(spec model.SpecRecord) (stcorpus.Record, error) {
 		BodyText:    spec.BodyText,
 		ContentHash: spec.ContentHash,
 		Metadata:    metadata,
-	}.Normalized()
+	}.Normalize()
 }
 
 func corpusRecordFromDoc(doc model.DocRecord) (stcorpus.Record, error) {
@@ -266,7 +266,7 @@ func corpusRecordFromDoc(doc model.DocRecord) (stcorpus.Record, error) {
 		BodyText:    doc.BodyText,
 		ContentHash: doc.ContentHash,
 		Metadata:    cloneMetadata(doc.Metadata),
-	}.Normalized()
+	}.Normalize()
 }
 
 func publishBusinessIndexContext(ctx context.Context, cfg *config.Config, records *source.LoadResult, result *RebuildResult, snapshotPath string) error {

--- a/internal/index/reuse.go
+++ b/internal/index/reuse.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/chunk"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 type reuseState struct {

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -12,7 +12,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/ranking"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 const (
@@ -364,11 +364,13 @@ func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stin
 	preferHistorical := ranking.SearchPrefersHistoricalContext(query.Query)
 
 	hits, err := snapshot.Search(ctx, stindex.SnapshotSearchQuery{
-		Text:     query.Query,
-		Limit:    searchCandidateLimit(query.Limit),
-		Kinds:    []string{query.Kind},
-		Embedder: embedder,
-		Reranker: historicalSectionReranker{preferHistorical: preferHistorical},
+		SearchParams: stindex.SearchParams{
+			Text:     query.Query,
+			Limit:    searchCandidateLimit(query.Limit),
+			Kinds:    []string{query.Kind},
+			Embedder: embedder,
+			Reranker: historicalSectionReranker{preferHistorical: preferHistorical},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("query search candidates: %w", err)

--- a/internal/index/search_test.go
+++ b/internal/index/search_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
-	stindex "github.com/dusk-network/stroma/index"
+	stindex "github.com/dusk-network/stroma/v2/index"
 )
 
 func TestSearchSpecsReturnsRankedSections(t *testing.T) {

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 
-	ststore "github.com/dusk-network/stroma/store"
+	ststore "github.com/dusk-network/stroma/v2/store"
 )
 
 func openReadWriteContext(ctx context.Context, path string) (*sql.DB, error) {

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
-	stindex "github.com/dusk-network/stroma/index"
-	ststore "github.com/dusk-network/stroma/store"
+	stindex "github.com/dusk-network/stroma/v2/index"
+	ststore "github.com/dusk-network/stroma/v2/store"
 )
 
 // UpdatePreconditionError reports that the existing index is structurally

--- a/internal/index/update_test.go
+++ b/internal/index/update_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
-	ststore "github.com/dusk-network/stroma/store"
+	ststore "github.com/dusk-network/stroma/v2/store"
 )
 
 func TestUpdateNoOp(t *testing.T) {


### PR DESCRIPTION
## Summary

- Upgrade `github.com/dusk-network/stroma v0.4.0` → `github.com/dusk-network/stroma/v2 v2.0.0` (two majors; v2 tag uses the SIV `/v2` module path).
- Migrate two breaking-change call sites: `Record.Normalized()` → `Normalize()`, and `SnapshotSearchQuery` literal wrapped in `SearchParams{}`.
- Adversarial-reviewed via `/codex:adversarial-review` (no findings); `make fmt && make vet && make test` all clean.

## Breaking changes handled

- **`corpus.Record.Normalized()` → `Normalize() (Record, error)`** — two call sites in `internal/index/rebuild.go` (`corpusRecordFromSpec`, `corpusRecordFromDoc`). Both callers already returned `(stcorpus.Record, error)`, so error propagation is identity.
- **`SnapshotSearchQuery` now embeds `SearchParams`** — Go composite literals can't address promoted fields, so the `snapshot.Search` call in `internal/index/search.go` wraps `Text/Limit/Kinds/Embedder/Reranker` in a `SearchParams{}` literal. No semantic change.

## Semantic shift worth flagging

Stroma v1 made `corpus.HashRecord` injective. Pituitary doesn't call it directly, but stroma's internal `BuildOptions.ReuseFromPath` probe uses it, so **the first rebuild after this merge will miss the reuse cache and fall back to a full rebuild.** Correctness-safe; one-time performance cliff only. Pituitary's content-addressed snapshot path (`internal/index/corpus_snapshot.go`) means stale v0.4.0 snapshot files get GC'd naturally.

## Scope intentionally held to a mechanical bump

Stroma v2 ships several features relevant to Pituitary (adaptive chunking via `chunk.Policy` / `KindRouterPolicy`, quantization, matryoshka prefilter, `ChunkContextualizer`, `MaxBatchSize` on the OpenAI embedder). None are adopted in this PR. Each is worth a separate design conversation — planned as follow-ups once this bump is green.

## Go-module hygiene

`go mod tidy` demoted `github.com/asg017/sqlite-vec-go-bindings` and `github.com/ncruces/go-sqlite3` to `// indirect`. Verified no direct `.go` import in Pituitary's source — they arrive transitively through stroma.

## Test plan

- [x] `make fmt && make vet && make test` — green locally
- [x] `go build ./...` — clean
- [x] `go mod tidy` — clean (noted demotions above)
- [x] `/codex:adversarial-review` — approved, no findings
- [ ] CI green
- [ ] Copilot review resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)