### PR TITLE
Surface chunk contextualizer state in status / rebuild output (#347)

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -210,6 +210,15 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 }
 
 func runIndexUpdate(ctx context.Context, cfg *config.Config, records *source.LoadResult, showDelta bool, format string, stderr io.Writer) (*index.RebuildResult, error) {
+	// Deliberately no emitRebuildContextualizerConfig here: the
+	// incremental update path does not thread ChunkPolicy or
+	// Contextualizer through to stroma (see internal/index/update.go —
+	// no references to either field). Emitting the announcement here
+	// would be an observability lie: we'd tell operators the
+	// contextualizer is active while changed records are processed
+	// through the non-contextual path. Filed separately; keep this
+	// path silent about contextualizer posture until update actually
+	// honors it.
 	progressReporter := indexProgressReporter(format, stderr)
 	if showDelta {
 		return index.UpdateWithDeltaContextAndOptions(ctx, cfg, records, index.UpdateOptions{ComputeDelta: true}, progressReporter)
@@ -218,8 +227,33 @@ func runIndexUpdate(ctx context.Context, cfg *config.Config, records *source.Loa
 }
 
 func runIndexRebuild(ctx context.Context, cfg *config.Config, records *source.LoadResult, full bool, format string, stderr io.Writer) (*index.RebuildResult, error) {
+	emitRebuildContextualizerConfig(cfg, format, stderr)
 	progressReporter := indexProgressReporter(format, stderr)
 	return index.RebuildWithProgressContextAndOptions(ctx, cfg, records, index.RebuildOptions{Full: full}, progressReporter)
+}
+
+// emitRebuildContextualizerConfig announces a non-nil chunk contextualizer
+// once per rebuild, before progress events start. The disabled path is
+// silent per #347 so day-to-day rebuilds stay quiet and only opted-in
+// behavior produces an extra line.
+//
+// Text mode only. JSON mode stderr is a progress-only NDJSON stream
+// (every line is a "rebuild_progress"/"index" event; see the strict
+// decoder in cmd/index_test.go's decodeIndexProgressEvents). Mixing a
+// second event type into that stream would silently break existing
+// strict parsers. Machine consumers should read contextualizer state
+// from `pituitary status --format json`, which carries it on the
+// runtime_config.contextualizer field for both enabled and disabled
+// postures.
+func emitRebuildContextualizerConfig(cfg *config.Config, format string, stderr io.Writer) {
+	if cfg == nil || format != commandFormatText {
+		return
+	}
+	contextualizer := strings.TrimSpace(cfg.Runtime.Chunking.Contextualizer.Format)
+	if contextualizer == "" {
+		return
+	}
+	fmt.Fprintf(stderr, "pituitary index: chunking contextualizer active (format=%s)\n", contextualizer)
 }
 
 func indexProgressReporter(format string, stderr io.Writer) index.RebuildProgressReporter {

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
 )
 
 func TestRunIndexValidatesConfig(t *testing.T) {
@@ -380,6 +382,147 @@ path = "specs"
 	}
 	if !strings.Contains(stderr.String(), `runtime.embedder.endpoint: value is required for provider "openai_compatible"`) {
 		t.Fatalf("runIndex() stderr %q does not contain missing-endpoint detail", stderr.String())
+	}
+}
+
+func TestRunIndexEmitsContextualizerConfigLineInTextMode(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.chunking.contextualizer]
+format = "title_ancestry"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr=%q)", exitCode, stderr.String())
+	}
+
+	progress := stderr.String()
+	want := "pituitary index: chunking contextualizer active (format=title_ancestry)"
+	if !strings.Contains(progress, want) {
+		t.Fatalf("runIndex() stderr %q does not contain %q", progress, want)
+	}
+}
+
+func TestRunIndexJSONRebuildKeepsStderrProgressOnlyWhenContextualizerEnabled(t *testing.T) {
+	// Regression: the JSON stderr stream is a strict NDJSON of
+	// rebuild_progress events (see decodeIndexProgressEvents). The
+	// contextualizer announcement is deliberately text-mode only —
+	// injecting a second event type would break strict parsers.
+	// Machine consumers should read contextualizer posture from
+	// `pituitary status --format json`, not from the rebuild stream.
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.chunking.contextualizer]
+format = "ref_title"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr=%q)", exitCode, stderr.String())
+	}
+
+	if strings.Contains(stderr.String(), "contextualizer") {
+		t.Fatalf("runIndex() JSON stderr %q leaked a contextualizer config line into the progress-only stream", stderr.String())
+	}
+}
+
+func TestEmitRebuildContextualizerConfigTextOnly(t *testing.T) {
+	t.Parallel()
+
+	// Direct helper test: locks both the text-only output and the
+	// JSON-mode silence so a well-meaning future change that adds a
+	// JSON event type back has to update both this test and the
+	// decodeIndexProgressEvents strict decoder together. Nothing
+	// else in cmd/ exercises the JSON-mode helper path directly.
+	cfg := &config.Config{}
+	cfg.Runtime.Chunking.Contextualizer.Format = config.ChunkContextualizerFormatTitleAncestry
+
+	var textOut bytes.Buffer
+	emitRebuildContextualizerConfig(cfg, commandFormatText, &textOut)
+	if got, want := textOut.String(), "pituitary index: chunking contextualizer active (format=title_ancestry)\n"; got != want {
+		t.Fatalf("text mode emit = %q, want %q", got, want)
+	}
+
+	var jsonOut bytes.Buffer
+	emitRebuildContextualizerConfig(cfg, commandFormatJSON, &jsonOut)
+	if jsonOut.Len() != 0 {
+		t.Fatalf("json mode emit = %q, want empty (progress-only stream)", jsonOut.String())
+	}
+
+	var disabledOut bytes.Buffer
+	emitRebuildContextualizerConfig(&config.Config{}, commandFormatText, &disabledOut)
+	if disabledOut.Len() != 0 {
+		t.Fatalf("disabled emit = %q, want empty", disabledOut.String())
+	}
+
+	var nilOut bytes.Buffer
+	emitRebuildContextualizerConfig(nil, commandFormatText, &nilOut)
+	if nilOut.Len() != 0 {
+		t.Fatalf("nil cfg emit = %q, want empty", nilOut.String())
+	}
+}
+
+func TestRunIndexIsSilentAboutContextualizerWhenDisabled(t *testing.T) {
+	// Regression: the zero-config path must not emit a contextualizer
+	// line. Quiet-on-default output is part of the #347 contract so
+	// existing rebuild scripts that grep stderr don't see new noise
+	// after the contextualizer feature is available but not opted in.
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr=%q)", exitCode, stderr.String())
+	}
+
+	if strings.Contains(stderr.String(), "contextualizer") {
+		t.Fatalf("runIndex() stderr %q leaked a contextualizer line on the disabled path", stderr.String())
 	}
 }
 

--- a/cmd/render_status.go
+++ b/cmd/render_status.go
@@ -95,15 +95,20 @@ func renderStatusResult(w io.Writer, result *statusResult) {
 	}
 	if result.RuntimeConfig != nil {
 		fmt.Fprintf(w, "  %s\n", p.white("RUNTIME CONFIG"))
-		for i, item := range []struct {
+		// Providers are never the last tree item anymore — the
+		// contextualizer line below is always emitted (enabled or
+		// disabled) per #347, so both providers are mid-branches.
+		for _, item := range []struct {
 			Name     string
 			Provider statusRuntimeProvider
 		}{
 			{Name: "runtime.embedder", Provider: result.RuntimeConfig.Embedder},
 			{Name: "runtime.analysis", Provider: result.RuntimeConfig.Analysis},
 		} {
-			fmt.Fprintf(w, "  %s %s\n", p.treeItem(i == 1), renderRuntimeProviderSummary(item.Name, item.Provider))
+			fmt.Fprintf(w, "  %s %s\n", p.treeItem(false), renderRuntimeProviderSummary(item.Name, item.Provider))
 		}
+		fmt.Fprintf(w, "  %s runtime.chunking.contextualizer: %s\n",
+			p.treeItem(true), renderContextualizerSummary(result.RuntimeConfig.Contextualizer))
 	}
 	if result.Runtime != nil {
 		fmt.Fprintf(w, "  %s %s\n", p.dim("runtime probe:"), result.Runtime.Scope)
@@ -262,6 +267,17 @@ func renderSpecFamilies(w io.Writer, families *index.FamilyResult) {
 			fmt.Fprintf(w, "    %s ... and %d more\n", p.dim(""), len(families.Ungoverned)-5)
 		}
 	}
+}
+
+// renderContextualizerSummary formats the contextualizer entry in the
+// RUNTIME CONFIG block. Disabled prints "disabled" so an operator can
+// confirm the current posture at a glance; enabled prints
+// "format=<name>" for symmetry with the " | "-joined provider summary.
+func renderContextualizerSummary(format string) string {
+	if format == "" {
+		return "disabled"
+	}
+	return "format=" + format
 }
 
 func renderRuntimeProviderSummary(name string, provider statusRuntimeProvider) string {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -44,6 +44,11 @@ type statusResult struct {
 type statusRuntimeConfig struct {
 	Embedder statusRuntimeProvider `json:"embedder"`
 	Analysis statusRuntimeProvider `json:"analysis"`
+	// Contextualizer is always emitted (no omitempty) so JSON
+	// consumers can distinguish "contextualizer explicitly disabled"
+	// (empty string) from "field absent / schema drift / older
+	// binary". Mirrors the text renderer's always-show posture.
+	Contextualizer string `json:"contextualizer"`
 }
 
 type statusRuntimeProvider struct {
@@ -207,6 +212,7 @@ func newStatusRuntimeConfig(runtimeConfig *app.RuntimeConfigStatus) *statusRunti
 			TimeoutMS:  runtimeConfig.Analysis.TimeoutMS,
 			MaxRetries: runtimeConfig.Analysis.MaxRetries,
 		},
+		Contextualizer: runtimeConfig.Contextualizer,
 	}
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -677,6 +677,159 @@ path = "specs"
 	}
 }
 
+func TestRunStatusShowsContextualizerDisabledByDefault(t *testing.T) {
+	repo := t.TempDir()
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus(nil, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0 (stderr=%q)", exitCode, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "runtime.chunking.contextualizer: disabled") {
+		t.Fatalf("runStatus() output %q does not report contextualizer disabled state", out)
+	}
+}
+
+func TestRunStatusShowsContextualizerFormatWhenEnabled(t *testing.T) {
+	repo := t.TempDir()
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[runtime.chunking.contextualizer]
+format = "title_ancestry"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus(nil, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runStatus() exit code = %d, want 0 (stderr=%q)", exitCode, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "runtime.chunking.contextualizer: format=title_ancestry") {
+		t.Fatalf("runStatus() output %q does not report active contextualizer format", out)
+	}
+	if strings.Contains(out, "runtime.chunking.contextualizer: disabled") {
+		t.Fatalf("runStatus() output %q incorrectly reports disabled when contextualizer is set", out)
+	}
+}
+
+func TestRunStatusJSONSurfacesContextualizerForBothPostures(t *testing.T) {
+	// The JSON status payload carries the contextualizer field
+	// unconditionally (no omitempty) so machine consumers can
+	// distinguish "disabled" (empty string) from "field absent /
+	// older binary / schema drift". Covers both postures in one
+	// test so regression on either path fails loud.
+	type jsonPayload struct {
+		Result struct {
+			RuntimeConfig struct {
+				Contextualizer string `json:"contextualizer"`
+			} `json:"runtime_config"`
+		} `json:"result"`
+	}
+
+	cases := []struct {
+		name          string
+		fixtureBlock  string
+		wantFormatVal string
+	}{
+		{
+			name:          "enabled surfaces format",
+			fixtureBlock:  "[runtime.chunking.contextualizer]\nformat = \"ref_title\"\n",
+			wantFormatVal: "ref_title",
+		},
+		{
+			name:          "disabled surfaces explicit empty string",
+			fixtureBlock:  "",
+			wantFormatVal: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+			mustWriteIndexFixture(t, repo, fmt.Sprintf(`
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+%s
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`, tc.fixtureBlock))
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := withWorkingDir(t, repo, func() int {
+				return runStatus([]string{"--format", "json"}, &stdout, &stderr)
+			})
+			if exitCode != 0 {
+				t.Fatalf("runStatus() exit code = %d, want 0 (stderr=%q)", exitCode, stderr.String())
+			}
+
+			var payload jsonPayload
+			if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+				t.Fatalf("unmarshal status json: %v (stdout=%q)", err, stdout.String())
+			}
+			if got := payload.Result.RuntimeConfig.Contextualizer; got != tc.wantFormatVal {
+				t.Fatalf("result.runtime_config.contextualizer = %q, want %q", got, tc.wantFormatVal)
+			}
+
+			// Regression: the field itself must be present in the
+			// raw JSON even on the disabled path.
+			if !strings.Contains(stdout.String(), `"contextualizer":"`) &&
+				!strings.Contains(stdout.String(), `"contextualizer": "`) {
+				t.Fatalf("status JSON does not carry contextualizer key:\n%s", stdout.String())
+			}
+		})
+	}
+}
+
 func TestRunStatusTextIncludesResolvedRuntimeProfiles(t *testing.T) {
 	repo := t.TempDir()
 	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -30,8 +30,9 @@ type StatusResult struct {
 }
 
 type RuntimeConfigStatus struct {
-	Embedder RuntimeProviderStatus
-	Analysis RuntimeProviderStatus
+	Embedder       RuntimeProviderStatus
+	Analysis       RuntimeProviderStatus
+	Contextualizer string // empty means disabled; otherwise the configured format name.
 }
 
 type RuntimeProviderStatus struct {
@@ -74,8 +75,9 @@ func Status(ctx context.Context, configPath string, request StatusRequest) Respo
 			EmbedderProvider: cfg.Runtime.Embedder.Provider,
 			AnalysisProvider: cfg.Runtime.Analysis.Provider,
 			RuntimeConfig: &RuntimeConfigStatus{
-				Embedder: runtimeProviderStatus(cfg.Runtime.Embedder),
-				Analysis: runtimeProviderStatus(cfg.Runtime.Analysis),
+				Embedder:       runtimeProviderStatus(cfg.Runtime.Embedder),
+				Analysis:       runtimeProviderStatus(cfg.Runtime.Analysis),
+				Contextualizer: cfg.Runtime.Chunking.Contextualizer.Format,
 			},
 			Index:         status,
 			Freshness:     freshness,


### PR DESCRIPTION
Closes #347. Follow-up to #343 / #346.

## Summary

- \`pituitary status\` always reports contextualizer posture as the last entry in the RUNTIME CONFIG block: text prints \`runtime.chunking.contextualizer: format=<name>\` when enabled or \`disabled\` otherwise; JSON carries the same under \`runtime_config.contextualizer\` (no \`omitempty\`, so disabled stays machine-observable).
- \`pituitary index --rebuild\` emits a single text-mode line when the contextualizer is active (\`pituitary index: chunking contextualizer active (format=<name>)\`) and stays silent when disabled, matching the #347 AC.
- JSON stderr remains a progress-only NDJSON stream. The contextualizer does not leak into it — machine consumers read posture from \`pituitary status --format json\`.

## Design notes

- **Status always emits, rebuild only when active.** Intentional asymmetry: status is the "what is active in this workspace?" surface (observability-first), so it must surface the disabled posture too. Rebuild is a per-run log stream where noise matters more than discoverability, so silence on the default path keeps existing CI scripts quiet.
- **Disabled state is machine-observable.** Dropped \`omitempty\` on the status JSON field so consumers can distinguish \`"contextualizer":""\` (disabled) from field absence (older binary / schema drift). Explicit sentinel beats implicit absence.
- **Rebuild JSON stream stays progress-only.** Pituitary's existing \`decodeIndexProgressEvents\` (\`cmd/index_test.go:1043\`) asserts every stderr line is a \`rebuild_progress\`/\`index\` event. Adding a \`rebuild_config\` event into that stream would silently break strict parsers. Kept the one-shot line text-mode only and point machine consumers at \`status\` instead.
- **Update path is intentionally silent.** \`runIndexUpdate\` does not emit because the incremental update code path does not thread \`ChunkPolicy\` or \`Contextualizer\` through to stroma (\`internal/index/update.go:377\` passes only \`Path, Embedder\`). Emitting there would be an observability lie. Filed as **#348** with its own acceptance criteria.

## Pre-commit adversarial review

Ran \`/codex:adversarial-review\` before commit. Three blockers flagged, all addressed:

- **[high]** \`--update\` announcement was a lie — update path ignores the configured contextualizer. Removed the emission from \`runIndexUpdate\` + filed #348 for the underlying threading bug.
- **[high]** The initial JSON \`rebuild_config\` event would break the strict progress-only NDJSON parser. Dropped JSON emission entirely; text-only satisfies the AC and avoids the stream contract break.
- **[medium]** Status JSON hid the disabled state via \`omitempty\`. Removed \`omitempty\` so consumers can distinguish disabled from absent.

## Test plan
- [x] \`make ci\` green locally (fmt + full test + vet).
- [x] Status text: \`runtime.chunking.contextualizer: disabled\` on zero config, \`format=title_ancestry\` when set, mutually exclusive.
- [x] Status JSON: field always present, correct value for both postures (table-driven).
- [x] Rebuild text: emits the active line when enabled.
- [x] Rebuild JSON regression: stderr does not contain a contextualizer line (strict progress-only).
- [x] Rebuild silent-when-disabled regression.
- [x] Direct unit test of \`emitRebuildContextualizerConfig\` locking text-only behavior + JSON no-op + nil-cfg + disabled-format branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)