### PR TITLE
Thread chunking config through incremental update path (#348)

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -210,26 +210,33 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 }
 
 func runIndexUpdate(ctx context.Context, cfg *config.Config, records *source.LoadResult, showDelta bool, format string, stderr io.Writer) (*index.RebuildResult, error) {
-	// Deliberately no emitRebuildContextualizerConfig here: the
-	// incremental update path does not thread ChunkPolicy or
-	// Contextualizer through to stroma (see internal/index/update.go —
-	// no references to either field). Emitting the announcement here
-	// would be an observability lie: we'd tell operators the
-	// contextualizer is active while changed records are processed
-	// through the non-contextual path. Filed separately; keep this
-	// path silent about contextualizer posture until update actually
-	// honors it.
 	progressReporter := indexProgressReporter(format, stderr)
+	var result *index.RebuildResult
+	var err error
 	if showDelta {
-		return index.UpdateWithDeltaContextAndOptions(ctx, cfg, records, index.UpdateOptions{ComputeDelta: true}, progressReporter)
+		result, err = index.UpdateWithDeltaContextAndOptions(ctx, cfg, records, index.UpdateOptions{ComputeDelta: true}, progressReporter)
+	} else {
+		result, err = index.UpdateWithProgressContextAndOptions(ctx, cfg, records, progressReporter)
 	}
-	return index.UpdateWithProgressContextAndOptions(ctx, cfg, records, progressReporter)
+	// Emit the contextualizer line only after a successful update so
+	// stderr never implies that contextualization applied when the
+	// update actually failed before publish.
+	if err == nil {
+		emitRebuildContextualizerConfig(cfg, format, stderr)
+	}
+	return result, err
 }
 
 func runIndexRebuild(ctx context.Context, cfg *config.Config, records *source.LoadResult, full bool, format string, stderr io.Writer) (*index.RebuildResult, error) {
-	emitRebuildContextualizerConfig(cfg, format, stderr)
 	progressReporter := indexProgressReporter(format, stderr)
-	return index.RebuildWithProgressContextAndOptions(ctx, cfg, records, index.RebuildOptions{Full: full}, progressReporter)
+	result, err := index.RebuildWithProgressContextAndOptions(ctx, cfg, records, index.RebuildOptions{Full: full}, progressReporter)
+	// Emit the contextualizer line only after a successful rebuild so
+	// stderr never implies that contextualization applied when the
+	// rebuild actually failed before publish.
+	if err == nil {
+		emitRebuildContextualizerConfig(cfg, format, stderr)
+	}
+	return result, err
 }
 
 // emitRebuildContextualizerConfig announces a non-nil chunk contextualizer

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -239,10 +239,13 @@ func runIndexRebuild(ctx context.Context, cfg *config.Config, records *source.Lo
 	return result, err
 }
 
-// emitRebuildContextualizerConfig announces a non-nil chunk contextualizer
-// once per rebuild, before progress events start. The disabled path is
-// silent per #347 so day-to-day rebuilds stay quiet and only opted-in
-// behavior produces an extra line.
+// emitRebuildContextualizerConfig announces a non-nil chunk
+// contextualizer once per rebuild or update, after the data-path call
+// returns without error. Callers must only invoke this on success so
+// stderr never implies the contextualizer was applied when rebuild or
+// update aborted before publish. The disabled path is silent per #347
+// so day-to-day runs stay quiet and only opted-in behavior produces
+// an extra line.
 //
 // Text mode only. JSON mode stderr is a progress-only NDJSON stream
 // (every line is a "rebuild_progress"/"index" event; see the strict

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -439,6 +439,9 @@ func finalizeBusinessIndexContext(ctx context.Context, db *sql.DB, cfg *config.C
 	if err := upsertMetadataContext(ctx, tx, "source_fingerprint", sourceFingerprint(cfg)); err != nil {
 		return err
 	}
+	if err := upsertMetadataContext(ctx, tx, "chunking_config_fingerprint", chunkingConfigFingerprint(cfg.Runtime.Chunking)); err != nil {
+		return err
+	}
 	if manifest := sourceManifestJSON(cfg); manifest != "" {
 		if err := upsertMetadataContext(ctx, tx, "source_manifest", manifest); err != nil {
 			return err
@@ -891,6 +894,31 @@ func fingerprint(parts []string) string {
 	sort.Strings(parts)
 	hash := sha256.Sum256([]byte(strings.Join(parts, "\n")))
 	return hex.EncodeToString(hash[:])
+}
+
+// chunkingConfigFingerprint is a stable hash of every field that
+// affects how a record is chunked or contextualized. It is persisted
+// at rebuild time and validated on --update so a config change
+// between rebuild and update can't silently produce a snapshot with
+// mixed chunk shapes (old records re-chunked under one policy, new
+// records under another). Any mismatch forces an explicit rebuild.
+func chunkingConfigFingerprint(cfg config.ChunkingConfig) string {
+	parts := []string{
+		"contextualizer_format=" + cfg.Contextualizer.Format,
+		"spec_policy=" + cfg.Spec.Policy,
+		fmt.Sprintf("spec_max_tokens=%d", cfg.Spec.MaxTokens),
+		fmt.Sprintf("spec_overlap_tokens=%d", cfg.Spec.OverlapTokens),
+		fmt.Sprintf("spec_max_sections=%d", cfg.Spec.MaxSections),
+		fmt.Sprintf("spec_child_max_tokens=%d", cfg.Spec.ChildMaxTokens),
+		fmt.Sprintf("spec_child_overlap_tokens=%d", cfg.Spec.ChildOverlapTokens),
+		"doc_policy=" + cfg.Doc.Policy,
+		fmt.Sprintf("doc_max_tokens=%d", cfg.Doc.MaxTokens),
+		fmt.Sprintf("doc_overlap_tokens=%d", cfg.Doc.OverlapTokens),
+		fmt.Sprintf("doc_max_sections=%d", cfg.Doc.MaxSections),
+		fmt.Sprintf("doc_child_max_tokens=%d", cfg.Doc.ChildMaxTokens),
+		fmt.Sprintf("doc_child_overlap_tokens=%d", cfg.Doc.ChildOverlapTokens),
+	}
+	return fingerprint(parts)
 }
 
 // inferASTEdgesContext walks the workspace for code files, extracts symbols via

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -55,7 +55,7 @@ func TestRebuildCreatesSQLiteIndexFromFixtures(t *testing.T) {
 
 	assertCount(t, db, `SELECT COUNT(*) FROM artifacts`, 5)
 	assertCount(t, db, `SELECT COUNT(*) FROM edges`, 9)
-	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 7)
+	assertCount(t, db, `SELECT COUNT(*) FROM metadata`, 8)
 	assertMetadataValue(t, db, "embedder_fingerprint", "fixture|fixture-8d|plain_v1")
 	assertMetadataValue(t, db, "stroma_snapshot_path", stromaSnapshotPathForContent(cfg.Workspace.ResolvedIndexPath, result.ContentFingerprint))
 	assertMetadataValue(t, db, "source_fingerprint", sourceFingerprint(cfg))

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	pchunk "github.com/dusk-network/pituitary/internal/chunk"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
 	stindex "github.com/dusk-network/stroma/v2/index"
@@ -310,6 +311,9 @@ func validateIncrementalUpdateEligibilityContext(ctx context.Context, db *sql.DB
 	if err := validateStoredEmbedderContext(ctx, db, embedder.Fingerprint(), dimension); err != nil {
 		return "", &UpdatePreconditionError{Reason: err.Error()}
 	}
+	if err := validateStoredChunkingConfigContext(ctx, db, cfg.Runtime.Chunking); err != nil {
+		return "", &UpdatePreconditionError{Reason: err.Error(), Action: "run `pituitary index --rebuild`"}
+	}
 
 	snapshotPath, err := stromaSnapshotPathFromDBContext(ctx, db, cfg.Workspace.ResolvedIndexPath)
 	if err != nil {
@@ -332,6 +336,34 @@ func validateIncrementalUpdateEligibilityContext(ctx context.Context, db *sql.DB
 	default:
 		return snapshotPath, nil
 	}
+}
+
+// validateStoredChunkingConfigContext rejects an incremental update
+// whose current chunking/contextualizer config would diverge from the
+// config in force when the snapshot was built. Without this gate,
+// updating after a config change would re-chunk changed records under
+// the new config while leaving unchanged records on the old chunk
+// shapes — a silent mixed-generation snapshot.
+//
+// Older snapshots (built before this fingerprint was persisted) have
+// no stored value; we skip the check in that case rather than
+// force-rebuild every pre-existing index, because rebuild.go did
+// honor the active config even without recording the fingerprint.
+// The first post-fingerprint rebuild self-heals the metadata gap.
+func validateStoredChunkingConfigContext(ctx context.Context, db *sql.DB, current config.ChunkingConfig) error {
+	stored, err := readOptionalMetadataValueContext(ctx, db, "chunking_config_fingerprint")
+	if err != nil {
+		return err
+	}
+	stored = strings.TrimSpace(stored)
+	if stored == "" {
+		return nil
+	}
+	want := chunkingConfigFingerprint(current)
+	if stored != want {
+		return fmt.Errorf("chunking config changed since last rebuild (stored %s, current %s)", stored, want)
+	}
+	return nil
 }
 
 func readRequiredMetadataValueContext(ctx context.Context, db *sql.DB, key string) (string, error) {
@@ -374,9 +406,31 @@ func updateStromaSnapshotContext(
 		}
 		return "", nil, err
 	}
+	// Thread the same chunking config through stroma's Update path
+	// that rebuild.go threads through stroma's Rebuild path. Without
+	// this, a repo configured with per-kind chunking or an opt-in
+	// contextualizer sees those settings honored on --rebuild but
+	// silently ignored on --update, producing mixed chunk shapes or
+	// mixed context_prefix semantics across the same snapshot.
+	chunkPolicy, err := pchunk.Resolve(chunkConfigFromRuntime(cfg.Runtime.Chunking))
+	if err != nil {
+		if cleanupSnapshot != nil {
+			cleanupSnapshot()
+		}
+		return "", nil, fmt.Errorf("resolve chunk policy: %w", err)
+	}
+	contextualizer, err := pchunk.ResolveContextualizer(chunkContextualizerFromRuntime(cfg.Runtime.Chunking))
+	if err != nil {
+		if cleanupSnapshot != nil {
+			cleanupSnapshot()
+		}
+		return "", nil, fmt.Errorf("resolve chunk contextualizer: %w", err)
+	}
 	if _, err := stindex.Update(ctx, selectedRecords, diff.removed, stindex.UpdateOptions{
-		Path:     targetSnapshotPath,
-		Embedder: embedder,
+		Path:           targetSnapshotPath,
+		Embedder:       embedder,
+		ChunkPolicy:    chunkPolicy,
+		Contextualizer: contextualizer,
 	}); err != nil {
 		if cleanupSnapshot != nil {
 			cleanupSnapshot()

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -349,7 +349,9 @@ func validateIncrementalUpdateEligibilityContext(ctx context.Context, db *sql.DB
 // no stored value; we skip the check in that case rather than
 // force-rebuild every pre-existing index, because rebuild.go did
 // honor the active config even without recording the fingerprint.
-// The first post-fingerprint rebuild self-heals the metadata gap.
+// The metadata gap is self-healed by the first rebuild OR update
+// after this change, since publishBusinessIndexContext runs on both
+// paths and upserts chunking_config_fingerprint unconditionally.
 func validateStoredChunkingConfigContext(ctx context.Context, db *sql.DB, current config.ChunkingConfig) error {
 	stored, err := readOptionalMetadataValueContext(ctx, db, "chunking_config_fingerprint")
 	if err != nil {

--- a/internal/index/update_test.go
+++ b/internal/index/update_test.go
@@ -679,6 +679,350 @@ func TestUpdateDeltaNoOpHasNoChanges(t *testing.T) {
 	}
 }
 
+// TestUpdateContextualizerPrefixMatchesFreshRebuild is the regression
+// guard for #348: before this fix, stindex.Update was called without
+// Contextualizer set, so changed records re-embedded with empty
+// context_prefix while unchanged records kept the prefix stroma had
+// persisted on the initial rebuild. The snapshot ended up with mixed
+// semantics — old records with prefixes, new records without. This
+// test proves that an incremental update now produces byte-identical
+// context_prefix values to what a fresh rebuild at the updated state
+// would produce.
+func TestUpdateContextualizerPrefixMatchesFreshRebuild(t *testing.T) {
+	t.Parallel()
+
+	// Workspace A: rebuild → modify one doc → update.
+	incrementalCfg, changedPrefix, unchangedPrefix := prefixesAfterUpdate(t)
+
+	// Workspace B: rebuild directly against the modified content.
+	freshChanged, freshUnchanged := prefixesAfterFreshRebuild(t)
+
+	if changedPrefix == "" {
+		t.Fatalf("workspace A post-update context_prefix (changed doc) is empty; contextualizer did not run on update (cfg.IndexPath=%s)", incrementalCfg.Workspace.ResolvedIndexPath)
+	}
+	if changedPrefix != freshChanged {
+		t.Fatalf("post-update context_prefix (changed) = %q, want %q (fresh rebuild)", changedPrefix, freshChanged)
+	}
+	// Regression: the unchanged record must keep its original prefix
+	// too — reuse logic in stroma can only preserve the prefix if
+	// rebuild persisted a prefix and update didn't wipe it. A bug in
+	// the threading that "mostly works" might re-chunk the changed
+	// record correctly but invalidate reuse for the unchanged one.
+	if unchangedPrefix == "" {
+		t.Fatalf("workspace A post-update context_prefix (unchanged doc) is empty; reuse dropped the stored prefix")
+	}
+	if unchangedPrefix != freshUnchanged {
+		t.Fatalf("post-update context_prefix (unchanged) = %q, want %q (fresh rebuild)", unchangedPrefix, freshUnchanged)
+	}
+}
+
+// TestUpdateChunkingConfigSkewTriggersFullRebuild is the regression
+// guard for the config-skew hazard flagged in the adversarial review
+// of #348: after an operator changes runtime.chunking config between
+// rebuild and update, the incremental path would otherwise re-chunk
+// changed records under the new config while leaving unchanged
+// records on the old chunk shapes, silently producing a mixed-
+// generation snapshot. The rebuild-time chunking_config_fingerprint
+// plus the precondition check at
+// validateStoredChunkingConfigContext route the update through the
+// existing precondition→fallback-to-full-rebuild path, producing a
+// coherent snapshot without operator intervention.
+func TestUpdateChunkingConfigSkewTriggersFullRebuild(t *testing.T) {
+	t.Parallel()
+
+	repoDir, indexPath := t.TempDir(), filepath.Join(t.TempDir(), "pituitary.db")
+	configPath := filepath.Join(t.TempDir(), "pituitary.toml")
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guides", "mutable.md"), "# Mutable\n\n## Policy\n\ninitial body.\n")
+	writeContextualizerConfig(t, configPath, repoDir, indexPath, "")
+	if _, err := loadAndRebuild(t, configPath); err != nil {
+		t.Fatalf("initial rebuild: %v", err)
+	}
+
+	// Operator enables the contextualizer and runs --update.
+	writeContextualizerConfig(t, configPath, repoDir, indexPath, "title_ancestry")
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig: %v", err)
+	}
+	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	if err != nil {
+		t.Fatalf("UpdateContextWithOptions: %v", err)
+	}
+	if !result.FullRebuild {
+		t.Fatalf("result.FullRebuild = false, want true (config skew should force a full rebuild fallback); result=%+v", result)
+	}
+	// With the rebuild fallback, every record gets the new prefix
+	// applied — no mixed-generation snapshot.
+	if got := firstChunkContextPrefix(t, cfg.Workspace.ResolvedIndexPath, "doc://guides/mutable"); got == "" {
+		t.Fatalf("expected contextualizer prefix on mutable doc after fallback rebuild; got empty")
+	}
+}
+
+func writeContextualizerConfig(t *testing.T, configPath, repoDir, indexPath, format string) {
+	t.Helper()
+	block := ""
+	if format != "" {
+		block = fmt.Sprintf("\n[runtime.chunking.contextualizer]\nformat = %q\n", format)
+	}
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repoDir)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+`+block+`
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+}
+
+// TestUpdateChunkPolicyAppliedToChangedRecord is the regression guard
+// for the chunk-policy half of #348: before this fix, the per-kind
+// ChunkPolicy was not threaded into stindex.Update, so changed records
+// re-chunked through stroma's default MarkdownPolicy instead of the
+// configured policy. We prove parity here by comparing section count
+// for a changed record against what a fresh rebuild produces.
+func TestUpdateChunkPolicyAppliedToChangedRecord(t *testing.T) {
+	t.Parallel()
+
+	incrementalCount, _ := sectionCountAndHeadingsAfterUpdate(t)
+	freshCount, _ := sectionCountAndHeadingsAfterFreshRebuild(t)
+
+	if incrementalCount == 0 {
+		t.Fatal("workspace A post-update section count is 0; update did not persist the changed record")
+	}
+	if incrementalCount != freshCount {
+		t.Fatalf("post-update section count = %d, want %d (fresh rebuild); update path is not applying configured ChunkPolicy (fell back to default MarkdownPolicy heading-split)", incrementalCount, freshCount)
+	}
+}
+
+// prefixesAfterUpdate walks a rebuild → modify one doc → update
+// sequence with contextualizer enabled and returns the persisted
+// context_prefix for both a changed doc and an unchanged sibling.
+// The unchanged sibling is critical: it catches bugs where the
+// update path correctly re-chunks the changed doc but drops or
+// mutates reused prefixes for records that shouldn't have touched.
+func prefixesAfterUpdate(t *testing.T) (cfg *config.Config, changed, unchanged string) {
+	t.Helper()
+	repoDir, configPath, _ := contextualizerFixture(t, "initial")
+	cfg, err := loadAndRebuild(t, configPath)
+	if err != nil {
+		t.Fatalf("initial rebuild: %v", err)
+	}
+
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guides", "mutable.md"),
+		"# Mutable\n\n## Policy\n\nupdated body for parity test.\n")
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig (post-edit): %v", err)
+	}
+	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	if err != nil {
+		t.Fatalf("UpdateContextWithOptions: %v", err)
+	}
+	if result.FullRebuild {
+		t.Fatalf("update fell through to full rebuild; cannot exercise the incremental path")
+	}
+	return cfg,
+		firstChunkContextPrefix(t, cfg.Workspace.ResolvedIndexPath, "doc://guides/mutable"),
+		firstChunkContextPrefix(t, cfg.Workspace.ResolvedIndexPath, "doc://guides/stable")
+}
+
+// prefixesAfterFreshRebuild does a single rebuild against the
+// already-updated content and returns both the changed and unchanged
+// records' first-chunk prefixes.
+func prefixesAfterFreshRebuild(t *testing.T) (changed, unchanged string) {
+	t.Helper()
+	_, configPath, _ := contextualizerFixture(t, "updated")
+	cfg, err := loadAndRebuild(t, configPath)
+	if err != nil {
+		t.Fatalf("fresh rebuild: %v", err)
+	}
+	return firstChunkContextPrefix(t, cfg.Workspace.ResolvedIndexPath, "doc://guides/mutable"),
+		firstChunkContextPrefix(t, cfg.Workspace.ResolvedIndexPath, "doc://guides/stable")
+}
+
+// sectionCountAndHeadingsAfterUpdate runs rebuild → modify → update
+// with a non-default ChunkPolicy and returns the section count +
+// headings for the changed record.
+func sectionCountAndHeadingsAfterUpdate(t *testing.T) (int, []string) {
+	t.Helper()
+	repoDir, configPath, _ := chunkPolicyFixture(t, "initial")
+	cfg, err := loadAndRebuild(t, configPath)
+	if err != nil {
+		t.Fatalf("initial rebuild: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guides", "mutable.md"),
+		"# Mutable\n\n## Policy\n\nSection one body with several descriptive words for token-budget.\n\n## Retention\n\nSection two body with several additional descriptive words for token-budget.\n\n## Expiry\n\nSection three body with several more descriptive words for token-budget.\n")
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig (post-edit): %v", err)
+	}
+	result, err := UpdateContextWithOptions(context.Background(), cfg, records)
+	if err != nil {
+		t.Fatalf("UpdateContextWithOptions: %v", err)
+	}
+	if result.FullRebuild {
+		t.Fatalf("update fell through to full rebuild; cannot exercise the incremental path")
+	}
+	return chunkDetailsForRecord(t, cfg.Workspace.ResolvedIndexPath, "doc://guides/mutable")
+}
+
+// sectionCountAndHeadingsAfterFreshRebuild rebuilds directly against
+// the post-edit content with the same ChunkPolicy and returns the
+// changed record's section count + headings.
+func sectionCountAndHeadingsAfterFreshRebuild(t *testing.T) (int, []string) {
+	t.Helper()
+	_, configPath, _ := chunkPolicyFixture(t, "updated")
+	cfg, err := loadAndRebuild(t, configPath)
+	if err != nil {
+		t.Fatalf("fresh rebuild: %v", err)
+	}
+	return chunkDetailsForRecord(t, cfg.Workspace.ResolvedIndexPath, "doc://guides/mutable")
+}
+
+// contextualizerFixture writes a workspace with the contextualizer
+// enabled. The content stage ("initial" or "updated") selects whether
+// the mutable doc has its pre- or post-edit body so the same function
+// covers both halves of the rebuild/update parity comparison.
+func contextualizerFixture(t *testing.T, stage string) (repoDir, configPath, indexPath string) {
+	t.Helper()
+	repoDir = t.TempDir()
+	indexPath = filepath.Join(t.TempDir(), "pituitary.db")
+	configPath = filepath.Join(t.TempDir(), "pituitary.toml")
+
+	body := "# Mutable\n\n## Policy\n\ninitial body.\n"
+	if stage == "updated" {
+		body = "# Mutable\n\n## Policy\n\nupdated body for parity test.\n"
+	}
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guides", "mutable.md"), body)
+	// Second doc — never edited across stages. Its prefix must
+	// survive an incremental update unchanged so the test can prove
+	// the update path preserved the reused chunk's context_prefix
+	// column rather than wiping it.
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guides", "stable.md"),
+		"# Stable\n\n## Reference\n\nbody that never changes.\n")
+
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repoDir)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[runtime.chunking.contextualizer]
+format = "title_ancestry"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+	return repoDir, configPath, indexPath
+}
+
+// chunkPolicyFixture writes a workspace configured with late_chunk
+// for docs. Late-chunking emits parent + leaf chunks, so the stored
+// chunk count for a multi-section record differs structurally from
+// what stroma's default MarkdownPolicy would produce — that
+// divergence is the signal the test pivots on to prove the policy is
+// honored on the update path and not silently reverted to the
+// default.
+func chunkPolicyFixture(t *testing.T, stage string) (repoDir, configPath, indexPath string) {
+	t.Helper()
+	repoDir = t.TempDir()
+	indexPath = filepath.Join(t.TempDir(), "pituitary.db")
+	configPath = filepath.Join(t.TempDir(), "pituitary.toml")
+
+	body := "# Mutable\n\n## Policy\n\ninitial body paragraph.\n"
+	if stage == "updated" {
+		body = "# Mutable\n\n## Policy\n\nSection one body with several descriptive words for token-budget.\n\n## Retention\n\nSection two body with several additional descriptive words for token-budget.\n\n## Expiry\n\nSection three body with several more descriptive words for token-budget.\n"
+	}
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guides", "mutable.md"), body)
+
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repoDir)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[runtime.chunking.doc]
+policy = "late_chunk"
+max_tokens = 64
+child_max_tokens = 4
+child_overlap_tokens = 1
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+	return repoDir, configPath, indexPath
+}
+
+// firstChunkContextPrefix reads the persisted context_prefix for the
+// first chunk of the named record from the stroma snapshot DB.
+func firstChunkContextPrefix(t *testing.T, indexPath, recordRef string) string {
+	t.Helper()
+	db := mustOpenCorpusReadOnly(t, indexPath)
+	defer db.Close()
+	var prefix string
+	if err := db.QueryRow(
+		`SELECT context_prefix FROM chunks WHERE record_ref = ? ORDER BY id LIMIT 1`,
+		recordRef,
+	).Scan(&prefix); err != nil {
+		t.Fatalf("query context_prefix for %s: %v", recordRef, err)
+	}
+	return prefix
+}
+
+// chunkDetailsForRecord returns the chunk count and headings stored
+// for the named record in the snapshot, preserving id-order.
+func chunkDetailsForRecord(t *testing.T, indexPath, recordRef string) (int, []string) {
+	t.Helper()
+	db := mustOpenCorpusReadOnly(t, indexPath)
+	defer db.Close()
+	rows, err := db.Query(
+		`SELECT heading FROM chunks WHERE record_ref = ? ORDER BY id`,
+		recordRef,
+	)
+	if err != nil {
+		t.Fatalf("query chunks for %s: %v", recordRef, err)
+	}
+	defer rows.Close()
+	var headings []string
+	for rows.Next() {
+		var h string
+		if err := rows.Scan(&h); err != nil {
+			t.Fatalf("scan chunk for %s: %v", recordRef, err)
+		}
+		headings = append(headings, h)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate chunks for %s: %v", recordRef, err)
+	}
+	return len(headings), headings
+}
+
 // loadAndRebuild loads config and performs an initial rebuild.
 func loadAndRebuild(t *testing.T, configPath string) (*config.Config, error) {
 	t.Helper()


### PR DESCRIPTION
Closes #348. Completes the #345/#346 threading: chunking config is now honored equally on \`--rebuild\` and \`--update\`, with a fingerprint-based precondition that protects against config-skew mixed-generation snapshots.

## Summary

- \`internal/index/update.go\` now passes \`ChunkPolicy\` and \`Contextualizer\` into \`stindex.UpdateOptions\`, resolved via the same \`pchunk.Resolve\` / \`pchunk.ResolveContextualizer\` helpers rebuild.go already uses.
- Rebuild persists a \`chunking_config_fingerprint\` (stable hash of every field that affects chunk shape or prefix) to snapshot metadata; update validates it against the current config and routes to the existing \`rebuildUpdateContext\` fallback on mismatch. Config skew becomes a silent rebuild-through-fallback rather than a silent mixed-generation snapshot.
- \`cmd/index.go\` moves the contextualizer stderr announcement to *after* the data-path call succeeds on both rebuild and update, so a failed rebuild never leaves stderr implying contextualization applied.

## Tests

Three regression tests, each demonstrated to fail against a reverted fix before being relied on:

- **Contextualizer parity**: rebuild → edit one of two docs → update, then compare \`context_prefix\` against a fresh rebuild at the updated state. Asserts both the *changed* record (re-chunked with the policy) and an *unchanged* sibling (reused from the prior snapshot) end up with byte-identical prefixes. The unchanged-sibling assertion specifically catches bugs where update "mostly works" but invalidates reuse.
- **ChunkPolicy parity**: same shape, but uses \`late_chunk\` (parent + leaf chunks) so the stored chunk count structurally diverges from stroma's default \`MarkdownPolicy\`. Fails by 9 chunks when ChunkPolicy is not threaded.
- **Config-skew fallback**: rebuild with contextualizer disabled, enable it in config, run \`--update\`. Asserts \`result.FullRebuild == true\` and that the resulting snapshot's context_prefix is populated — proving the fingerprint check routes the operator to a coherent snapshot without intervention.

## Pre-commit adversarial review

Ran \`/codex:adversarial-review\`. Three blockers flagged, all addressed:

- **[high]** Config-skew silent divergence: my initial threading fix correctly applied chunking to changed records but left unchanged records on old chunk shapes when config changed between rebuild and update. Added \`chunking_config_fingerprint\` + precondition check.
- **[medium]** Parity tests too shallow: the initial version had only one doc per fixture, couldn't catch reuse-path bugs. Added an unchanged sibling to the contextualizer fixture + assertion.
- **[medium]** Announcement before preflight: emission happened before the stroma call, so a failed update left stderr implying success. Moved emission to after the data-path call returns without error (both rebuild and update paths).

## Test plan
- [x] \`make ci\` green locally (fmt + test + vet).
- [x] New tests fail against a reverted fix (TDD sanity check).
- [x] Existing metadata-count test updated for the new fingerprint column.
- [x] Full-text/FTS regression surfaces unchanged (stroma internals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)