### PR TITLE
Regenerate AI mirrors via ccd sync (beta.1)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- GENERATED: source=AGENTS.md format-version=1 sha256=55962d79a17214d157357b5e1d77c003372767ae221b7d21255895a5340e26ba -->
+<!-- GENERATED: source=AGENTS.md format-version=1 sha256=f872fbd69c0feb2732866dfad848d652fb6789fab35100df61adf7d76b0746bc -->
 
 # CLAUDE.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- GENERATED: source=AGENTS.md format-version=1 sha256=43cb2256fd95fcc94773e58c4068857453e6c352edba3a431ac1348b413dc8da -->
+<!-- GENERATED: source=AGENTS.md format-version=1 sha256=f872fbd69c0feb2732866dfad848d652fb6789fab35100df61adf7d76b0746bc -->
 
 > Generated from `AGENTS.md`. Edit `AGENTS.md`, then rerun `scripts/sync-ai-docs.sh --write`.
 > If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
@@ -15,6 +15,7 @@ Pituitary is a consistency governance tool that keeps specifications, documentat
 ## Coding Standards
 
 - Read [README.md](README.md) and [ARCHITECTURE.md](ARCHITECTURE.md) before deep implementation work. Use the active GitHub issues for backlog and priority context.
+- If you touch core write paths or repo governance, also read [docs/development/repo-governance.md](docs/development/repo-governance.md).
 - Treat repository docs as the primary source of truth; keep GitHub issues aligned with them rather than the reverse.
 - Prefer small, reversible changes and deterministic tooling over hand-maintained generated state.
 - Keep outputs machine-readable where the architecture expects JSON-first behavior.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,4 @@
-<!-- GENERATED: source=AGENTS.md format-version=1 sha256=43cb2256fd95fcc94773e58c4068857453e6c352edba3a431ac1348b413dc8da -->
+<!-- GENERATED: source=AGENTS.md format-version=1 sha256=f872fbd69c0feb2732866dfad848d652fb6789fab35100df61adf7d76b0746bc -->
 
 > Generated from `AGENTS.md`. Edit `AGENTS.md`, then rerun `scripts/sync-ai-docs.sh --write`.
 > If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
@@ -16,6 +16,7 @@ Pituitary is a consistency governance tool that keeps specifications, documentat
 ## Coding Standards
 
 - Read [README.md](README.md) and [ARCHITECTURE.md](ARCHITECTURE.md) before deep implementation work. Use the active GitHub issues for backlog and priority context.
+- If you touch core write paths or repo governance, also read [docs/development/repo-governance.md](docs/development/repo-governance.md).
 - Treat repository docs as the primary source of truth; keep GitHub issues aligned with them rather than the reverse.
 - Prefer small, reversible changes and deterministic tooling over hand-maintained generated state.
 - Keep outputs machine-readable where the architecture expects JSON-first behavior.


### PR DESCRIPTION
## Summary
- Regenerates `CLAUDE.md`, `GEMINI.md`, and `.claude/CLAUDE.md` using `ccd sync` under ccd 1.0.0-beta.1 (upgraded from 1.0.0-alpha.9).
- Picks up one real content change from `AGENTS.md:13` (the `docs/development/repo-governance.md` reading pointer) that alpha.9's generator had silently missed.
- Mirror `sha256=` headers now match the canonical `AGENTS.md` fingerprint; `ccd doctor` reports 0 failures.

## Test plan
- [x] `ccd --version` → `1.0.0-beta.1`
- [x] `ccd sync --path .` → writes 3 mirror files
- [x] `ccd doctor` → all PASS, including "Generated mirrors are in sync"
- [x] Target file `docs/development/repo-governance.md` exists (so the new bullet is not a dangling link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)