### PR TITLE
Adopt stroma v2 ChunkContextualizer with heading-hierarchy prefix (#343)

### DIFF
--- a/internal/chunk/contextualizer.go
+++ b/internal/chunk/contextualizer.go
@@ -1,0 +1,148 @@
+package chunk
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	stchunk "github.com/dusk-network/stroma/v2/chunk"
+	stcorpus "github.com/dusk-network/stroma/v2/corpus"
+	stindex "github.com/dusk-network/stroma/v2/index"
+)
+
+// PrefixFormat selects the layout of the per-chunk context prefix.
+//
+// Heading content is always passed through verbatim. Stroma's
+// chunk.Section.Heading is a " / "-joined display string produced by
+// stroma/chunk.joinHeadings; reparsing it on this side would be wrong
+// whenever a heading's literal text contains " / " (e.g. "Latency /
+// Throughput trade-offs"). We treat the heading as opaque and only
+// compose it with record-level identifiers.
+type PrefixFormat string
+
+const (
+	// PrefixFormatTitleAncestry is "<Title> > <Heading>" with the
+	// heading string verbatim from stroma. Strongest signal for
+	// cross-spec heading collisions (e.g. "Rate limits" in SPEC-043
+	// vs SPEC-018).
+	PrefixFormatTitleAncestry PrefixFormat = "title_ancestry"
+
+	// PrefixFormatRefTitle is "[<Ref>] <Title>". Machine-identifier-
+	// forward variant; stable across Title edits. Does not include
+	// heading, which trades heading-collision disambiguation for
+	// Ref-stability.
+	PrefixFormatRefTitle PrefixFormat = "ref_title"
+)
+
+// ContextualizerConfig is the chunk-package-facing config for the
+// contextualizer. A zero value means "no contextualizer" — the rebuild
+// path stays byte-identical to the pre-#343 contract (no prefix, no
+// chunks.context_prefix column writes, no reuse-cache invalidation).
+type ContextualizerConfig struct {
+	// Format selects the prefix layout. Empty means disabled.
+	Format PrefixFormat
+}
+
+// IsZero reports whether no contextualizer is configured.
+func (c ContextualizerConfig) IsZero() bool {
+	return c.Format == ""
+}
+
+// BuildPrefix is the pure per-section prefix function. Deterministic
+// and I/O-free: stroma persists the prefix in chunks.context_prefix
+// and pivots reuse-cache invalidation on its bytes, so any non-
+// determinism here would silently force full rebuilds.
+//
+// Returns "" when the inputs yield no meaningful signal; stroma's
+// runContextualizer normalizes whitespace-only entries to "" upstream
+// so "no prefix" flows uniformly to embedding, FTS, and the reuse key.
+//
+// The heading string is never reparsed — it is passed through opaquely
+// from stroma. This keeps the contract orthogonal to stroma's current
+// heading display format and avoids silently corrupting prefixes when
+// a heading's literal text contains the " / " separator sequence.
+func BuildPrefix(format PrefixFormat, record stcorpus.Record, section stchunk.Section) string {
+	title := strings.TrimSpace(record.Title)
+	heading := strings.TrimSpace(section.Heading)
+	ref := strings.TrimSpace(record.Ref)
+
+	switch format {
+	case PrefixFormatTitleAncestry:
+		parts := make([]string, 0, 2)
+		if title != "" {
+			parts = append(parts, title)
+		}
+		if heading != "" && heading != title {
+			parts = append(parts, heading)
+		}
+		return strings.Join(parts, " > ")
+
+	case PrefixFormatRefTitle:
+		switch {
+		case ref != "" && title != "":
+			return "[" + ref + "] " + title
+		case title != "":
+			return title
+		case ref != "":
+			return "[" + ref + "]"
+		default:
+			return ""
+		}
+
+	default:
+		return ""
+	}
+}
+
+// Contextualizer is pituitary's stindex.ChunkContextualizer adapter.
+// It is a thin wrapper around BuildPrefix: all policy lives in the
+// pure function so the adapter stays trivially correct w.r.t. stroma's
+// "return exactly len(sections) prefixes" contract.
+type Contextualizer struct {
+	format PrefixFormat
+}
+
+// NewContextualizer returns a Contextualizer for the given format.
+// Unknown formats are rejected at construction time so misconfiguration
+// surfaces before the rebuild begins, not as a silent empty-prefix run.
+func NewContextualizer(format PrefixFormat) (*Contextualizer, error) {
+	if !knownPrefixFormat(format) {
+		return nil, fmt.Errorf("unknown contextualizer format %q (expected %q or %q)",
+			format, PrefixFormatTitleAncestry, PrefixFormatRefTitle)
+	}
+	return &Contextualizer{format: format}, nil
+}
+
+// ContextualizeChunks satisfies stindex.ChunkContextualizer.
+func (c *Contextualizer) ContextualizeChunks(
+	_ context.Context, record stcorpus.Record, sections []stchunk.Section,
+) ([]string, error) {
+	out := make([]string, len(sections))
+	for i, s := range sections {
+		out[i] = BuildPrefix(c.format, record, s)
+	}
+	return out, nil
+}
+
+// ResolveContextualizer is the sibling of Resolve: it builds the stroma
+// ChunkContextualizer from pituitary's ContextualizerConfig. A zero
+// config returns (nil, nil) so the pre-#343 rebuild contract stays
+// intact until users opt in.
+func ResolveContextualizer(cfg ContextualizerConfig) (stindex.ChunkContextualizer, error) {
+	if cfg.IsZero() {
+		return nil, nil
+	}
+	return NewContextualizer(cfg.Format)
+}
+
+func knownPrefixFormat(f PrefixFormat) bool {
+	switch f {
+	case PrefixFormatTitleAncestry, PrefixFormatRefTitle:
+		return true
+	default:
+		return false
+	}
+}
+
+// Compile-time interface check.
+var _ stindex.ChunkContextualizer = (*Contextualizer)(nil)

--- a/internal/chunk/contextualizer_test.go
+++ b/internal/chunk/contextualizer_test.go
@@ -1,0 +1,236 @@
+package chunk
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	stchunk "github.com/dusk-network/stroma/v2/chunk"
+	stcorpus "github.com/dusk-network/stroma/v2/corpus"
+	stindex "github.com/dusk-network/stroma/v2/index"
+)
+
+func TestBuildPrefix_TitleAncestry(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		record stcorpus.Record
+		sec    stchunk.Section
+		want   string
+	}{
+		{
+			name:   "full ancestry from stroma joined heading",
+			record: stcorpus.Record{Title: "SPEC-043: Rate limiting"},
+			sec:    stchunk.Section{Heading: "Policy / Rate limits"},
+			want:   "SPEC-043: Rate limiting > Policy / Rate limits",
+		},
+		{
+			name:   "single-level heading",
+			record: stcorpus.Record{Title: "SPEC-043"},
+			sec:    stchunk.Section{Heading: "Overview"},
+			want:   "SPEC-043 > Overview",
+		},
+		{
+			name:   "heading equals title collapses to title",
+			record: stcorpus.Record{Title: "SPEC-043"},
+			sec:    stchunk.Section{Heading: "SPEC-043"},
+			want:   "SPEC-043",
+		},
+		{
+			name:   "empty heading yields title alone",
+			record: stcorpus.Record{Title: "SPEC-043"},
+			sec:    stchunk.Section{},
+			want:   "SPEC-043",
+		},
+		{
+			name:   "empty title keeps heading verbatim",
+			record: stcorpus.Record{},
+			sec:    stchunk.Section{Heading: "Top / Sub"},
+			want:   "Top / Sub",
+		},
+		{
+			name:   "whitespace inputs collapse to empty",
+			record: stcorpus.Record{Title: "  "},
+			sec:    stchunk.Section{Heading: "  "},
+			want:   "",
+		},
+		{
+			// Regression: a single-section heading whose literal text
+			// contains the " / " separator sequence must not be
+			// reparsed as multi-level ancestry. BuildPrefix passes the
+			// heading opaquely, so the output preserves the original
+			// text exactly.
+			name:   "heading containing literal slash is preserved",
+			record: stcorpus.Record{Title: "SPEC-043"},
+			sec:    stchunk.Section{Heading: "Latency / Throughput trade-offs"},
+			want:   "SPEC-043 > Latency / Throughput trade-offs",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := BuildPrefix(PrefixFormatTitleAncestry, tc.record, tc.sec)
+			if got != tc.want {
+				t.Fatalf("BuildPrefix() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildPrefix_RefTitle(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		record stcorpus.Record
+		want   string
+	}{
+		{"ref and title", stcorpus.Record{Ref: "spec:rate-limiting", Title: "Rate limiting"}, "[spec:rate-limiting] Rate limiting"},
+		{"title only", stcorpus.Record{Title: "Rate limiting"}, "Rate limiting"},
+		{"ref only", stcorpus.Record{Ref: "spec:rate-limiting"}, "[spec:rate-limiting]"},
+		{"both empty", stcorpus.Record{}, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := BuildPrefix(PrefixFormatRefTitle, tc.record, stchunk.Section{Heading: "ignored"})
+			if got != tc.want {
+				t.Fatalf("BuildPrefix() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildPrefix_UnknownFormatReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := BuildPrefix("semantic", stcorpus.Record{Title: "X"}, stchunk.Section{Heading: "Y"})
+	if got != "" {
+		t.Fatalf("BuildPrefix(unknown) = %q, want empty", got)
+	}
+}
+
+func TestBuildPrefix_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	// Reuse-cache invalidation in stroma pivots on stable prefix output
+	// across rebuilds; prove determinism here so a future non-stable
+	// change gets caught at the unit layer rather than silently
+	// triggering full rebuilds in prod.
+	record := stcorpus.Record{Ref: "spec:rate-limiting", Title: "SPEC-043: Rate limiting"}
+	section := stchunk.Section{Heading: "Policy / Rate limits"}
+
+	for _, format := range []PrefixFormat{
+		PrefixFormatTitleAncestry, PrefixFormatRefTitle,
+	} {
+		first := BuildPrefix(format, record, section)
+		for i := 0; i < 32; i++ {
+			if got := BuildPrefix(format, record, section); got != first {
+				t.Fatalf("BuildPrefix(%q) iteration %d = %q, want stable %q",
+					format, i, got, first)
+			}
+		}
+	}
+}
+
+func TestResolveContextualizer_ZeroConfigReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	c, err := ResolveContextualizer(ContextualizerConfig{})
+	if err != nil {
+		t.Fatalf("ResolveContextualizer(zero): %v", err)
+	}
+	if c != nil {
+		t.Fatalf("ResolveContextualizer(zero) = %T, want nil (preserves pre-#343 rebuild contract)", c)
+	}
+}
+
+func TestResolveContextualizer_KnownFormat(t *testing.T) {
+	t.Parallel()
+
+	c, err := ResolveContextualizer(ContextualizerConfig{Format: PrefixFormatTitleAncestry})
+	if err != nil {
+		t.Fatalf("ResolveContextualizer: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected a non-nil contextualizer")
+	}
+}
+
+func TestResolveContextualizer_UnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveContextualizer(ContextualizerConfig{Format: "semantic"})
+	if err == nil {
+		t.Fatal("expected error for unknown format")
+	}
+	if !strings.Contains(err.Error(), "unknown contextualizer format") {
+		t.Fatalf("error should mention unknown format; got: %v", err)
+	}
+}
+
+func TestContextualizer_ContextualizeChunksLenMatchesSections(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewContextualizer(PrefixFormatTitleAncestry)
+	if err != nil {
+		t.Fatalf("NewContextualizer: %v", err)
+	}
+	record := stcorpus.Record{Title: "SPEC-043: Rate limiting"}
+	sections := []stchunk.Section{
+		{Heading: "Policy / Rate limits"},
+		{Heading: "Policy / Burst"},
+		{Heading: ""},
+	}
+	prefixes, err := c.ContextualizeChunks(context.Background(), record, sections)
+	if err != nil {
+		t.Fatalf("ContextualizeChunks: %v", err)
+	}
+	if got, want := len(prefixes), len(sections); got != want {
+		t.Fatalf("len(prefixes) = %d, want %d (stroma rejects mismatched lengths)", got, want)
+	}
+	if !strings.Contains(prefixes[0], "Rate limits") {
+		t.Fatalf("prefix[0] = %q, expected ancestry leaf", prefixes[0])
+	}
+}
+
+func TestContextualizer_EmptySectionsReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewContextualizer(PrefixFormatTitleAncestry)
+	if err != nil {
+		t.Fatalf("NewContextualizer: %v", err)
+	}
+	prefixes, err := c.ContextualizeChunks(context.Background(), stcorpus.Record{Title: "X"}, nil)
+	if err != nil {
+		t.Fatalf("ContextualizeChunks: %v", err)
+	}
+	if len(prefixes) != 0 {
+		t.Fatalf("len(prefixes) = %d, want 0 for empty sections", len(prefixes))
+	}
+}
+
+func TestContextualizer_SatisfiesStromaInterface(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewContextualizer(PrefixFormatRefTitle)
+	if err != nil {
+		t.Fatalf("NewContextualizer: %v", err)
+	}
+	var iface stindex.ChunkContextualizer = c
+	_ = iface
+}
+
+func TestContextualizerConfig_IsZero(t *testing.T) {
+	t.Parallel()
+
+	if !(ContextualizerConfig{}).IsZero() {
+		t.Fatal("zero ContextualizerConfig should be IsZero")
+	}
+	if (ContextualizerConfig{Format: PrefixFormatRefTitle}).IsZero() {
+		t.Fatal("populated ContextualizerConfig should not be IsZero")
+	}
+}

--- a/internal/config/chunking_test.go
+++ b/internal/config/chunking_test.go
@@ -136,6 +136,140 @@ maks_tokens = 512
 	}
 }
 
+func TestLoadRuntimeChunkingParsesContextualizer(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.chunking.contextualizer]
+format = "title_ancestry"
+`)
+
+	if got := cfg.Runtime.Chunking.Contextualizer.Format; got != ChunkContextualizerFormatTitleAncestry {
+		t.Fatalf("contextualizer.format = %q, want %q", got, ChunkContextualizerFormatTitleAncestry)
+	}
+	if cfg.Runtime.Chunking.Contextualizer.IsZero() {
+		t.Fatal("contextualizer should not be IsZero once format is set")
+	}
+}
+
+func TestLoadRuntimeChunkingRejectsUnknownContextualizerFormat(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.chunking.contextualizer]
+format = "semantic"
+`)
+	if err == nil {
+		t.Fatal("expected error for unsupported contextualizer format")
+	}
+	if !strings.Contains(err.Error(), "unsupported format") {
+		t.Fatalf("error should mention unsupported format; got %v", err)
+	}
+	if !strings.Contains(err.Error(), `"title_ancestry"`) {
+		t.Fatalf("error should list supported formats; got %v", err)
+	}
+}
+
+func TestLoadRuntimeChunkingRejectsUnknownContextualizerField(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.chunking.contextualizer]
+formst = "title_ancestry"
+`)
+	if err == nil {
+		t.Fatal("expected error for misspelled contextualizer field")
+	}
+	if !strings.Contains(err.Error(), "formst") {
+		t.Fatalf("error should name the misspelled field; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "format") {
+		t.Fatalf("error should suggest the correct field; got %v", err)
+	}
+}
+
+func TestLoadRuntimeChunkingRejectsUnknownChunkingSubtree(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.chunking.gadget]
+policy = "markdown"
+`)
+	if err == nil {
+		t.Fatal("expected error for unknown subtree under runtime.chunking")
+	}
+	if !strings.Contains(err.Error(), `"contextualizer"`) {
+		t.Fatalf("error should suggest contextualizer alongside spec/doc; got %v", err)
+	}
+}
+
+func TestRenderRoundTripPreservesContextualizer(t *testing.T) {
+	t.Parallel()
+
+	// Regression: the first #343 drop shipped with ChunkingConfig
+	// carrying Contextualizer but Render omitting the block, which
+	// meant any render-based workflow silently downgraded the next
+	// load back to the no-contextualizer path. This test guards that
+	// an enabled contextualizer survives Render -> Load unchanged.
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.chunking.contextualizer]
+format = "title_ancestry"
+`)
+
+	rendered, err := Render(cfg)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(rendered, "[runtime.chunking.contextualizer]") {
+		t.Fatalf("rendered output missing contextualizer block:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `format = "title_ancestry"`) {
+		t.Fatalf("rendered output missing format value:\n%s", rendered)
+	}
+
+	round := loadRenderedConfig(t, rendered)
+	if got := round.Runtime.Chunking.Contextualizer.Format; got != ChunkContextualizerFormatTitleAncestry {
+		t.Fatalf("round-tripped contextualizer.format = %q, want %q", got, ChunkContextualizerFormatTitleAncestry)
+	}
+}
+
+// loadRenderedConfig loads an already-complete rendered config body
+// (one that already includes its own [[sources]] tables) without the
+// fixture append loadChunkingFixture performs.
+func loadRenderedConfig(t *testing.T, body string) *Config {
+	t.Helper()
+	repo := t.TempDir()
+	workspace := filepath.Join(repo, "workspace")
+	mustMkdirAll(t, filepath.Join(workspace, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, body)
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load round-trip: %v", err)
+	}
+	return cfg
+}
+
 func TestRenderRoundTripPreservesChunking(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,13 @@ const (
 
 	ChunkPolicyMarkdown  = "markdown"
 	ChunkPolicyLateChunk = "late_chunk"
+
+	// Chunk contextualizer formats. Duplicated here (rather than
+	// imported from internal/chunk) to keep the config package
+	// dependency-free of chunk, matching the pattern used for
+	// ChunkPolicy* above. Kept in lock-step with chunk.PrefixFormat*.
+	ChunkContextualizerFormatTitleAncestry = "title_ancestry"
+	ChunkContextualizerFormatRefTitle      = "ref_title"
 )
 
 // Config is the validated workspace configuration resolved from pituitary.toml.
@@ -105,13 +112,29 @@ type Runtime struct {
 // pipeline. A zero value means "no overrides" — the rebuild keeps the
 // pre-#338 default stroma MarkdownPolicy for every record.
 type ChunkingConfig struct {
-	Spec ChunkingKindConfig
-	Doc  ChunkingKindConfig
+	Spec           ChunkingKindConfig
+	Doc            ChunkingKindConfig
+	Contextualizer ChunkingContextualizerConfig
 }
 
-// IsZero reports whether no kind has an override configured.
+// IsZero reports whether no kind or contextualizer override is set.
 func (c ChunkingConfig) IsZero() bool {
-	return c.Spec.IsZero() && c.Doc.IsZero()
+	return c.Spec.IsZero() && c.Doc.IsZero() && c.Contextualizer.IsZero()
+}
+
+// ChunkingContextualizerConfig selects a per-chunk context prefix
+// builder. A zero value means "disabled" — the rebuild produces the
+// same snapshot it did before #343 (no prefix column writes, no
+// reuse-cache invalidation). Opt-in only.
+type ChunkingContextualizerConfig struct {
+	// Format selects the prefix layout. Empty means disabled.
+	// Validated against chunk.PrefixFormat at rebuild resolve time.
+	Format string
+}
+
+// IsZero reports whether the contextualizer is disabled.
+func (c ChunkingContextualizerConfig) IsZero() bool {
+	return strings.TrimSpace(c.Format) == ""
 }
 
 // ChunkingKindConfig is a per-kind chunking override. A zero value means
@@ -215,8 +238,9 @@ type rawRuntime struct {
 }
 
 type rawChunking struct {
-	Spec rawChunkingKind `toml:"spec"`
-	Doc  rawChunkingKind `toml:"doc"`
+	Spec           rawChunkingKind           `toml:"spec"`
+	Doc            rawChunkingKind           `toml:"doc"`
+	Contextualizer rawChunkingContextualizer `toml:"contextualizer"`
 }
 
 type rawChunkingKind struct {
@@ -226,6 +250,10 @@ type rawChunkingKind struct {
 	MaxSections        int    `toml:"max_sections"`
 	ChildMaxTokens     int    `toml:"child_max_tokens"`
 	ChildOverlapTokens int    `toml:"child_overlap_tokens"`
+}
+
+type rawChunkingContextualizer struct {
+	Format string `toml:"format"`
 }
 
 type rawSource struct {
@@ -1174,13 +1202,21 @@ func validateRuntime(runtime *Runtime) error {
 	}
 	validateChunkingKind(&errs, "runtime.chunking.spec", runtime.Chunking.Spec)
 	validateChunkingKind(&errs, "runtime.chunking.doc", runtime.Chunking.Doc)
+	validateChunkingContextualizer(&errs, "runtime.chunking.contextualizer", runtime.Chunking.Contextualizer)
 	return errs.err()
 }
 
 func buildChunkingConfig(raw rawChunking) ChunkingConfig {
 	return ChunkingConfig{
-		Spec: buildChunkingKind(raw.Spec),
-		Doc:  buildChunkingKind(raw.Doc),
+		Spec:           buildChunkingKind(raw.Spec),
+		Doc:            buildChunkingKind(raw.Doc),
+		Contextualizer: buildChunkingContextualizer(raw.Contextualizer),
+	}
+}
+
+func buildChunkingContextualizer(raw rawChunkingContextualizer) ChunkingContextualizerConfig {
+	return ChunkingContextualizerConfig{
+		Format: strings.TrimSpace(raw.Format),
 	}
 }
 
@@ -1227,6 +1263,23 @@ func validateChunkingKind(errs *validationErrors, label string, kind ChunkingKin
 	}
 	if kind.ChildOverlapTokens < 0 {
 		errs.add("%s.child_overlap_tokens: must be >= 0", label)
+	}
+}
+
+func validateChunkingContextualizer(errs *validationErrors, label string, cfg ChunkingContextualizerConfig) {
+	if cfg.IsZero() {
+		return
+	}
+	switch cfg.Format {
+	case ChunkContextualizerFormatTitleAncestry,
+		ChunkContextualizerFormatRefTitle:
+		// valid
+	default:
+		errs.add("%s.format: unsupported format %q (supported: %q, %q)",
+			label, cfg.Format,
+			ChunkContextualizerFormatTitleAncestry,
+			ChunkContextualizerFormatRefTitle,
+		)
 	}
 }
 

--- a/internal/config/parse_toml.go
+++ b/internal/config/parse_toml.go
@@ -102,17 +102,21 @@ func undecodedKeyMessage(key toml.Key) string {
 				if len(key) < 3 {
 					return fmt.Sprintf("unsupported runtime.chunking field %q", strings.Join(key[2:], "."))
 				}
-				if key[2] != "spec" && key[2] != "doc" {
-					return unsupportedFieldMessage("runtime.chunking", key[2], []string{"spec", "doc"})
+				switch key[2] {
+				case "spec", "doc":
+					if len(key) == 3 {
+						return fmt.Sprintf("unsupported runtime.chunking.%s field %q", key[2], strings.Join(key[3:], "."))
+					}
+					scope := "runtime.chunking." + key[2]
+					return unsupportedFieldMessage(scope, strings.Join(key[3:], "."), chunkingKindFields())
+				case "contextualizer":
+					if len(key) == 3 {
+						return fmt.Sprintf("unsupported runtime.chunking.contextualizer field %q", strings.Join(key[3:], "."))
+					}
+					return unsupportedFieldMessage("runtime.chunking.contextualizer", strings.Join(key[3:], "."), chunkingContextualizerFields())
+				default:
+					return unsupportedFieldMessage("runtime.chunking", key[2], []string{"spec", "doc", "contextualizer"})
 				}
-				if len(key) == 3 {
-					// Outer switch already handled bare section; any
-					// extra path element at this length is a toml
-					// oddity, fall through to generic error.
-					return fmt.Sprintf("unsupported runtime.chunking.%s field %q", key[2], strings.Join(key[3:], "."))
-				}
-				scope := "runtime.chunking." + key[2]
-				return unsupportedFieldMessage(scope, strings.Join(key[3:], "."), chunkingKindFields())
 			default:
 				return fmt.Sprintf("unsupported runtime.%s field %q", key[1], strings.Join(key[2:], "."))
 			}
@@ -174,6 +178,10 @@ func chunkingKindFields() []string {
 		"child_max_tokens",
 		"child_overlap_tokens",
 	}
+}
+
+func chunkingContextualizerFields() []string {
+	return []string{"format"}
 }
 
 func unsupportedFieldMessage(scope, field string, valid []string) string {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -56,6 +56,10 @@ func Render(cfg *Config) (string, error) {
 		builder.WriteString("\n[runtime.chunking.doc]\n")
 		writeChunkingKindConfig(&builder, cfg.Runtime.Chunking.Doc)
 	}
+	if !cfg.Runtime.Chunking.Contextualizer.IsZero() {
+		builder.WriteString("\n[runtime.chunking.contextualizer]\n")
+		writeChunkingContextualizerConfig(&builder, cfg.Runtime.Chunking.Contextualizer)
+	}
 
 	if len(cfg.Terminology.ExcludePaths) > 0 {
 		builder.WriteString("\n[terminology]\n")
@@ -133,6 +137,12 @@ func writeRuntimeProviderConfig(builder *strings.Builder, provider RuntimeProvid
 	}
 	if base == nil || provider.MaxResponseTokens != base.MaxResponseTokens {
 		fmt.Fprintf(builder, "max_response_tokens = %d\n", provider.MaxResponseTokens)
+	}
+}
+
+func writeChunkingContextualizerConfig(builder *strings.Builder, cfg ChunkingContextualizerConfig) {
+	if format := strings.TrimSpace(cfg.Format); format != "" {
+		fmt.Fprintf(builder, "format = %s\n", strconv.Quote(format))
 	}
 }
 

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -200,11 +200,16 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 	if err != nil {
 		return nil, fmt.Errorf("resolve chunk policy: %w", err)
 	}
+	contextualizer, err := pchunk.ResolveContextualizer(chunkContextualizerFromRuntime(cfg.Runtime.Chunking))
+	if err != nil {
+		return nil, fmt.Errorf("resolve chunk contextualizer: %w", err)
+	}
 
 	stromaOptions := stindex.BuildOptions{
-		Path:        snapshotPath,
-		Embedder:    embedder,
-		ChunkPolicy: chunkPolicy,
+		Path:           snapshotPath,
+		Embedder:       embedder,
+		ChunkPolicy:    chunkPolicy,
+		Contextualizer: contextualizer,
 	}
 	if !options.Full {
 		// Stroma rebuilds through Path+".new", so reusing the currently published
@@ -267,6 +272,16 @@ func chunkKindFromConfig(kind config.ChunkingKindConfig) pchunk.KindConfig {
 		MaxSections:        kind.MaxSections,
 		ChildMaxTokens:     kind.ChildMaxTokens,
 		ChildOverlapTokens: kind.ChildOverlapTokens,
+	}
+}
+
+// chunkContextualizerFromRuntime adapts the config-layer contextualizer
+// shape to the chunk package's ContextualizerConfig. Format names are
+// duplicated in the config package so this is a pure string copy; the
+// chunk package validates the format at resolve time.
+func chunkContextualizerFromRuntime(cfg config.ChunkingConfig) pchunk.ContextualizerConfig {
+	return pchunk.ContextualizerConfig{
+		Format: pchunk.PrefixFormat(cfg.Contextualizer.Format),
 	}
 }
 


### PR DESCRIPTION
Closes #343.

## Summary

- Threads stroma v2's `index.ChunkContextualizer` through the rebuild path so per-chunk embeddings carry a context prefix composed from the record's identity and heading ancestry.
- Zero-config is a no-op: without `[runtime.chunking.contextualizer]`, `ResolveContextualizer` returns `(nil, nil)` and the rebuild produces the same snapshot (same reuse cache, same embeddings) as pre-#343. Opt-in only.
- Two prefix formats ship: `title_ancestry` (`"<Title> > <heading>"`) and `ref_title` (`"[<Ref>] <Title>"`). Both treat stroma's `section.Heading` as opaque text — no reparsing.

## Design notes

- **Sibling, not nested.** `ResolveContextualizer` lives alongside `Resolve` in `internal/chunk`; `chunk.Config` / `chunk.Resolve` stay byte-identical to what #345 shipped. Contextualization and chunking compose only at `stindex.BuildOptions`.
- **Heading opacity.** Stroma's heading is a ` / `-joined display string without separator escaping. A heading whose text literally contains ` / ` (e.g. `"Latency / Throughput trade-offs"`) must not be split as ancestry. `BuildPrefix` emits the heading verbatim; regression test locks this in at `internal/chunk/contextualizer_test.go`.
- **Full TOML round-trip.** `parse_toml.go` accepts `[runtime.chunking.contextualizer]` as a first-class subtree with suggestions on typos; `render.go` serializes it; a Load → Render → Load round-trip test in `internal/config/chunking_test.go` guards that enabling the contextualizer survives config rewrites.
- **Determinism.** The prefix persists in stroma's `chunks.context_prefix` column and pivots reuse-cache invalidation. `TestBuildPrefix_Deterministic` iterates 32× per format to catch accidental nondeterminism at the unit layer rather than as surprise full-rebuilds in prod.

## What's NOT in this PR (acceptance-criteria follow-ups)

- [ ] Precision@k benchmark on cross-spec heading-collision queries. Needs a representative corpus and harness; likely co-scheduled with #341 matryoshka so the benchmark can compare at multiple dimensions.
- [ ] Nomic/OpenAI strategy-prefix composition test. Stroma wraps our prefix inside the embedder strategy envelope (see `contextualEmbeddingText` in stroma v2), so this is correct by construction, but the AC wants it verified. Add to the benchmark PR.
- [ ] Observability surface for the enabled/disabled state (see follow-up issue filed after merge).

## Pre-commit adversarial review

Ran `/codex:adversarial-review` before commit. First drop had three real blockers, all addressed:
- [critical] The strict TOML parser rejected the new `contextualizer` subtree — the feature was unreachable via the canonical config path. Parser now accepts it with full typo suggestions.
- [high] `Render` omitted the contextualizer block, silently downgrading on round-trip. Fixed + round-trip test added.
- [high] `BuildPrefix` was reparsing stroma's heading separator and would silently corrupt prefixes containing literal ` / `. Redesigned to pass heading opaquely; dropped `title_leaf` (the only format that required extraction).

## Test plan
- [x] `make ci` green locally (fmt / test / vet).
- [x] New chunk-package tests: format output, unknown-format rejection, determinism, interface satisfaction, empty-sections slice, config IsZero.
- [x] New config-package tests: parses contextualizer block, rejects unknown formats / fields / subtrees with suggestions, full Load → Render → Load round-trip.
- [ ] Precision@k benchmark (deferred — see acceptance-criteria follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)