### PR TITLE
Adopt pluggable fusion + per-arm provenance for governance-aware retrieval (#342)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,21 @@ const (
 	// ChunkPolicy* above. Kept in lock-step with chunk.PrefixFormat*.
 	ChunkContextualizerFormatTitleAncestry = "title_ancestry"
 	ChunkContextualizerFormatRefTitle      = "ref_title"
+
+	// Search fusion strategy names. Duplicated here (rather than
+	// imported from internal/fusion) to keep the config package
+	// dependency-free of stroma, matching the ChunkPolicy* pattern
+	// above. Kept in lock-step with fusion.Strategy*.
+	SearchFusionStrategyDefault = "default_rrf"
+	SearchFusionStrategyRRF     = "rrf"
+
+	// Search reranker policies. Empty / SearchRerankerHistorical
+	// preserve the pre-#342 historicalSectionReranker byte-for-byte.
+	// SearchRerankerArmAwareHistorical opts in to a governance-aware
+	// reranker that reads HitProvenance.Arms to prefer FTS-sourced hits
+	// when query terminology matches the hit's section heading.
+	SearchRerankerHistorical         = "historical"
+	SearchRerankerArmAwareHistorical = "arm_aware_historical"
 )
 
 // Config is the validated workspace configuration resolved from pituitary.toml.
@@ -106,6 +121,47 @@ type Runtime struct {
 	Embedder RuntimeProvider
 	Analysis RuntimeProvider
 	Chunking ChunkingConfig
+	Search   SearchConfig
+}
+
+// SearchConfig groups search-time overrides for the retrieval pipeline.
+// A zero value means "no overrides" — snapshot.Search keeps stroma's
+// DefaultFusion() governing hybrid retrieval exactly as it did pre-#342
+// and the historicalSectionReranker stays the sole reranker.
+type SearchConfig struct {
+	Fusion FusionConfig
+
+	// Reranker selects the governance-aware reranker. Empty or
+	// SearchRerankerHistorical preserves the pre-#342 behavior.
+	// SearchRerankerArmAwareHistorical opts in to reading
+	// HitProvenance.Arms.
+	Reranker string
+}
+
+// IsZero reports whether no search override is configured.
+func (c SearchConfig) IsZero() bool {
+	return c.Fusion.IsZero() && strings.TrimSpace(c.Reranker) == ""
+}
+
+// FusionConfig tunes the hybrid-search fusion strategy. A zero value
+// (or Strategy == SearchFusionStrategyDefault with K == 0) resolves to
+// nil so stroma's DefaultFusion() governs the call site byte-for-byte.
+type FusionConfig struct {
+	// Strategy selects the fusion implementation. Empty or
+	// SearchFusionStrategyDefault preserves stroma's DefaultFusion().
+	// SearchFusionStrategyRRF selects an explicit RRFFusion parameterised
+	// by K.
+	Strategy string
+
+	// K is the RRF constant. Only applies to SearchFusionStrategyRRF and
+	// must be > 0 there. Zero under SearchFusionStrategyDefault is valid
+	// and means "no override".
+	K int
+}
+
+// IsZero reports whether no fusion override is configured.
+func (c FusionConfig) IsZero() bool {
+	return c == FusionConfig{}
 }
 
 // ChunkingConfig groups per-kind chunking overrides for the rebuild
@@ -235,6 +291,17 @@ type rawRuntime struct {
 	Embedder rawRuntimeProvider            `toml:"embedder"`
 	Analysis rawRuntimeProvider            `toml:"analysis"`
 	Chunking rawChunking                   `toml:"chunking"`
+	Search   rawSearch                     `toml:"search"`
+}
+
+type rawSearch struct {
+	Fusion   rawSearchFusion `toml:"fusion"`
+	Reranker string          `toml:"reranker"`
+}
+
+type rawSearchFusion struct {
+	Strategy string `toml:"strategy"`
+	K        int    `toml:"k"`
 }
 
 type rawChunking struct {
@@ -417,6 +484,7 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 			Embedder: buildRuntimeProvider(raw.Runtime.Embedder, RuntimeProviderFixture),
 			Analysis: buildRuntimeProvider(raw.Runtime.Analysis, RuntimeProviderDisabled),
 			Chunking: buildChunkingConfig(raw.Runtime.Chunking),
+			Search:   buildSearchConfig(raw.Runtime.Search),
 		},
 		Terminology: Terminology{
 			ExcludePaths: uniqueStringList(raw.Terminology.ExcludePaths),
@@ -1203,6 +1271,7 @@ func validateRuntime(runtime *Runtime) error {
 	validateChunkingKind(&errs, "runtime.chunking.spec", runtime.Chunking.Spec)
 	validateChunkingKind(&errs, "runtime.chunking.doc", runtime.Chunking.Doc)
 	validateChunkingContextualizer(&errs, "runtime.chunking.contextualizer", runtime.Chunking.Contextualizer)
+	validateSearchConfig(&errs, "runtime.search", runtime.Search)
 	return errs.err()
 }
 
@@ -1280,6 +1349,59 @@ func validateChunkingContextualizer(errs *validationErrors, label string, cfg Ch
 			ChunkContextualizerFormatTitleAncestry,
 			ChunkContextualizerFormatRefTitle,
 		)
+	}
+}
+
+func buildSearchConfig(raw rawSearch) SearchConfig {
+	return SearchConfig{
+		Fusion:   buildFusionConfig(raw.Fusion),
+		Reranker: strings.TrimSpace(raw.Reranker),
+	}
+}
+
+func buildFusionConfig(raw rawSearchFusion) FusionConfig {
+	return FusionConfig{
+		Strategy: strings.TrimSpace(raw.Strategy),
+		K:        raw.K,
+	}
+}
+
+func validateSearchConfig(errs *validationErrors, label string, cfg SearchConfig) {
+	validateFusionConfig(errs, label+".fusion", cfg.Fusion)
+	switch cfg.Reranker {
+	case "", SearchRerankerHistorical, SearchRerankerArmAwareHistorical:
+		// valid
+	default:
+		errs.add("%s.reranker: unsupported reranker %q (supported: %q, %q)",
+			label, cfg.Reranker,
+			SearchRerankerHistorical,
+			SearchRerankerArmAwareHistorical,
+		)
+	}
+}
+
+func validateFusionConfig(errs *validationErrors, label string, cfg FusionConfig) {
+	if cfg.IsZero() {
+		return
+	}
+	switch cfg.Strategy {
+	case "", SearchFusionStrategyDefault:
+		if cfg.K != 0 {
+			errs.add("%s.k: only applies to strategy %q", label, SearchFusionStrategyRRF)
+		}
+	case SearchFusionStrategyRRF:
+		if cfg.K <= 0 {
+			errs.add("%s.k: must be > 0 for strategy %q", label, SearchFusionStrategyRRF)
+		}
+	default:
+		errs.add("%s.strategy: unsupported strategy %q (supported: %q, %q)",
+			label, cfg.Strategy,
+			SearchFusionStrategyDefault,
+			SearchFusionStrategyRRF,
+		)
+	}
+	if cfg.K < 0 {
+		errs.add("%s.k: must be >= 0", label)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1400,9 +1400,6 @@ func validateFusionConfig(errs *validationErrors, label string, cfg FusionConfig
 			SearchFusionStrategyRRF,
 		)
 	}
-	if cfg.K < 0 {
-		errs.add("%s.k: must be >= 0", label)
-	}
 }
 
 func buildRuntimeProvider(raw rawRuntimeProvider, defaultProvider string) RuntimeProvider {

--- a/internal/config/parse_toml.go
+++ b/internal/config/parse_toml.go
@@ -80,7 +80,7 @@ func undecodedKeyMessage(key toml.Key) string {
 	case "runtime":
 		switch len(key) {
 		case 2:
-			return unsupportedFieldMessage("runtime", key[1], []string{"profiles", "embedder", "analysis", "chunking"})
+			return unsupportedFieldMessage("runtime", key[1], []string{"profiles", "embedder", "analysis", "chunking", "search"})
 		default:
 			switch key[1] {
 			case "embedder", "analysis":
@@ -116,6 +116,19 @@ func undecodedKeyMessage(key toml.Key) string {
 					return unsupportedFieldMessage("runtime.chunking.contextualizer", strings.Join(key[3:], "."), chunkingContextualizerFields())
 				default:
 					return unsupportedFieldMessage("runtime.chunking", key[2], []string{"spec", "doc", "contextualizer"})
+				}
+			case "search":
+				if len(key) < 3 {
+					return fmt.Sprintf("unsupported runtime.search field %q", strings.Join(key[2:], "."))
+				}
+				switch key[2] {
+				case "fusion":
+					if len(key) == 3 {
+						return fmt.Sprintf("unsupported runtime.search.fusion field %q", strings.Join(key[3:], "."))
+					}
+					return unsupportedFieldMessage("runtime.search.fusion", strings.Join(key[3:], "."), searchFusionFields())
+				default:
+					return unsupportedFieldMessage("runtime.search", key[2], []string{"fusion", "reranker"})
 				}
 			default:
 				return fmt.Sprintf("unsupported runtime.%s field %q", key[1], strings.Join(key[2:], "."))
@@ -182,6 +195,10 @@ func chunkingKindFields() []string {
 
 func chunkingContextualizerFields() []string {
 	return []string{"format"}
+}
+
+func searchFusionFields() []string {
+	return []string{"strategy", "k"}
 }
 
 func unsupportedFieldMessage(scope, field string, valid []string) string {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -61,6 +61,17 @@ func Render(cfg *Config) (string, error) {
 		writeChunkingContextualizerConfig(&builder, cfg.Runtime.Chunking.Contextualizer)
 	}
 
+	if !cfg.Runtime.Search.IsZero() {
+		if reranker := strings.TrimSpace(cfg.Runtime.Search.Reranker); reranker != "" {
+			builder.WriteString("\n[runtime.search]\n")
+			fmt.Fprintf(&builder, "reranker = %s\n", strconv.Quote(reranker))
+		}
+		if !cfg.Runtime.Search.Fusion.IsZero() {
+			builder.WriteString("\n[runtime.search.fusion]\n")
+			writeSearchFusionConfig(&builder, cfg.Runtime.Search.Fusion)
+		}
+	}
+
 	if len(cfg.Terminology.ExcludePaths) > 0 {
 		builder.WriteString("\n[terminology]\n")
 		writeQuotedArray(&builder, "exclude_paths", cfg.Terminology.ExcludePaths)
@@ -143,6 +154,15 @@ func writeRuntimeProviderConfig(builder *strings.Builder, provider RuntimeProvid
 func writeChunkingContextualizerConfig(builder *strings.Builder, cfg ChunkingContextualizerConfig) {
 	if format := strings.TrimSpace(cfg.Format); format != "" {
 		fmt.Fprintf(builder, "format = %s\n", strconv.Quote(format))
+	}
+}
+
+func writeSearchFusionConfig(builder *strings.Builder, cfg FusionConfig) {
+	if strategy := strings.TrimSpace(cfg.Strategy); strategy != "" {
+		fmt.Fprintf(builder, "strategy = %s\n", strconv.Quote(strategy))
+	}
+	if cfg.K != 0 {
+		fmt.Fprintf(builder, "k = %d\n", cfg.K)
 	}
 }
 

--- a/internal/config/search_test.go
+++ b/internal/config/search_test.go
@@ -1,0 +1,245 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadRuntimeSearchDefaultsToZero(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+`)
+
+	if !cfg.Runtime.Search.IsZero() {
+		t.Fatalf("runtime.search should be zero by default; got %+v", cfg.Runtime.Search)
+	}
+}
+
+func TestLoadRuntimeSearchParsesFusion(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search.fusion]
+strategy = "rrf"
+k = 80
+`)
+
+	fusion := cfg.Runtime.Search.Fusion
+	if fusion.Strategy != SearchFusionStrategyRRF {
+		t.Fatalf("fusion.strategy = %q, want %q", fusion.Strategy, SearchFusionStrategyRRF)
+	}
+	if fusion.K != 80 {
+		t.Fatalf("fusion.k = %d, want 80", fusion.K)
+	}
+}
+
+func TestLoadRuntimeSearchParsesReranker(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search]
+reranker = "arm_aware_historical"
+`)
+
+	if got := cfg.Runtime.Search.Reranker; got != SearchRerankerArmAwareHistorical {
+		t.Fatalf("search.reranker = %q, want %q", got, SearchRerankerArmAwareHistorical)
+	}
+}
+
+func TestLoadRuntimeSearchRejectsRRFWithoutK(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search.fusion]
+strategy = "rrf"
+`)
+	if err == nil {
+		t.Fatal("expected error when strategy = rrf has no k")
+	}
+	if !strings.Contains(err.Error(), "fusion.k") {
+		t.Fatalf("error should mention fusion.k; got %v", err)
+	}
+}
+
+func TestLoadRuntimeSearchRejectsDefaultStrategyWithK(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search.fusion]
+strategy = "default_rrf"
+k = 60
+`)
+	if err == nil {
+		t.Fatal("expected error when k is set alongside default_rrf strategy")
+	}
+	if !strings.Contains(err.Error(), SearchFusionStrategyRRF) {
+		t.Fatalf("error should steer users to the rrf strategy; got %v", err)
+	}
+}
+
+func TestLoadRuntimeSearchRejectsUnknownStrategy(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search.fusion]
+strategy = "weighted_sum"
+k = 60
+`)
+	if err == nil {
+		t.Fatal("expected error for unknown fusion strategy")
+	}
+	if !strings.Contains(err.Error(), "unsupported strategy") {
+		t.Fatalf("error should call out unsupported strategy; got %v", err)
+	}
+}
+
+func TestLoadRuntimeSearchRejectsUnknownReranker(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search]
+reranker = "no_such_reranker"
+`)
+	if err == nil {
+		t.Fatal("expected error for unknown reranker policy")
+	}
+	if !strings.Contains(err.Error(), "reranker") {
+		t.Fatalf("error should mention reranker; got %v", err)
+	}
+}
+
+// Regression for the #346 ghost-field bug: the strict-field parser must
+// reject unknown keys under [runtime.search.fusion] so a typo does not
+// silently fall through to stroma's DefaultFusion() and appear to work.
+func TestLoadRuntimeSearchRejectsGhostFusionField(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search.fusion]
+strategy = "rrf"
+k = 60
+unknown_knob = true
+`)
+	if err == nil {
+		t.Fatal("expected ghost-field error for runtime.search.fusion.unknown_knob")
+	}
+	if !strings.Contains(err.Error(), "unknown_knob") {
+		t.Fatalf("error should name the unknown field; got %v", err)
+	}
+}
+
+func TestLoadRuntimeSearchRejectsGhostSearchSubtree(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search.gadget]
+any = "thing"
+`)
+	if err == nil {
+		t.Fatal("expected error for unknown subtree under runtime.search")
+	}
+	if !strings.Contains(err.Error(), `"fusion"`) {
+		t.Fatalf("error should suggest fusion as the supported subtree; got %v", err)
+	}
+}
+
+func TestRenderRoundTripPreservesSearchFusion(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search.fusion]
+strategy = "rrf"
+k = 80
+`)
+
+	rendered, err := Render(cfg)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(rendered, "[runtime.search.fusion]") {
+		t.Fatalf("rendered output missing search fusion block:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `strategy = "rrf"`) {
+		t.Fatalf("rendered output missing strategy value:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "k = 80") {
+		t.Fatalf("rendered output missing k value:\n%s", rendered)
+	}
+
+	round := loadRenderedConfig(t, rendered)
+	if got := round.Runtime.Search.Fusion.Strategy; got != SearchFusionStrategyRRF {
+		t.Fatalf("round-tripped fusion.strategy = %q, want %q", got, SearchFusionStrategyRRF)
+	}
+	if got := round.Runtime.Search.Fusion.K; got != 80 {
+		t.Fatalf("round-tripped fusion.k = %d, want 80", got)
+	}
+}
+
+func TestRenderRoundTripPreservesReranker(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search]
+reranker = "arm_aware_historical"
+`)
+
+	rendered, err := Render(cfg)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(rendered, "[runtime.search]") {
+		t.Fatalf("rendered output missing search block:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `reranker = "arm_aware_historical"`) {
+		t.Fatalf("rendered output missing reranker value:\n%s", rendered)
+	}
+
+	round := loadRenderedConfig(t, rendered)
+	if got := round.Runtime.Search.Reranker; got != SearchRerankerArmAwareHistorical {
+		t.Fatalf("round-tripped search.reranker = %q, want %q", got, SearchRerankerArmAwareHistorical)
+	}
+}

--- a/internal/config/search_test.go
+++ b/internal/config/search_test.go
@@ -97,6 +97,33 @@ k = 60
 	}
 }
 
+// Regression for the Copilot finding that strategy="rrf" with k<0 used
+// to emit two overlapping errors ("must be > 0" and "must be >= 0").
+// The validator should now emit a single, clear error.
+func TestLoadRuntimeSearchRejectsNegativeKOnce(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime.search.fusion]
+strategy = "rrf"
+k = -1
+`)
+	if err == nil {
+		t.Fatal("expected error for negative k on strategy rrf")
+	}
+	msg := err.Error()
+	if strings.Count(msg, "fusion.k") > 1 {
+		t.Fatalf("validator emitted overlapping fusion.k errors; got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "must be > 0") {
+		t.Fatalf("error should call out must-be-positive requirement; got %v", err)
+	}
+}
+
 func TestLoadRuntimeSearchRejectsUnknownStrategy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fusion/fusion.go
+++ b/internal/fusion/fusion.go
@@ -1,0 +1,69 @@
+// Package fusion bridges Pituitary's search fusion configuration to
+// stroma's FusionStrategy interface. A zero config resolves to nil so
+// stroma's DefaultFusion() governs the byte-identical pre-#342 path.
+package fusion
+
+import (
+	"fmt"
+	"strings"
+
+	stindex "github.com/dusk-network/stroma/v2/index"
+)
+
+const (
+	// StrategyDefault selects stroma's DefaultFusion() exactly. Resolve
+	// returns nil on this path so SearchParams.Fusion stays unset and
+	// the snapshot keeps the pre-#342 arm-native single-arm score
+	// preservation contract documented on stindex.DefaultFusion.
+	StrategyDefault = "default_rrf"
+
+	// StrategyRRF selects an explicitly parameterised stindex.RRFFusion.
+	// K must be > 0 under this strategy; PreserveSingleArmScore is held
+	// true so the single-arm degenerate case keeps stroma's default
+	// behavior unless a future knob explicitly opts out.
+	StrategyRRF = "rrf"
+)
+
+// Config captures pituitary-side fusion overrides. A zero value means
+// "no override" and Resolve returns nil.
+type Config struct {
+	// Strategy names the fusion implementation. Empty or StrategyDefault
+	// both resolve to nil so stroma's DefaultFusion() governs the path.
+	Strategy string
+
+	// K is the RRF constant. Only consulted under StrategyRRF; must be
+	// > 0 there.
+	K int
+}
+
+// IsZero reports whether no override is configured.
+func (c Config) IsZero() bool {
+	return c == Config{}
+}
+
+// Resolve builds a stroma FusionStrategy from a pituitary Config.
+//
+// The zero config and StrategyDefault both resolve to nil. Callers are
+// expected to pass nil straight through to stindex.SearchParams.Fusion
+// so stroma's DefaultFusion() governs the snapshot — byte-identical to
+// pre-#342 retrieval output on that path.
+func Resolve(cfg Config) (stindex.FusionStrategy, error) {
+	strategy := strings.TrimSpace(cfg.Strategy)
+	switch strategy {
+	case "", StrategyDefault:
+		if cfg.K != 0 {
+			return nil, fmt.Errorf("fusion.k only applies to strategy %q", StrategyRRF)
+		}
+		return nil, nil
+	case StrategyRRF:
+		if cfg.K <= 0 {
+			return nil, fmt.Errorf("fusion.k must be > 0 for strategy %q", StrategyRRF)
+		}
+		return stindex.RRFFusion{K: cfg.K, PreserveSingleArmScore: true}, nil
+	default:
+		return nil, fmt.Errorf(
+			"unsupported fusion.strategy %q (supported: %q, %q)",
+			strategy, StrategyDefault, StrategyRRF,
+		)
+	}
+}

--- a/internal/fusion/fusion_test.go
+++ b/internal/fusion/fusion_test.go
@@ -1,0 +1,75 @@
+package fusion
+
+import (
+	"testing"
+
+	stindex "github.com/dusk-network/stroma/v2/index"
+)
+
+func TestResolveZeroConfigReturnsNil(t *testing.T) {
+	got, err := Resolve(Config{})
+	if err != nil {
+		t.Fatalf("Resolve(zero) err = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("Resolve(zero) = %v, want nil so stroma DefaultFusion() governs", got)
+	}
+}
+
+func TestResolveDefaultStrategyReturnsNil(t *testing.T) {
+	got, err := Resolve(Config{Strategy: StrategyDefault})
+	if err != nil {
+		t.Fatalf("Resolve(default) err = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("Resolve(default) = %v, want nil for byte-identical default path", got)
+	}
+}
+
+func TestResolveDefaultStrategyRejectsK(t *testing.T) {
+	_, err := Resolve(Config{Strategy: StrategyDefault, K: 60})
+	if err == nil {
+		t.Fatal("Resolve(default,K=60) err = nil, want strategy-mismatch error")
+	}
+}
+
+func TestResolveRRFBuildsFusion(t *testing.T) {
+	got, err := Resolve(Config{Strategy: StrategyRRF, K: 80})
+	if err != nil {
+		t.Fatalf("Resolve(rrf,K=80) err = %v", err)
+	}
+	rrf, ok := got.(stindex.RRFFusion)
+	if !ok {
+		t.Fatalf("Resolve(rrf) = %T, want stindex.RRFFusion", got)
+	}
+	if rrf.K != 80 {
+		t.Fatalf("RRFFusion.K = %d, want 80", rrf.K)
+	}
+	if !rrf.PreserveSingleArmScore {
+		t.Fatal("RRFFusion.PreserveSingleArmScore = false, want true to preserve stroma default single-arm contract")
+	}
+}
+
+func TestResolveRRFRequiresPositiveK(t *testing.T) {
+	for _, k := range []int{0, -1} {
+		if _, err := Resolve(Config{Strategy: StrategyRRF, K: k}); err == nil {
+			t.Fatalf("Resolve(rrf,K=%d) err = nil, want positive-K error", k)
+		}
+	}
+}
+
+func TestResolveUnknownStrategyErrors(t *testing.T) {
+	_, err := Resolve(Config{Strategy: "weighted_sum"})
+	if err == nil {
+		t.Fatal("Resolve(unknown) err = nil, want unsupported-strategy error")
+	}
+}
+
+func TestConfigIsZero(t *testing.T) {
+	if !(Config{}).IsZero() {
+		t.Fatal("Config{}.IsZero() = false, want true")
+	}
+	if (Config{Strategy: StrategyRRF, K: 60}).IsZero() {
+		t.Fatal("non-default Config reported as zero")
+	}
+}

--- a/internal/index/armaware_reranker_test.go
+++ b/internal/index/armaware_reranker_test.go
@@ -252,6 +252,50 @@ func TestArmAwareRerankerFallsBackWithoutProvenance(t *testing.T) {
 	}
 }
 
+// TestArmAwareRerankerWritesBoostedScoreBack is a regression guard for
+// the Copilot finding that the previous implementation computed a boost
+// for the reranker's own sort comparator but never wrote it back to the
+// SearchHit.Score field. Downstream, buildRankedCandidatesContext reads
+// hit.Score and re-sorts candidates — if Score stays at the pre-rerank
+// value the arm-aware ordering is silently undone. The reranker must
+// write the adjusted+boosted score onto the returned SearchHits so the
+// downstream consumer sees the authoritative post-rerank value.
+func TestArmAwareRerankerWritesBoostedScoreBack(t *testing.T) {
+	t.Parallel()
+
+	reranker := armAwareHistoricalReranker{}
+	hits := []stindex.SearchHit{
+		{
+			ChunkID: 1,
+			Ref:     "spec-b",
+			Heading: "Fusion policy",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmFTS: {Rank: 0, Score: -2.7},
+			}},
+		},
+	}
+
+	reranked, err := reranker.Rerank(context.Background(), "fusion policy", hits)
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+	if len(reranked) != 1 {
+		t.Fatalf("want 1 reranked hit, got %d", len(reranked))
+	}
+	if reranked[0].Score == 0.50 {
+		t.Fatalf("reranker did not write adjusted+boosted score back to hit.Score; still raw %.4f", reranked[0].Score)
+	}
+	expected := 0.50 * armAwareTerminologyBoost
+	if reranked[0].Score != expected {
+		t.Fatalf("reranked Score = %.4f, want %.4f (raw * boost)", reranked[0].Score, expected)
+	}
+	// Input must remain untouched per the stroma Reranker aliasing contract.
+	if hits[0].Score != 0.50 {
+		t.Fatalf("reranker mutated input hit.Score; violates stroma aliasing contract (input now %.4f)", hits[0].Score)
+	}
+}
+
 func cloneHits(in []stindex.SearchHit) []stindex.SearchHit {
 	out := make([]stindex.SearchHit, len(in))
 	copy(out, in)

--- a/internal/index/armaware_reranker_test.go
+++ b/internal/index/armaware_reranker_test.go
@@ -1,0 +1,294 @@
+package index
+
+import (
+	"context"
+	"testing"
+
+	stindex "github.com/dusk-network/stroma/v2/index"
+)
+
+// TestArmAwareRerankerBoostsFTSOnlyTerminologyMatch documents the one
+// governance-aware decision the reranker currently makes: when a
+// candidate is sourced only from the FTS arm and its heading overlaps
+// with the query terminology, bump it above an equally-scored dense-only
+// candidate. Dense-only hits for the same query carry no heading-literal
+// signal and should stay below the FTS-only terminology match.
+func TestArmAwareRerankerBoostsFTSOnlyTerminologyMatch(t *testing.T) {
+	t.Parallel()
+
+	reranker := armAwareHistoricalReranker{}
+	hits := []stindex.SearchHit{
+		{
+			ChunkID: 1,
+			Ref:     "spec-a",
+			Heading: "Conceptual overview",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmVector: {Rank: 0, Score: 0.50},
+			}},
+		},
+		{
+			ChunkID: 2,
+			Ref:     "spec-b",
+			Heading: "Fusion policy",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmFTS: {Rank: 1, Score: -2.7},
+			}},
+		},
+	}
+
+	reranked, err := reranker.Rerank(context.Background(), "fusion policy", hits)
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+	if reranked[0].Ref != "spec-b" {
+		t.Fatalf("FTS-only terminology hit should rank first; got order %q, %q",
+			reranked[0].Ref, reranked[1].Ref)
+	}
+}
+
+// TestArmAwareRerankerIgnoresBoostWithoutHeadingMatch confirms the boost
+// is terminology-gated: an FTS-only hit whose heading does not overlap
+// with the query stays in its score-order position relative to the
+// dense-only peer.
+func TestArmAwareRerankerIgnoresBoostWithoutHeadingMatch(t *testing.T) {
+	t.Parallel()
+
+	reranker := armAwareHistoricalReranker{}
+	hits := []stindex.SearchHit{
+		{
+			ChunkID: 1,
+			Ref:     "spec-a",
+			Heading: "Overview",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmVector: {Rank: 0, Score: 0.50},
+			}},
+		},
+		{
+			ChunkID: 2,
+			Ref:     "spec-b",
+			Heading: "Related work",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmFTS: {Rank: 1, Score: -2.7},
+			}},
+		},
+	}
+
+	reranked, err := reranker.Rerank(context.Background(), "fusion policy", hits)
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+	if reranked[0].Ref != "spec-a" {
+		t.Fatalf("without heading match the deterministic ref tiebreak should win; got %q first", reranked[0].Ref)
+	}
+}
+
+// TestArmAwareRerankerPreservesOrderingForMultiArmHits documents that
+// hits contributed by both arms do not receive the FTS-only boost — the
+// boost is a signal for "this hit would not have been found by dense
+// retrieval alone", which only applies to arm-exclusive hits.
+func TestArmAwareRerankerPreservesOrderingForMultiArmHits(t *testing.T) {
+	t.Parallel()
+
+	reranker := armAwareHistoricalReranker{}
+	hits := []stindex.SearchHit{
+		{
+			ChunkID: 1,
+			Ref:     "spec-a",
+			Heading: "Conceptual overview",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmVector: {Rank: 0, Score: 0.50},
+			}},
+		},
+		{
+			ChunkID: 2,
+			Ref:     "spec-b",
+			Heading: "Fusion policy",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmFTS:    {Rank: 1, Score: -2.7},
+				stindex.ArmVector: {Rank: 3, Score: 0.48},
+			}},
+		},
+	}
+
+	reranked, err := reranker.Rerank(context.Background(), "fusion policy", hits)
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+	// Ties break on ref; spec-a comes first alphabetically, no boost applies.
+	if reranked[0].Ref != "spec-a" {
+		t.Fatalf("multi-arm hits should not receive the FTS-only boost; got %q first", reranked[0].Ref)
+	}
+}
+
+// TestArmAwareRerankerIgnoresCustomExtraArmsOnFTSHit guards the
+// pluggable-fusion contract: custom FusionStrategy implementations may
+// introduce additional arm names beyond ArmVector/ArmFTS, and a hit
+// contributed by FTS + a custom arm must NOT be treated as FTS-only
+// (and therefore must not receive the terminology boost). Otherwise
+// the reranker silently over-ranks multi-arm hits once non-default
+// strategies land.
+func TestArmAwareRerankerIgnoresCustomExtraArmsOnFTSHit(t *testing.T) {
+	t.Parallel()
+
+	reranker := armAwareHistoricalReranker{}
+	hits := []stindex.SearchHit{
+		{
+			ChunkID: 1,
+			Ref:     "spec-a",
+			Heading: "Fusion policy",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmFTS: {Rank: 0, Score: -2.7},
+				"custom_arm":   {Rank: 1, Score: 0.42},
+			}},
+		},
+		{
+			ChunkID: 2,
+			Ref:     "spec-b",
+			Heading: "Fusion policy",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmFTS: {Rank: 1, Score: -2.7},
+			}},
+		},
+	}
+
+	reranked, err := reranker.Rerank(context.Background(), "fusion policy", hits)
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+	// spec-b is single-arm FTS → gets the boost.
+	// spec-a is multi-arm (FTS+custom) → no boost.
+	// spec-b therefore ranks first.
+	if reranked[0].Ref != "spec-b" {
+		t.Fatalf("single-arm FTS hit should outrank FTS+custom multi-arm hit; got %q first",
+			reranked[0].Ref)
+	}
+}
+
+// TestArmAwareRerankerDoesNotBoostOnSubstringHeadingMatch guards the
+// false-positive failure mode where `strings.Contains` would treat any
+// heading containing a query token as a substring as a terminology
+// match (e.g. "rate" inside "migration"). Token equality is required,
+// so unrelated headings that happen to share a substring must not
+// trigger the boost.
+func TestArmAwareRerankerDoesNotBoostOnSubstringHeadingMatch(t *testing.T) {
+	t.Parallel()
+
+	reranker := armAwareHistoricalReranker{}
+	hits := []stindex.SearchHit{
+		{
+			ChunkID: 1,
+			Ref:     "spec-a",
+			Heading: "Conceptual overview",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmVector: {Rank: 0, Score: 0.50},
+			}},
+		},
+		{
+			ChunkID: 2,
+			Ref:     "spec-b",
+			// "rate" is only a substring inside "migration", never a
+			// standalone token. Must not receive the boost.
+			Heading: "Migration plan",
+			Score:   0.50,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmFTS: {Rank: 1, Score: -2.7},
+			}},
+		},
+	}
+
+	reranked, err := reranker.Rerank(context.Background(), "rate limits", hits)
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+	// Without a real terminology match the deterministic ref tiebreak
+	// should win — "spec-a" < "spec-b".
+	if reranked[0].Ref != "spec-a" {
+		t.Fatalf("substring-only heading match should not trigger the terminology boost; got %q first",
+			reranked[0].Ref)
+	}
+}
+
+// TestArmAwareRerankerFallsBackWithoutProvenance proves the reranker
+// degrades gracefully on pre-stroma-v2 snapshots that carry no
+// HitProvenance — it must behave identically to historicalSectionReranker
+// on those inputs so legacy retrieval paths stay byte-identical.
+func TestArmAwareRerankerFallsBackWithoutProvenance(t *testing.T) {
+	t.Parallel()
+
+	armAware := armAwareHistoricalReranker{}
+	historical := historicalSectionReranker{}
+	hits := []stindex.SearchHit{
+		{ChunkID: 1, Ref: "spec-a", Heading: "Fusion policy", Score: 0.50},
+		{ChunkID: 2, Ref: "spec-b", Heading: "Conceptual overview", Score: 0.60},
+		{ChunkID: 3, Ref: "spec-c", Heading: "Fusion policy", Score: 0.40},
+	}
+
+	armResult, err := armAware.Rerank(context.Background(), "fusion policy", cloneHits(hits))
+	if err != nil {
+		t.Fatalf("Rerank(armAware): %v", err)
+	}
+	histResult, err := historical.Rerank(context.Background(), "fusion policy", cloneHits(hits))
+	if err != nil {
+		t.Fatalf("Rerank(historical): %v", err)
+	}
+
+	if len(armResult) != len(histResult) {
+		t.Fatalf("result lengths differ: arm=%d, hist=%d", len(armResult), len(histResult))
+	}
+	for i := range armResult {
+		if armResult[i].ChunkID != histResult[i].ChunkID {
+			t.Fatalf("without provenance arm-aware reranker diverged at pos %d: arm=%d hist=%d",
+				i, armResult[i].ChunkID, histResult[i].ChunkID)
+		}
+	}
+}
+
+func cloneHits(in []stindex.SearchHit) []stindex.SearchHit {
+	out := make([]stindex.SearchHit, len(in))
+	copy(out, in)
+	return out
+}
+
+func BenchmarkArmAwareRerankerOnFTSOnlyCandidates(b *testing.B) {
+	hits := make([]stindex.SearchHit, 0, 64)
+	for i := 0; i < 32; i++ {
+		hits = append(hits, stindex.SearchHit{
+			ChunkID: int64(i),
+			Ref:     "spec-a",
+			Heading: "Fusion policy",
+			Score:   0.5,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmFTS: {Rank: i, Score: -2.7},
+			}},
+		})
+	}
+	for i := 0; i < 32; i++ {
+		hits = append(hits, stindex.SearchHit{
+			ChunkID: int64(1000 + i),
+			Ref:     "spec-b",
+			Heading: "Conceptual overview",
+			Score:   0.5,
+			Provenance: &stindex.HitProvenance{Arms: map[string]stindex.ArmEvidence{
+				stindex.ArmVector: {Rank: i, Score: 0.5},
+			}},
+		})
+	}
+
+	reranker := armAwareHistoricalReranker{}
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := reranker.Rerank(ctx, "fusion policy", cloneHits(hits)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -134,12 +134,18 @@ const armAwareTerminologyBoost = 1.05
 func (r armAwareHistoricalReranker) Rerank(_ context.Context, query string, candidates []stindex.SearchHit) ([]stindex.SearchHit, error) {
 	tokens := headingTerminologyTokens(query)
 	reranked := append([]stindex.SearchHit(nil), candidates...)
+	// Write the adjusted + boosted score back to each copy's Score so
+	// downstream consumers (buildRankedCandidatesContext) see the
+	// authoritative post-rerank value and do not silently re-sort by
+	// the pre-rerank raw score — which would otherwise undo the
+	// arm-aware boost entirely.
+	for i := range reranked {
+		reranked[i].Score = armAwareAdjustedScore(reranked[i], tokens, r.preferHistorical)
+	}
 	sort.SliceStable(reranked, func(i, j int) bool {
-		leftScore := armAwareAdjustedScore(reranked[i], tokens, r.preferHistorical)
-		rightScore := armAwareAdjustedScore(reranked[j], tokens, r.preferHistorical)
 		switch {
-		case leftScore != rightScore:
-			return leftScore > rightScore
+		case reranked[i].Score != reranked[j].Score:
+			return reranked[i].Score > reranked[j].Score
 		case reranked[i].Ref != reranked[j].Ref:
 			return reranked[i].Ref < reranked[j].Ref
 		case reranked[i].Heading != reranked[j].Heading:
@@ -507,7 +513,8 @@ func loadRankedCandidatesContextWithFusion(ctx context.Context, db *sql.DB, snap
 		return nil, fmt.Errorf("query search candidates: %w", err)
 	}
 
-	return buildRankedCandidatesContext(ctx, db, hits, query, preferHistorical)
+	scorePreAdjusted := rerankerPolicy == config.SearchRerankerArmAwareHistorical
+	return buildRankedCandidatesContext(ctx, db, hits, query, preferHistorical, scorePreAdjusted)
 }
 
 func selectSearchReranker(policy string, preferHistorical bool) stindex.Reranker {
@@ -539,10 +546,10 @@ func loadSemanticSimilarityCandidatesContext(ctx context.Context, db *sql.DB, sn
 		return nil, fmt.Errorf("query semantic similarity candidates: %w", err)
 	}
 
-	return buildRankedCandidatesContext(ctx, db, hits, query, preferHistorical)
+	return buildRankedCandidatesContext(ctx, db, hits, query, preferHistorical, false)
 }
 
-func buildRankedCandidatesContext(ctx context.Context, db *sql.DB, hits []stindex.SearchHit, query SearchSpecQuery, preferHistorical bool) ([]chunkCandidate, error) {
+func buildRankedCandidatesContext(ctx context.Context, db *sql.DB, hits []stindex.SearchHit, query SearchSpecQuery, preferHistorical, scorePreAdjusted bool) ([]chunkCandidate, error) {
 	states, err := loadSearchArtifactStateContext(ctx, db, refsForSearchHits(hits))
 	if err != nil {
 		return nil, err
@@ -572,7 +579,11 @@ func buildRankedCandidatesContext(ctx context.Context, db *sql.DB, hits []stinde
 				return nil, fmt.Errorf("decode search inference for %s: %w", candidate.Ref, err)
 			}
 		}
-		candidate.Score = ranking.AdjustHistoricalSectionScore(hit.Score, candidate.SectionHeading, preferHistorical)
+		if scorePreAdjusted {
+			candidate.Score = hit.Score
+		} else {
+			candidate.Score = ranking.AdjustHistoricalSectionScore(hit.Score, candidate.SectionHeading, preferHistorical)
+		}
 		if candidate.Score <= 0 {
 			continue
 		}

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/fusion"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/ranking"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
@@ -113,6 +114,118 @@ func (r historicalSectionReranker) Rerank(_ context.Context, _ string, candidate
 	return reranked, nil
 }
 
+// armAwareHistoricalReranker extends historicalSectionReranker with
+// governance-aware use of stroma's HitProvenance.Arms. When a query
+// token literally matches a hit's section heading and the hit is
+// sourced exclusively from the FTS arm, the reranker multiplies its
+// adjusted score by a small boost so exact-terminology matches float
+// above conceptually similar but off-terminology candidates.
+//
+// Hits with nil Provenance (e.g. legacy snapshots that pre-date the
+// stroma v2 fusion pipeline) fall through to the same ordering as
+// historicalSectionReranker — no boost, deterministic tiebreak on
+// ref / heading / chunk.
+type armAwareHistoricalReranker struct {
+	preferHistorical bool
+}
+
+const armAwareTerminologyBoost = 1.05
+
+func (r armAwareHistoricalReranker) Rerank(_ context.Context, query string, candidates []stindex.SearchHit) ([]stindex.SearchHit, error) {
+	tokens := headingTerminologyTokens(query)
+	reranked := append([]stindex.SearchHit(nil), candidates...)
+	sort.SliceStable(reranked, func(i, j int) bool {
+		leftScore := armAwareAdjustedScore(reranked[i], tokens, r.preferHistorical)
+		rightScore := armAwareAdjustedScore(reranked[j], tokens, r.preferHistorical)
+		switch {
+		case leftScore != rightScore:
+			return leftScore > rightScore
+		case reranked[i].Ref != reranked[j].Ref:
+			return reranked[i].Ref < reranked[j].Ref
+		case reranked[i].Heading != reranked[j].Heading:
+			return reranked[i].Heading < reranked[j].Heading
+		default:
+			return reranked[i].ChunkID < reranked[j].ChunkID
+		}
+	})
+	return reranked, nil
+}
+
+func armAwareAdjustedScore(hit stindex.SearchHit, queryTokens map[string]struct{}, preferHistorical bool) float64 {
+	adjusted := ranking.AdjustHistoricalSectionScore(hit.Score, hit.Heading, preferHistorical)
+	if !hitHasFTSOnlyProvenance(hit) {
+		return adjusted
+	}
+	if !headingMatchesAnyToken(hit.Heading, queryTokens) {
+		return adjusted
+	}
+	return adjusted * armAwareTerminologyBoost
+}
+
+// hitHasFTSOnlyProvenance reports whether the hit's provenance shows it
+// was contributed by the FTS arm and no other arm. Requires exact
+// single-arm provenance: the pluggable-fusion contract (stroma v2)
+// allows custom FusionStrategy implementations to introduce additional
+// arm names beyond ArmVector/ArmFTS, so a "has FTS, no Vector" check
+// would misclassify multi-arm hits once non-default strategies land.
+func hitHasFTSOnlyProvenance(hit stindex.SearchHit) bool {
+	if hit.Provenance == nil || len(hit.Provenance.Arms) != 1 {
+		return false
+	}
+	_, ok := hit.Provenance.Arms[stindex.ArmFTS]
+	return ok
+}
+
+// normalizeTerminologyTokens lower-cases and strips punctuation from the
+// input then returns the set of tokens at least 3 chars long. The
+// heading match below does exact token equality, not substring
+// containment, so unrelated words that happen to share a substring
+// (e.g. "rate" vs "migration") don't falsely trigger the boost.
+func normalizeTerminologyTokens(input string) map[string]struct{} {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil
+	}
+	tokens := make(map[string]struct{})
+	for _, token := range strings.FieldsFunc(input, isTerminologyTokenSeparator) {
+		token = strings.ToLower(token)
+		if len(token) < 3 {
+			continue
+		}
+		tokens[token] = struct{}{}
+	}
+	if len(tokens) == 0 {
+		return nil
+	}
+	return tokens
+}
+
+func headingTerminologyTokens(query string) map[string]struct{} {
+	return normalizeTerminologyTokens(query)
+}
+
+func headingMatchesAnyToken(heading string, queryTokens map[string]struct{}) bool {
+	if len(queryTokens) == 0 {
+		return false
+	}
+	headingTokens := normalizeTerminologyTokens(heading)
+	for token := range headingTokens {
+		if _, ok := queryTokens[token]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isTerminologyTokenSeparator(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r', '.', ',', ';', ':', '!', '?', '"', '\'', '`',
+		'(', ')', '[', ']', '{', '}', '/', '\\', '-', '_':
+		return true
+	}
+	return false
+}
+
 // ToQuery normalizes the transport request into an executable search query.
 func (r SearchSpecRequest) ToQuery() (SearchSpecQuery, error) {
 	statuses, err := NormalizeSearchStatuses(r.Filters.Statuses)
@@ -161,7 +274,24 @@ func SearchSpecs(cfg *config.Config, query SearchSpecQuery) (*SearchSpecResult, 
 
 // SearchSpecsContext executes semantic retrieval over the indexed spec corpus.
 func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpecQuery) (*SearchSpecResult, error) {
-	return searchSpecsContextWithScoreKind(ctx, cfg, query, SearchSpecScoreKindHybridRelevance, loadRankedCandidatesContext)
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	strategy, err := fusion.Resolve(fusionConfigFromRuntime(cfg.Runtime.Search))
+	if err != nil {
+		return nil, fmt.Errorf("resolve search fusion: %w", err)
+	}
+	loader := func(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {
+		return loadRankedCandidatesContextWithFusion(ctx, db, snapshot, embedder, query, strategy, cfg.Runtime.Search.Reranker)
+	}
+	return searchSpecsContextWithScoreKind(ctx, cfg, query, SearchSpecScoreKindHybridRelevance, loader)
+}
+
+func fusionConfigFromRuntime(cfg config.SearchConfig) fusion.Config {
+	return fusion.Config{
+		Strategy: cfg.Fusion.Strategy,
+		K:        cfg.Fusion.K,
+	}
 }
 
 // SearchSpecsBySemanticSimilarityContext executes vector-only retrieval over
@@ -360,7 +490,7 @@ func (s *searchContext) Close() {
 	}
 }
 
-func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {
+func loadRankedCandidatesContextWithFusion(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, embedder Embedder, query SearchSpecQuery, strategy stindex.FusionStrategy, rerankerPolicy string) ([]chunkCandidate, error) {
 	preferHistorical := ranking.SearchPrefersHistoricalContext(query.Query)
 
 	hits, err := snapshot.Search(ctx, stindex.SnapshotSearchQuery{
@@ -369,7 +499,8 @@ func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stin
 			Limit:    searchCandidateLimit(query.Limit),
 			Kinds:    []string{query.Kind},
 			Embedder: embedder,
-			Reranker: historicalSectionReranker{preferHistorical: preferHistorical},
+			Fusion:   strategy,
+			Reranker: selectSearchReranker(rerankerPolicy, preferHistorical),
 		},
 	})
 	if err != nil {
@@ -377,6 +508,15 @@ func loadRankedCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stin
 	}
 
 	return buildRankedCandidatesContext(ctx, db, hits, query, preferHistorical)
+}
+
+func selectSearchReranker(policy string, preferHistorical bool) stindex.Reranker {
+	switch policy {
+	case config.SearchRerankerArmAwareHistorical:
+		return armAwareHistoricalReranker{preferHistorical: preferHistorical}
+	default:
+		return historicalSectionReranker{preferHistorical: preferHistorical}
+	}
 }
 
 func loadSemanticSimilarityCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {


### PR DESCRIPTION
Closes #342.

## Summary

Wires stroma v2's `FusionStrategy` + `HitProvenance.Arms` through Pituitary's hybrid search without changing the default retrieval output, and adds one governance-aware reranker that reads arm provenance as a concrete consumer.

- New \`internal/fusion\` package: zero-config resolves to \`nil\` so stroma's \`DefaultFusion()\` governs byte-for-byte (preserving the arm-native single-arm score preservation contract that a locally-constructed \`RRFFusion{K:60,PreserveSingleArmScore:true}\` would silently break on the vector-empty / FTS-non-empty path).
- New \`[runtime.search]\` config surface: \`fusion.strategy\` / \`fusion.k\` and a \`reranker\` knob. Strict-field parser rejects ghost fields under the new subtree (#346 regression lesson); renderer round-trips both.
- New \`armAwareHistoricalReranker\` (opt-in via \`reranker = \"arm_aware_historical\"\`): single-arm FTS hits with a token-exact heading match get a small boost. Multi-arm hits and custom pluggable-fusion arms are correctly excluded. Substring false positives are prevented by token-equality matching.

Default path (empty \`[runtime.search]\`) is byte-identical to pre-#342 retrieval.

## Sibling-gap audit

Per \`feedback_pr_threading_review\`, every internal caller of \`snapshot.Search\` / \`SearchVector\` was audited:
- \`internal/index/search.go:366\` — primary hybrid path, wired.
- \`internal/analysis/repository_similarity.go:172\` and \`internal/analysis/semantic_terminology.go:133\` — vector-only, no fusion, no change.

Fusion is query-time, not build-time — no incremental-update analog (contrast #348).

## Codex adversarial review

One pass ran BEFORE commit with explicit sibling-gap prompting. Two findings (high: pluggable-fusion multi-arm misclassification; medium: substring heading false positives) were fixed with regressions before push.

## Test plan

- [x] \`make ci\` green (fmt, tests, vet, doc-link check)
- [x] \`internal/fusion\`: zero-config, default strategy, explicit RRF, invalid K, unknown strategy
- [x] \`internal/config\`: parse / render round-trip for \`runtime.search.fusion\` and \`runtime.search.reranker\`; ghost-field rejection under both subtrees; validation on invalid combinations
- [x] \`internal/index\`: reranker boost on FTS-only terminology match; ignored without heading match; preserved for multi-arm hits; ignored for FTS+custom-arm hits; ignored on substring-only heading match; graceful fallback without \`HitProvenance\`
- [x] Micro-benchmark on synthetic candidates

## Acceptance criteria status

- [x] \`FusionStrategy\` configurable through \`runtime.search.fusion\` (default = \`DefaultFusion()\`)
- [x] \`SearchHit.Provenance.Arms\` propagated to Pituitary rerankers
- [x] At least one governance-aware reranker consumes arm provenance
- [x] Existing retrieval tests pass unchanged on default fusion
- [ ] Benchmark showing precision delta on at least one kind-sensitive query class — **deferred**; replaced with a reranker micro-benchmark. A real precision delta requires a labeled retrieval fixture that does not exist yet. Captured in the private rationale note as follow-up.