### PR TITLE
Default docs to LateChunkPolicy with rebuild-gated rollout (#344)

### DIFF
--- a/internal/chunk/policy.go
+++ b/internal/chunk/policy.go
@@ -87,9 +87,11 @@ func (c KindConfig) IsZero() bool {
 	return c == KindConfig{}
 }
 
-// Config aggregates per-kind chunking overrides. A zero value means "no
-// router, no overrides" — Resolve returns a nil Policy so stroma's
-// default MarkdownPolicy applies exactly as it did pre-#338.
+// Config aggregates per-kind chunking overrides. A zero value means
+// "no operator overrides" — Resolve still materializes a
+// KindRouterPolicy carrying the resolver's built-in defaults
+// (MarkdownPolicy for specs, LateChunkPolicy for docs under #344).
+// See Resolve for the full per-kind semantics.
 type Config struct {
 	Spec KindConfig
 	Doc  KindConfig
@@ -116,7 +118,7 @@ func (c Config) IsZero() bool {
 //     DefaultDocLateChunk* knobs (#344 product lever — long-form docs
 //     get parent+leaf hierarchy feeding ExpandContext). Operators who
 //     don't want the storage overhead opt back by setting
-//     `[runtime.chunking.doc]` policy = "markdown"`, which overrides the
+//     `[runtime.chunking.doc] policy = "markdown"`, which overrides the
 //     default via ByKind.
 //
 // The tuning knobs users set without an explicit Policy field still

--- a/internal/chunk/policy.go
+++ b/internal/chunk/policy.go
@@ -18,7 +18,36 @@ const (
 	// Parents live as storage-only context that ExpandContext can surface
 	// on demand; children are what participate in retrieval.
 	PolicyLateChunk = "late_chunk"
+
+	// DefaultDocLateChunkParentMaxTokens is the default parent section
+	// budget used when docs fall through to the #344 LateChunkPolicy
+	// default. Sized for long-form docs while staying well under typical
+	// context windows.
+	DefaultDocLateChunkParentMaxTokens = 2048
+	// DefaultDocLateChunkChildMaxTokens caps leaf chunks at a size that
+	// still embeds cleanly with mainstream 512-token embedders.
+	DefaultDocLateChunkChildMaxTokens = 384
+	// DefaultDocLateChunkChildOverlapTokens adds small leaf overlap so
+	// heading-straddling queries do not lose recall at chunk boundaries.
+	DefaultDocLateChunkChildOverlapTokens = 48
 )
+
+// ResolverDefaultsVersion tags the behavior of Resolve when a kind is
+// left unconfigured. It is persisted in the rebuild-time chunking
+// fingerprint so that flipping a default here forces `--update` to fall
+// back to a full rebuild instead of silently producing a mixed-
+// generation snapshot with old records on the old default and new
+// records on the new default.
+//
+//   - "1" (pre-#344): zero-config returned a nil policy, so both kinds
+//     fell through to stroma's MarkdownPolicy default.
+//   - "2" (#344): zero-config for docs now defaults to LateChunkPolicy
+//     with the tuned DefaultDocLateChunk* knobs; spec defaults are
+//     unchanged.
+//
+// Bump this string whenever Resolve's zero-config behavior changes so
+// pre-existing snapshots fail the fingerprint check and get rebuilt.
+const ResolverDefaultsVersion = "2"
 
 // KindConfig describes the chunking policy for a single record kind
 // (spec or doc). A zero value means "no override" — the resolver treats
@@ -73,26 +102,28 @@ func (c Config) IsZero() bool {
 
 // Resolve builds a stroma chunk.Policy from pituitary's per-kind config.
 //
-// When no kind has an override configured (cfg.IsZero()), Resolve
-// returns nil. Callers are expected to pass nil straight through to
-// stroma, which preserves the default MarkdownPolicy behavior that
-// shipped before the router was introduced — i.e., byte-identical to
-// pre-change output.
+// Resolve always returns a non-nil KindRouterPolicy. Its Default mirrors
+// stroma's bounded nil-policy path (MarkdownPolicy with the
+// DefaultMaxChunkSections cap in place) so unknown kinds keep the
+// pre-#338 DoS guard.
 //
-// When at least one kind is configured, Resolve returns a
-// KindRouterPolicy whose Default mirrors stroma's bounded nil-policy
-// path (MarkdownPolicy with the DefaultMaxChunkSections cap in place)
-// so a repo that only configures one kind does not silently disable
-// the per-record section cap on the other kind. The ByKind map carries
-// the configured kinds resolved to their concrete policies; those
-// policies also receive the same cap substitution when the user left
-// max_sections unset, so "I only tuned max_tokens" never implicitly
-// disables the DoS guard.
+// Per-kind resolution:
+//
+//   - Spec: keeps stroma's MarkdownPolicy default via router.Default when
+//     unconfigured; explicit `[runtime.chunking.spec]` builds a concrete
+//     policy and pins it in ByKind.
+//   - Doc: when unconfigured, defaults to LateChunkPolicy with the
+//     DefaultDocLateChunk* knobs (#344 product lever — long-form docs
+//     get parent+leaf hierarchy feeding ExpandContext). Operators who
+//     don't want the storage overhead opt back by setting
+//     `[runtime.chunking.doc]` policy = "markdown"`, which overrides the
+//     default via ByKind.
+//
+// The tuning knobs users set without an explicit Policy field still
+// resolve through MarkdownPolicy (buildPolicy treats empty Policy as
+// PolicyMarkdown), so "I only tuned max_tokens" keeps the DoS guard on
+// without silently inheriting the late-chunk default.
 func Resolve(cfg Config) (stchunk.Policy, error) {
-	if cfg.IsZero() {
-		return nil, nil
-	}
-
 	router := stchunk.KindRouterPolicy{
 		Default: stchunk.MarkdownPolicy{
 			Options: stchunk.Options{MaxSections: stindex.DefaultMaxChunkSections},
@@ -112,8 +143,22 @@ func Resolve(cfg Config) (stchunk.Policy, error) {
 			return nil, fmt.Errorf("doc chunking: %w", err)
 		}
 		router.ByKind[sdk.ArtifactKindDoc] = policy
+	} else {
+		router.ByKind[sdk.ArtifactKindDoc] = defaultDocPolicy()
 	}
 	return router, nil
+}
+
+// defaultDocPolicy returns the #344 LateChunkPolicy default for docs.
+// Kept as a helper so callers and tests agree on the exact defaults
+// without scattering magic numbers.
+func defaultDocPolicy() stchunk.LateChunkPolicy {
+	return stchunk.LateChunkPolicy{
+		ParentMaxTokens:    DefaultDocLateChunkParentMaxTokens,
+		ChildMaxTokens:     DefaultDocLateChunkChildMaxTokens,
+		ChildOverlapTokens: DefaultDocLateChunkChildOverlapTokens,
+		MaxSections:        stindex.DefaultMaxChunkSections,
+	}
 }
 
 // resolveMaxSections mirrors stroma's index.resolveMaxChunkSections.

--- a/internal/chunk/policy_test.go
+++ b/internal/chunk/policy_test.go
@@ -14,21 +14,78 @@ import (
 	"github.com/dusk-network/pituitary/sdk"
 )
 
-func TestResolve_ZeroConfigReturnsNilPolicy(t *testing.T) {
+func TestResolve_ZeroConfigDefaultsDocsToLateChunk(t *testing.T) {
 	t.Parallel()
 
+	// #344: zero-config Resolve now always materializes a router so
+	// docs pick up the LateChunkPolicy default. Router.Default keeps
+	// the pre-#338 MarkdownPolicy contract for any unknown kind, and
+	// specs fall through to that Default (no explicit ByKind entry).
 	policy, err := Resolve(Config{})
 	if err != nil {
 		t.Fatalf("Resolve(zero) returned error: %v", err)
 	}
-	if policy != nil {
-		t.Fatalf("Resolve(zero) = %T, want nil (preserves default stroma behavior)", policy)
+	router, ok := policy.(stchunk.KindRouterPolicy)
+	if !ok {
+		t.Fatalf("Resolve(zero) = %T, want KindRouterPolicy", policy)
+	}
+	defaultPolicy, ok := router.Default.(stchunk.MarkdownPolicy)
+	if !ok {
+		t.Fatalf("router.Default = %T, want MarkdownPolicy", router.Default)
+	}
+	if got, want := defaultPolicy.Options.MaxSections, stindex.DefaultMaxChunkSections; got != want {
+		t.Fatalf("router.Default MaxSections = %d, want %d", got, want)
+	}
+	if _, specConfigured := router.ByKind[sdk.ArtifactKindSpec]; specConfigured {
+		t.Fatalf("router.ByKind has spec entry on zero config; specs should fall through to router.Default")
+	}
+	docPolicy, ok := router.ByKind[sdk.ArtifactKindDoc].(stchunk.LateChunkPolicy)
+	if !ok {
+		t.Fatalf("router.ByKind[doc] = %T, want LateChunkPolicy on zero config", router.ByKind[sdk.ArtifactKindDoc])
+	}
+	if docPolicy.ParentMaxTokens != DefaultDocLateChunkParentMaxTokens ||
+		docPolicy.ChildMaxTokens != DefaultDocLateChunkChildMaxTokens ||
+		docPolicy.ChildOverlapTokens != DefaultDocLateChunkChildOverlapTokens {
+		t.Fatalf("default doc LateChunkPolicy = %+v, want parent=%d child=%d overlap=%d",
+			docPolicy,
+			DefaultDocLateChunkParentMaxTokens,
+			DefaultDocLateChunkChildMaxTokens,
+			DefaultDocLateChunkChildOverlapTokens,
+		)
+	}
+	if got, want := docPolicy.MaxSections, stindex.DefaultMaxChunkSections; got != want {
+		t.Fatalf("default doc LateChunkPolicy.MaxSections = %d, want %d", got, want)
 	}
 }
 
-func TestResolve_SpecOnlyRoutesSpecAndDefaultsOthers(t *testing.T) {
+func TestResolve_ExplicitMarkdownDocOverridesDefault(t *testing.T) {
 	t.Parallel()
 
+	// AC: operators can opt back to MarkdownPolicy for docs when they
+	// don't want the LateChunkPolicy storage overhead. Explicit
+	// `policy = "markdown"` must win over the #344 default.
+	policy, err := Resolve(Config{
+		Doc: KindConfig{Policy: PolicyMarkdown, MaxTokens: 800},
+	})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	router := policy.(stchunk.KindRouterPolicy)
+	docPolicy, ok := router.ByKind[sdk.ArtifactKindDoc].(stchunk.MarkdownPolicy)
+	if !ok {
+		t.Fatalf("doc policy = %T, want MarkdownPolicy (explicit opt-back)", router.ByKind[sdk.ArtifactKindDoc])
+	}
+	if docPolicy.Options.MaxTokens != 800 {
+		t.Fatalf("doc MarkdownPolicy.Options.MaxTokens = %d, want 800", docPolicy.Options.MaxTokens)
+	}
+}
+
+func TestResolve_SpecOnlyPinsSpecAndKeepsDocDefault(t *testing.T) {
+	t.Parallel()
+
+	// Configuring only specs must leave docs on the #344 LateChunkPolicy
+	// default, and must not accidentally disable the DoS guard on the
+	// unknown-kind fallback (router.Default).
 	policy, err := Resolve(Config{
 		Spec: KindConfig{Policy: PolicyMarkdown, MaxTokens: 512},
 	})
@@ -42,16 +99,13 @@ func TestResolve_SpecOnlyRoutesSpecAndDefaultsOthers(t *testing.T) {
 	if _, ok := router.ByKind[sdk.ArtifactKindSpec]; !ok {
 		t.Fatalf("router missing spec entry; ByKind=%+v", router.ByKind)
 	}
-	if _, ok := router.ByKind[sdk.ArtifactKindDoc]; ok {
-		t.Fatalf("router has doc entry but doc was not configured")
+	if _, ok := router.ByKind[sdk.ArtifactKindDoc].(stchunk.LateChunkPolicy); !ok {
+		t.Fatalf("router.ByKind[doc] = %T, want LateChunkPolicy (#344 default applies when doc unconfigured)", router.ByKind[sdk.ArtifactKindDoc])
 	}
 	defaultPolicy, ok := router.Default.(stchunk.MarkdownPolicy)
 	if !ok {
 		t.Fatalf("router.Default = %T, want MarkdownPolicy", router.Default)
 	}
-	// Router Default must carry stroma's DefaultMaxChunkSections cap
-	// so the unconfigured kind keeps the same DoS guard as the
-	// pre-#338 nil-policy rebuild path.
 	if got, want := defaultPolicy.Options.MaxSections, stindex.DefaultMaxChunkSections; got != want {
 		t.Fatalf("router.Default MarkdownPolicy.Options.MaxSections = %d, want %d", got, want)
 	}

--- a/internal/index/chunking_config_fingerprint_test.go
+++ b/internal/index/chunking_config_fingerprint_test.go
@@ -1,0 +1,106 @@
+package index
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	pchunk "github.com/dusk-network/pituitary/internal/chunk"
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+// TestChunkingConfigFingerprintIncludesResolverDefaultsVersion regression-
+// guards #344: flipping a default in chunk.Resolve must invalidate stored
+// snapshot fingerprints so `--update` falls back to a full rebuild
+// instead of silently mixing pre- and post-flip chunk shapes.
+//
+// The test pins the raw input lines and their hash so any drift — a
+// missing version tag, a reordered field, a new knob added without
+// routing it through the version — trips here and forces a deliberate
+// version bump.
+func TestChunkingConfigFingerprintIncludesResolverDefaultsVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.ChunkingConfig{}
+	got := chunkingConfigFingerprint(cfg)
+
+	expectedParts := []string{
+		"resolver_defaults_version=" + pchunk.ResolverDefaultsVersion,
+		"contextualizer_format=",
+		"spec_policy=",
+		"spec_max_tokens=0",
+		"spec_overlap_tokens=0",
+		"spec_max_sections=0",
+		"spec_child_max_tokens=0",
+		"spec_child_overlap_tokens=0",
+		"doc_policy=",
+		"doc_max_tokens=0",
+		"doc_overlap_tokens=0",
+		"doc_max_sections=0",
+		"doc_child_max_tokens=0",
+		"doc_child_overlap_tokens=0",
+	}
+	sort.Strings(expectedParts)
+	hash := sha256.Sum256([]byte(strings.Join(expectedParts, "\n")))
+	want := hex.EncodeToString(hash[:])
+
+	if got != want {
+		t.Fatalf("chunkingConfigFingerprint(zero) = %s, want %s (resolver_defaults_version=%q)",
+			got, want, pchunk.ResolverDefaultsVersion)
+	}
+}
+
+// TestChunkingConfigFingerprintDifferentiatesResolverDefaults verifies
+// that the fingerprint changes when resolver_defaults_version differs,
+// which is the invariant that forces rebuild after a zero-config
+// default flip in chunk.Resolve.
+func TestChunkingConfigFingerprintDifferentiatesResolverDefaults(t *testing.T) {
+	t.Parallel()
+
+	base := func(version string) string {
+		parts := []string{
+			"resolver_defaults_version=" + version,
+			"contextualizer_format=",
+			"spec_policy=",
+			"spec_max_tokens=0",
+			"spec_overlap_tokens=0",
+			"spec_max_sections=0",
+			"spec_child_max_tokens=0",
+			"spec_child_overlap_tokens=0",
+			"doc_policy=",
+			"doc_max_tokens=0",
+			"doc_overlap_tokens=0",
+			"doc_max_sections=0",
+			"doc_child_max_tokens=0",
+			"doc_child_overlap_tokens=0",
+		}
+		sort.Strings(parts)
+		h := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+		return hex.EncodeToString(h[:])
+	}
+
+	v1 := base("1")
+	v2 := base("2")
+	if v1 == v2 {
+		t.Fatalf("fingerprint at v1 and v2 should differ but both = %s", v1)
+	}
+
+	// Ensure the live ResolverDefaultsVersion matches the v2 fingerprint
+	// (the #344 default), so we don't accidentally ship a release that
+	// still hashes to the v1 shape.
+	actual := chunkingConfigFingerprint(config.ChunkingConfig{})
+	want := base(pchunk.ResolverDefaultsVersion)
+	if actual != want {
+		t.Fatalf("live fingerprint = %s, want %s (for ResolverDefaultsVersion=%q)",
+			actual, want, pchunk.ResolverDefaultsVersion)
+	}
+
+	// Sanity: make sure the helper we used in the two branches actually
+	// reproduces the live fingerprint function's output shape.
+	if fmt.Sprintf("%x", sha256.Sum256([]byte{})) == v1 {
+		t.Fatalf("hash collision sanity check failed")
+	}
+}

--- a/internal/index/chunking_defaults_regression_test.go
+++ b/internal/index/chunking_defaults_regression_test.go
@@ -1,0 +1,162 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pchunk "github.com/dusk-network/pituitary/internal/chunk"
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+// TestValidateStoredChunkingConfigRejectsLegacyMissingFingerprint is
+// the regression for the high-severity Codex finding on #344: a
+// snapshot built before chunking_config_fingerprint was persisted
+// still carried the pre-#344 (v1) resolver defaults. If the validator
+// skipped the check on missing-fingerprint indexes AND the live
+// resolver has advanced to v2 (doc default is now LateChunkPolicy),
+// the first incremental update would re-chunk only the changed
+// records under late-chunk and leave the rest on Markdown — the
+// mixed-generation hazard the fingerprint exists to prevent.
+//
+// The validator must reject the missing-fingerprint branch whenever
+// pchunk.ResolverDefaultsVersion != "1", forcing a full rebuild
+// instead of a silently mixed update.
+func TestValidateStoredChunkingConfigRejectsLegacyMissingFingerprint(t *testing.T) {
+	t.Parallel()
+
+	if pchunk.ResolverDefaultsVersion == "1" {
+		t.Skip("regression only applies once resolver defaults have advanced past v1")
+	}
+
+	repoDir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "pituitary.db")
+	configPath := filepath.Join(t.TempDir(), "pituitary.toml")
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guides", "legacy.md"), "# Legacy\n\nbody.\n")
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repoDir)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig: %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("initial Rebuild: %v", err)
+	}
+
+	// Simulate a pre-fingerprint snapshot by deleting the metadata row.
+	ctx := context.Background()
+	db, err := sql.Open("sqlite3", indexPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM metadata WHERE key = 'chunking_config_fingerprint'`); err != nil {
+		db.Close()
+		t.Fatalf("clear chunking_config_fingerprint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close index db: %v", err)
+	}
+
+	roDB, err := OpenReadOnlyContext(ctx, indexPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnlyContext: %v", err)
+	}
+	defer roDB.Close()
+
+	err = validateStoredChunkingConfigContext(ctx, roDB, cfg.Runtime.Chunking)
+	if err == nil {
+		t.Fatalf("validateStoredChunkingConfigContext on missing fingerprint = nil, want error (legacy snapshots must rebuild once defaults move past v1)")
+	}
+	if !strings.Contains(err.Error(), "resolver defaults have advanced") {
+		t.Fatalf("error should mention advanced resolver defaults; got: %v", err)
+	}
+}
+
+// TestRebuildChunkCountReflectsLateChunkLeaves is the regression for
+// the medium-severity Codex finding on #344: summarizeRebuild's
+// predictive ChunkCount used chunk.Markdown, which undercounts docs
+// once LateChunkPolicy emits parent+leaf rows. The rebuild result
+// must now reflect the actual snapshot chunk count so operators can
+// see the real index-size / embed-cost footprint of the default flip.
+func TestRebuildChunkCountReflectsLateChunkLeaves(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "pituitary.db")
+	configPath := filepath.Join(t.TempDir(), "pituitary.toml")
+
+	// Build a doc body with one oversized section so LateChunkPolicy
+	// must split it into parent + multiple leaves. "word " * 400 is
+	// well above any reasonable ChildMaxTokens.
+	longSection := "# Long section\n\n" + strings.Repeat("word ", 400) + "\n"
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guides", "long.md"), longSection)
+
+	// Explicit LateChunkPolicy with a small ChildMaxTokens so the
+	// split happens deterministically regardless of the resolver's
+	// default tuning.
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repoDir)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[runtime.chunking.doc]
+policy = "late_chunk"
+max_tokens = 512
+child_max_tokens = 64
+child_overlap_tokens = 8
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig: %v", err)
+	}
+	result, err := Rebuild(cfg, records)
+	if err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+
+	// chunk.Markdown would return one section for this body (single
+	// heading with a long paragraph). LateChunkPolicy must emit a
+	// parent plus at least two leaves, so the post-refresh ChunkCount
+	// must exceed the Markdown baseline.
+	if result.ChunkCount <= 1 {
+		t.Fatalf("result.ChunkCount = %d, want > 1 (parent + leaves under LateChunkPolicy)", result.ChunkCount)
+	}
+}

--- a/internal/index/parent_chain.go
+++ b/internal/index/parent_chain.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	stchunk "github.com/dusk-network/stroma/v2/chunk"
 
@@ -47,9 +48,8 @@ func validateDocParentChainContext(ctx context.Context, snapshotPath string) err
 	}
 	defer db.Close()
 
-	const query = `
-SELECT COUNT(*),
-       IFNULL(GROUP_CONCAT(c.record_ref || '#' || c.id, ','), '')
+	const countQuery = `
+SELECT COUNT(*)
 FROM   chunks c
 JOIN   chunks p ON c.parent_chunk_id = p.id
 JOIN   records r ON c.record_ref = r.ref
@@ -58,15 +58,51 @@ WHERE  r.kind = ?
             OR p.parent_chunk_id IS NOT NULL)`
 
 	var brokenCount int
-	var brokenRefs string
-	if err := db.QueryRowContext(ctx, query, sdk.ArtifactKindDoc).Scan(&brokenCount, &brokenRefs); err != nil {
+	if err := db.QueryRowContext(ctx, countQuery, sdk.ArtifactKindDoc).Scan(&brokenCount); err != nil {
 		return fmt.Errorf("query doc parent-chain invariant: %w", err)
 	}
-	if brokenCount > 0 {
-		return fmt.Errorf(
-			"doc parent-chain validation failed: %d doc leaf chunk(s) point at a parent outside the same record or at a non-root parent; offenders: %s",
-			brokenCount, brokenRefs,
-		)
+	if brokenCount == 0 {
+		return nil
 	}
-	return nil
+
+	// Only when validation fails do we pay for a bounded sample of
+	// offenders for the error message. GROUP_CONCAT over every row on
+	// a healthy large snapshot would be wasted work (and can bump into
+	// SQLite's GROUP_CONCAT length limits on very large corpora).
+	const brokenSampleLimit = 10
+	const sampleQuery = `
+SELECT c.record_ref || '#' || c.id
+FROM   chunks c
+JOIN   chunks p ON c.parent_chunk_id = p.id
+JOIN   records r ON c.record_ref = r.ref
+WHERE  r.kind = ?
+       AND (c.record_ref <> p.record_ref
+            OR p.parent_chunk_id IS NOT NULL)
+LIMIT  ?`
+
+	rows, err := db.QueryContext(ctx, sampleQuery, sdk.ArtifactKindDoc, brokenSampleLimit)
+	if err != nil {
+		return fmt.Errorf("sample doc parent-chain offenders: %w", err)
+	}
+	defer rows.Close()
+	var offenders []string
+	for rows.Next() {
+		var ref string
+		if err := rows.Scan(&ref); err != nil {
+			return fmt.Errorf("scan doc parent-chain offender: %w", err)
+		}
+		offenders = append(offenders, ref)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate doc parent-chain offenders: %w", err)
+	}
+
+	sampleNote := ""
+	if brokenCount > len(offenders) {
+		sampleNote = fmt.Sprintf(" (sampled %d of %d)", len(offenders), brokenCount)
+	}
+	return fmt.Errorf(
+		"doc parent-chain validation failed: %d doc leaf chunk(s) point at a parent outside the same record or at a non-root parent; offenders%s: %s",
+		brokenCount, sampleNote, strings.Join(offenders, ","),
+	)
 }

--- a/internal/index/parent_chain.go
+++ b/internal/index/parent_chain.go
@@ -1,0 +1,72 @@
+package index
+
+import (
+	"context"
+	"fmt"
+
+	stchunk "github.com/dusk-network/stroma/v2/chunk"
+
+	"github.com/dusk-network/pituitary/sdk"
+)
+
+// docLateChunkActive reports whether the resolved chunk policy routes
+// doc records through LateChunkPolicy — either because an explicit
+// [runtime.chunking.doc] set it, or because the #344 zero-config
+// default applied. Unknown shapes (nil policy, raw MarkdownPolicy,
+// unfamiliar wrappers) return false so the validator short-circuits
+// without raising spurious errors.
+func docLateChunkActive(policy stchunk.Policy) bool {
+	router, ok := policy.(stchunk.KindRouterPolicy)
+	if !ok {
+		return false
+	}
+	_, ok = router.ByKind[sdk.ArtifactKindDoc].(stchunk.LateChunkPolicy)
+	return ok
+}
+
+// validateDocParentChainContext asserts the structural invariants of
+// LateChunkPolicy's parent/leaf output on doc records (#344 AC):
+//
+//  1. Any doc chunk with parent_chunk_id set must point at a chunk
+//     belonging to the same record — the parent/leaf span stays
+//     anchored inside one doc.
+//  2. The referenced parent must itself be a real parent (parent_chunk_id
+//     IS NULL). Stroma's LateChunkPolicy is one level deep; a leaf
+//     pointing at another leaf would mean the shape regressed.
+//
+// Note that LateChunkPolicy legitimately emits doc records as purely
+// flat parents (all parent_chunk_id NULL) when every heading-aware
+// section fits within ChildMaxTokens — stroma skips leaf emission in
+// that case to avoid duplicating the parent's body in a single-child
+// split. So we cannot require that leaves exist; we only validate the
+// shape of the leaves that do exist.
+func validateDocParentChainContext(ctx context.Context, snapshotPath string) error {
+	db, err := OpenReadOnlyContext(ctx, snapshotPath)
+	if err != nil {
+		return fmt.Errorf("open stroma snapshot %s for doc parent-chain validation: %w", snapshotPath, err)
+	}
+	defer db.Close()
+
+	const query = `
+SELECT COUNT(*),
+       IFNULL(GROUP_CONCAT(c.record_ref || '#' || c.id, ','), '')
+FROM   chunks c
+JOIN   chunks p ON c.parent_chunk_id = p.id
+JOIN   records r ON c.record_ref = r.ref
+WHERE  r.kind = ?
+       AND (c.record_ref <> p.record_ref
+            OR p.parent_chunk_id IS NOT NULL)`
+
+	var brokenCount int
+	var brokenRefs string
+	if err := db.QueryRowContext(ctx, query, sdk.ArtifactKindDoc).Scan(&brokenCount, &brokenRefs); err != nil {
+		return fmt.Errorf("query doc parent-chain invariant: %w", err)
+	}
+	if brokenCount > 0 {
+		return fmt.Errorf(
+			"doc parent-chain validation failed: %d doc leaf chunk(s) point at a parent outside the same record or at a non-root parent; offenders: %s",
+			brokenCount, brokenRefs,
+		)
+	}
+	return nil
+}

--- a/internal/index/parent_chain_test.go
+++ b/internal/index/parent_chain_test.go
@@ -1,0 +1,184 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	stchunk "github.com/dusk-network/stroma/v2/chunk"
+
+	pchunk "github.com/dusk-network/pituitary/internal/chunk"
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/source"
+	"github.com/dusk-network/pituitary/sdk"
+)
+
+func TestDocLateChunkActive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil policy is inactive", func(t *testing.T) {
+		t.Parallel()
+		if docLateChunkActive(nil) {
+			t.Fatalf("docLateChunkActive(nil) = true, want false")
+		}
+	})
+	t.Run("markdown-only router is inactive", func(t *testing.T) {
+		t.Parallel()
+		router := stchunk.KindRouterPolicy{
+			Default: stchunk.MarkdownPolicy{},
+			ByKind: map[string]stchunk.Policy{
+				sdk.ArtifactKindDoc:  stchunk.MarkdownPolicy{},
+				sdk.ArtifactKindSpec: stchunk.MarkdownPolicy{},
+			},
+		}
+		if docLateChunkActive(router) {
+			t.Fatalf("docLateChunkActive(markdown router) = true, want false")
+		}
+	})
+	t.Run("router with doc late-chunk is active", func(t *testing.T) {
+		t.Parallel()
+		router := stchunk.KindRouterPolicy{
+			Default: stchunk.MarkdownPolicy{},
+			ByKind: map[string]stchunk.Policy{
+				sdk.ArtifactKindDoc: stchunk.LateChunkPolicy{ChildMaxTokens: 256},
+			},
+		}
+		if !docLateChunkActive(router) {
+			t.Fatalf("docLateChunkActive(late-chunk router) = false, want true")
+		}
+	})
+	t.Run("resolver #344 default is active", func(t *testing.T) {
+		t.Parallel()
+		// The zero-config resolver is what production takes when the
+		// operator has no [runtime.chunking] block; the validator must
+		// treat that as late-chunk active so publishes are guarded.
+		policy, err := pchunk.Resolve(pchunk.Config{})
+		if err != nil {
+			t.Fatalf("Resolve(zero): %v", err)
+		}
+		if !docLateChunkActive(policy) {
+			t.Fatalf("docLateChunkActive(Resolve(zero)) = false, want true (#344 default)")
+		}
+	})
+}
+
+// TestValidateDocParentChainContextRejectsMultiLevelChain constructs
+// a synthetic snapshot where a doc chunk has parent_chunk_id pointing
+// at another non-root chunk — a shape LateChunkPolicy never emits
+// (it is one level deep by design). Stroma enforces same-record
+// linkage via a trigger but does NOT forbid multi-level chains, so
+// this is the exact gap the validator is here to cover.
+func TestValidateDocParentChainContextRejectsMultiLevelChain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repoDir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "pituitary.db")
+	configPath := filepath.Join(t.TempDir(), "pituitary.toml")
+
+	// A doc body with multiple heading-aware sections so the snapshot
+	// has several chunk rows we can stitch into an illegal chain.
+	docBody := "# Part 1\n\nalpha\n\n# Part 2\n\nbravo\n\n# Part 3\n\ncharlie\n"
+	mustWriteFile(t, filepath.Join(repoDir, "docs", "guide", "multi.md"), docBody)
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repoDir)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guide/*.md"]
+`)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig: %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("initial Rebuild: %v", err)
+	}
+
+	snapshotPath := currentSnapshotPathForTest(t, indexPath)
+	snapshotDB, err := sql.Open("sqlite3", snapshotPath)
+	if err != nil {
+		t.Fatalf("open snapshot db: %v", err)
+	}
+	defer snapshotDB.Close()
+
+	// Build an illegal A→B→C chain inside the single doc record.
+	rows, err := snapshotDB.QueryContext(ctx, `
+SELECT id FROM chunks
+ WHERE record_ref = 'doc://guide/multi'
+ ORDER BY chunk_index
+ LIMIT 3`)
+	if err != nil {
+		t.Fatalf("query chunk ids: %v", err)
+	}
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			t.Fatalf("scan id: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if len(ids) < 3 {
+		t.Fatalf("need at least 3 chunks for the test; got %d", len(ids))
+	}
+
+	// Make id[1]'s parent = id[0] (legitimate one-level), then make
+	// id[2]'s parent = id[1] (illegitimate two-level chain).
+	if _, err := snapshotDB.ExecContext(ctx,
+		`UPDATE chunks SET parent_chunk_id = ? WHERE id = ?`, ids[0], ids[1]); err != nil {
+		t.Fatalf("set one-level parent: %v", err)
+	}
+	if _, err := snapshotDB.ExecContext(ctx,
+		`UPDATE chunks SET parent_chunk_id = ? WHERE id = ?`, ids[1], ids[2]); err != nil {
+		t.Fatalf("stage two-level chain: %v", err)
+	}
+
+	if err := validateDocParentChainContext(ctx, snapshotPath); err == nil {
+		t.Fatalf("expected validation error for multi-level chain; got nil")
+	} else if !containsAll(err.Error(), "parent-chain validation failed", "doc://guide/multi") {
+		t.Fatalf("error should name the offender; got: %v", err)
+	}
+}
+
+func currentSnapshotPathForTest(tb testing.TB, indexPath string) string {
+	tb.Helper()
+	ctx := context.Background()
+	db, err := OpenReadOnlyContext(ctx, indexPath)
+	if err != nil {
+		tb.Fatalf("open index db: %v", err)
+	}
+	defer db.Close()
+	snapshot, err := stromaSnapshotPathFromDBContext(ctx, db, indexPath)
+	if err != nil {
+		tb.Fatalf("stroma snapshot path: %v", err)
+	}
+	return snapshot
+}
+
+func containsAll(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		if !strings.Contains(haystack, n) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -220,14 +220,56 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 		return nil, fmt.Errorf("build stroma snapshot: %w", err)
 	}
 
+	// #344 AC: under LateChunkPolicy we must actually see parent/leaf
+	// linkage land in the snapshot; validate loudly here so a
+	// regression in stroma or in the resolver cannot ship quietly.
+	if docLateChunkActive(chunkPolicy) {
+		if err := validateDocParentChainContext(ctx, snapshotPath); err != nil {
+			return nil, err
+		}
+	}
+
 	result := summarizeRebuild(records, dimension, reuseState, options)
 	result.ContentFingerprint = contentFP
 	result.IndexPath = indexPath
+
+	// summarizeRebuild computes ChunkCount predictively via the
+	// pre-router Markdown sectioner, which systematically undercounts
+	// doc chunks once LateChunkPolicy emits parent+leaf hierarchies.
+	// Refresh the count from the freshly-published snapshot so the
+	// reported chunk growth reflects reality — operators need to see
+	// the real index-size / embedding-cost footprint of the #344
+	// default to evaluate it.
+	if err := refreshRebuildChunkCountFromSnapshotContext(ctx, snapshotPath, result); err != nil {
+		return nil, err
+	}
 
 	if err := publishBusinessIndexContext(ctx, cfg, records, result, snapshotPath); err != nil {
 		return nil, err
 	}
 	return result, nil
+}
+
+// refreshRebuildChunkCountFromSnapshotContext overwrites result.ChunkCount
+// with the ground-truth count from the published stroma snapshot. This
+// replaces the Markdown-based predictive count that summarizeRebuild
+// produces, which is wrong for docs under LateChunkPolicy where each
+// record can emit a parent plus multiple leaves.
+func refreshRebuildChunkCountFromSnapshotContext(ctx context.Context, snapshotPath string, result *RebuildResult) error {
+	if result == nil || snapshotPath == "" {
+		return nil
+	}
+	snapshot, err := stindex.OpenSnapshot(ctx, snapshotPath)
+	if err != nil {
+		return fmt.Errorf("open stroma snapshot for chunk-count refresh: %w", err)
+	}
+	defer snapshot.Close()
+	stats, err := snapshot.Stats(ctx)
+	if err != nil {
+		return fmt.Errorf("read stroma snapshot stats: %w", err)
+	}
+	result.ChunkCount = stats.ChunkCount
+	return nil
 }
 
 func corpusRecordsFromLoadResult(records *source.LoadResult) ([]stcorpus.Record, error) {
@@ -902,8 +944,17 @@ func fingerprint(parts []string) string {
 // between rebuild and update can't silently produce a snapshot with
 // mixed chunk shapes (old records re-chunked under one policy, new
 // records under another). Any mismatch forces an explicit rebuild.
+//
+// The pchunk.ResolverDefaultsVersion component captures Resolve's
+// zero-config defaults. Without it, flipping a default in Resolve
+// (e.g. #344: doc default flips from MarkdownPolicy to LateChunkPolicy)
+// would leave existing snapshots' raw-field fingerprint unchanged and
+// silently mix chunk shapes across an incremental update. Including
+// the version forces rebuild on default flips even when no config
+// field changed on disk.
 func chunkingConfigFingerprint(cfg config.ChunkingConfig) string {
 	parts := []string{
+		"resolver_defaults_version=" + pchunk.ResolverDefaultsVersion,
 		"contextualizer_format=" + cfg.Contextualizer.Format,
 		"spec_policy=" + cfg.Spec.Policy,
 		fmt.Sprintf("spec_max_tokens=%d", cfg.Spec.MaxTokens),

--- a/internal/index/retrieval_precision_bench_test.go
+++ b/internal/index/retrieval_precision_bench_test.go
@@ -1,0 +1,275 @@
+//go:build precision_bench
+
+package index
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	stindex "github.com/dusk-network/stroma/v2/index"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/source"
+	"github.com/dusk-network/pituitary/sdk"
+)
+
+// TestRetrievalPrecisionBench measures precision@k / recall@10 / MRR for the
+// doc arm of the index against a labeled cases file. It is opt-in via the
+// precision_bench build tag because it needs a live embedder.
+//
+// Environment:
+//
+//	PITUITARY_PRECISION_CONFIG        path to workspace config toml (required)
+//	PITUITARY_PRECISION_CASES         path to cases JSON (required)
+//	PITUITARY_PRECISION_REPORT        path to write JSON report (optional)
+//	PITUITARY_PRECISION_LABEL         string tag for the run (optional)
+//	PITUITARY_PRECISION_SKIP_REBUILD  if "1", skip rebuild and reuse snapshot
+func TestRetrievalPrecisionBench(t *testing.T) {
+	configPath := strings.TrimSpace(os.Getenv("PITUITARY_PRECISION_CONFIG"))
+	casesPath := strings.TrimSpace(os.Getenv("PITUITARY_PRECISION_CASES"))
+	if configPath == "" || casesPath == "" {
+		t.Skip("set PITUITARY_PRECISION_CONFIG and PITUITARY_PRECISION_CASES to run")
+	}
+
+	ctx := context.Background()
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config %s: %v", configPath, err)
+	}
+
+	cases, err := loadPrecisionCases(casesPath)
+	if err != nil {
+		t.Fatalf("load cases %s: %v", casesPath, err)
+	}
+	if len(cases) == 0 {
+		t.Fatalf("cases file %s has no cases", casesPath)
+	}
+
+	if os.Getenv("PITUITARY_PRECISION_SKIP_REBUILD") != "1" {
+		records, err := source.LoadFromConfig(cfg)
+		if err != nil {
+			t.Fatalf("load sources: %v", err)
+		}
+		if _, err := RebuildContext(ctx, cfg, records); err != nil {
+			t.Fatalf("rebuild: %v", err)
+		}
+	}
+
+	db, err := OpenReadOnlyContext(ctx, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("open index db %s: %v", cfg.Workspace.ResolvedIndexPath, err)
+	}
+	defer db.Close()
+
+	snapshot, err := OpenStromaSnapshotContext(ctx, db, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		t.Fatalf("open stroma snapshot: %v", err)
+	}
+	defer snapshot.Close()
+
+	embedder, err := newEmbedder(cfg.Runtime.Embedder)
+	if err != nil {
+		t.Fatalf("build embedder: %v", err)
+	}
+
+	rep := &precisionReport{
+		Label:       strings.TrimSpace(os.Getenv("PITUITARY_PRECISION_LABEL")),
+		ConfigPath:  configPath,
+		CasesPath:   casesPath,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		CaseCount:   len(cases),
+	}
+
+	for _, c := range cases {
+		hits, err := snapshot.Search(ctx, stindex.SnapshotSearchQuery{
+			SearchParams: stindex.SearchParams{
+				Text:     c.Query,
+				Limit:    10,
+				Kinds:    []string{sdk.ArtifactKindDoc},
+				Embedder: embedder,
+			},
+		})
+		if err != nil {
+			t.Fatalf("case %s: search: %v", c.ID, err)
+		}
+		cr := evaluatePrecisionCase(c, hits)
+		rep.Cases = append(rep.Cases, cr)
+		rep.MeanPrecisionAt5 += cr.PrecisionAt5
+		rep.MeanPrecisionAt10 += cr.PrecisionAt10
+		rep.MeanRecallAt10 += cr.RecallAt10
+		rep.MeanReciprocalRank += cr.ReciprocalRank
+	}
+	n := float64(len(cases))
+	rep.MeanPrecisionAt5 /= n
+	rep.MeanPrecisionAt10 /= n
+	rep.MeanRecallAt10 /= n
+	rep.MeanReciprocalRank /= n
+
+	if reportPath := strings.TrimSpace(os.Getenv("PITUITARY_PRECISION_REPORT")); reportPath != "" {
+		if err := writePrecisionReport(reportPath, rep); err != nil {
+			t.Fatalf("write report %s: %v", reportPath, err)
+		}
+		t.Logf("wrote precision report: %s", reportPath)
+	}
+
+	t.Logf(
+		"label=%q cases=%d p@5=%.3f p@10=%.3f r@10=%.3f mrr=%.3f",
+		rep.Label, rep.CaseCount,
+		rep.MeanPrecisionAt5, rep.MeanPrecisionAt10,
+		rep.MeanRecallAt10, rep.MeanReciprocalRank,
+	)
+}
+
+type precisionCase struct {
+	ID              string   `json:"id"`
+	Query           string   `json:"query"`
+	RelevantDocRefs []string `json:"relevant_doc_refs"`
+}
+
+type precisionCaseResult struct {
+	ID             string   `json:"id"`
+	Query          string   `json:"query"`
+	Relevant       []string `json:"relevant"`
+	RetrievedTop10 []string `json:"retrieved_top_10"`
+	PrecisionAt5   float64  `json:"precision_at_5"`
+	PrecisionAt10  float64  `json:"precision_at_10"`
+	RecallAt10     float64  `json:"recall_at_10"`
+	ReciprocalRank float64  `json:"reciprocal_rank"`
+}
+
+type precisionReport struct {
+	Label              string                `json:"label,omitempty"`
+	GeneratedAt        string                `json:"generated_at"`
+	ConfigPath         string                `json:"config_path"`
+	CasesPath          string                `json:"cases_path"`
+	CaseCount          int                   `json:"case_count"`
+	MeanPrecisionAt5   float64               `json:"mean_precision_at_5"`
+	MeanPrecisionAt10  float64               `json:"mean_precision_at_10"`
+	MeanRecallAt10     float64               `json:"mean_recall_at_10"`
+	MeanReciprocalRank float64               `json:"mean_reciprocal_rank"`
+	Cases              []precisionCaseResult `json:"cases"`
+}
+
+func loadPrecisionCases(path string) ([]precisionCase, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cases []precisionCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		return nil, fmt.Errorf("decode cases: %w", err)
+	}
+	for i := range cases {
+		cases[i].ID = strings.TrimSpace(cases[i].ID)
+		cases[i].Query = strings.TrimSpace(cases[i].Query)
+		if cases[i].ID == "" {
+			return nil, fmt.Errorf("case %d: id is required", i)
+		}
+		if cases[i].Query == "" {
+			return nil, fmt.Errorf("case %s: query is required", cases[i].ID)
+		}
+		if len(cases[i].RelevantDocRefs) == 0 {
+			return nil, fmt.Errorf("case %s: relevant_doc_refs is required", cases[i].ID)
+		}
+	}
+	return cases, nil
+}
+
+func evaluatePrecisionCase(c precisionCase, hits []stindex.SearchHit) precisionCaseResult {
+	// Dedupe to unique doc refs in rank order — a doc appearing in
+	// multiple leaf chunks should still only count once at the doc level.
+	uniqueRefs := make([]string, 0, len(hits))
+	seen := make(map[string]bool, len(hits))
+	for _, h := range hits {
+		ref := strings.TrimSpace(h.Ref)
+		if ref == "" || seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		uniqueRefs = append(uniqueRefs, ref)
+	}
+
+	relevant := make(map[string]bool, len(c.RelevantDocRefs))
+	for _, r := range c.RelevantDocRefs {
+		relevant[strings.TrimSpace(r)] = true
+	}
+
+	top5 := truncate(uniqueRefs, 5)
+	top10 := truncate(uniqueRefs, 10)
+
+	cr := precisionCaseResult{
+		ID:             c.ID,
+		Query:          c.Query,
+		Relevant:       append([]string{}, c.RelevantDocRefs...),
+		RetrievedTop10: top10,
+		PrecisionAt5:   precisionAt(top5, relevant, 5),
+		PrecisionAt10:  precisionAt(top10, relevant, 10),
+		RecallAt10:     recallAt(top10, relevant, len(c.RelevantDocRefs)),
+		ReciprocalRank: reciprocalRank(top10, relevant),
+	}
+	sort.Strings(cr.Relevant)
+	return cr
+}
+
+func precisionAt(retrieved []string, relevant map[string]bool, k int) float64 {
+	if k <= 0 {
+		return 0
+	}
+	hits := 0
+	for _, r := range retrieved {
+		if relevant[r] {
+			hits++
+		}
+	}
+	return float64(hits) / float64(k)
+}
+
+func recallAt(retrieved []string, relevant map[string]bool, totalRelevant int) float64 {
+	if totalRelevant <= 0 {
+		return 0
+	}
+	hits := 0
+	for _, r := range retrieved {
+		if relevant[r] {
+			hits++
+		}
+	}
+	return float64(hits) / float64(totalRelevant)
+}
+
+func reciprocalRank(retrieved []string, relevant map[string]bool) float64 {
+	for i, r := range retrieved {
+		if relevant[r] {
+			return 1.0 / float64(i+1)
+		}
+	}
+	return 0
+}
+
+func truncate(values []string, n int) []string {
+	if len(values) <= n {
+		return append([]string{}, values...)
+	}
+	return append([]string{}, values[:n]...)
+}
+
+func writePrecisionReport(path string, rep *precisionReport) error {
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	data, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -161,6 +161,13 @@ func updateContext(ctx context.Context, cfg *config.Config, records *source.Load
 	}()
 
 	result.ContentFingerprint = contentFingerprint(records)
+	// Same reason as rebuildContext: summarizeRebuild's predictive
+	// Markdown-based ChunkCount undercounts doc chunks once
+	// LateChunkPolicy emits parent+leaf hierarchies, so refresh from
+	// the written snapshot before publishing.
+	if err := refreshRebuildChunkCountFromSnapshotContext(ctx, snapshotPath, result); err != nil {
+		return nil, err
+	}
 	if err := publishBusinessIndexContext(ctx, cfg, records, result, snapshotPath); err != nil {
 		return nil, err
 	}
@@ -346,12 +353,16 @@ func validateIncrementalUpdateEligibilityContext(ctx context.Context, db *sql.DB
 // shapes — a silent mixed-generation snapshot.
 //
 // Older snapshots (built before this fingerprint was persisted) have
-// no stored value; we skip the check in that case rather than
-// force-rebuild every pre-existing index, because rebuild.go did
-// honor the active config even without recording the fingerprint.
-// The metadata gap is self-healed by the first rebuild OR update
-// after this change, since publishBusinessIndexContext runs on both
-// paths and upserts chunking_config_fingerprint unconditionally.
+// no stored value. That was safe while resolver defaults were frozen,
+// because rebuild.go honored the active config even without recording
+// the fingerprint. Once pchunk.ResolverDefaultsVersion advances past
+// "1" (i.e., the resolver's zero-config output has changed since the
+// pre-fingerprint era), that premise breaks: an `--update` against a
+// pre-fingerprint snapshot would re-chunk only the changed records
+// under the new default and leave the rest on the old layout — the
+// exact mixed-generation hazard this gate exists to prevent. So we
+// reject missing fingerprints whenever the resolver has moved past v1
+// and route the caller through a full rebuild instead.
 func validateStoredChunkingConfigContext(ctx context.Context, db *sql.DB, current config.ChunkingConfig) error {
 	stored, err := readOptionalMetadataValueContext(ctx, db, "chunking_config_fingerprint")
 	if err != nil {
@@ -359,6 +370,12 @@ func validateStoredChunkingConfigContext(ctx context.Context, db *sql.DB, curren
 	}
 	stored = strings.TrimSpace(stored)
 	if stored == "" {
+		if pchunk.ResolverDefaultsVersion != "1" {
+			return fmt.Errorf(
+				"stored snapshot has no chunking_config_fingerprint and resolver defaults have advanced to version %q since it was built",
+				pchunk.ResolverDefaultsVersion,
+			)
+		}
 		return nil
 	}
 	want := chunkingConfigFingerprint(current)
@@ -438,6 +455,17 @@ func updateStromaSnapshotContext(
 			cleanupSnapshot()
 		}
 		return "", nil, normalizeStromaUpdateError(targetSnapshotPath, err)
+	}
+	// Mirror the rebuild-path guard so an incremental update cannot
+	// silently land a snapshot with doc leaves missing parent_chunk_id
+	// under LateChunkPolicy. The validator inspects the published target.
+	if docLateChunkActive(chunkPolicy) {
+		if err := validateDocParentChainContext(ctx, targetSnapshotPath); err != nil {
+			if cleanupSnapshot != nil {
+				cleanupSnapshot()
+			}
+			return "", nil, err
+		}
 	}
 	return targetSnapshotPath, cleanupSnapshot, nil
 }

--- a/scripts/bench-precision-344.sh
+++ b/scripts/bench-precision-344.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Run the #344 precision@k benchmark across three chunking configs and emit a
+# consolidated markdown report.
+#
+# Required env:
+#   BENCH_BASE_CONFIG   path to a pituitary.toml that indexes a representative
+#                       corpus with a live embedder. The config must NOT include
+#                       a [runtime.chunking] block — overlays supply it.
+#
+# Optional env:
+#   BENCH_CASES         path to the labeled cases JSON
+#                       (default: testdata/retrieval-bench/ccd-guide-cases.json)
+#   BENCH_OUT_DIR       where to drop per-variant JSON reports
+#                       (default: /tmp/pituitary-bench-344)
+#   BENCH_REPORT_MD     consolidated markdown output path
+#                       (default: docs/development/retrieval-precision-344.md)
+
+set -euo pipefail
+
+if [[ -z "${BENCH_BASE_CONFIG:-}" ]]; then
+  echo "bench-precision-344: BENCH_BASE_CONFIG is required" >&2
+  exit 2
+fi
+if [[ ! -f "${BENCH_BASE_CONFIG}" ]]; then
+  echo "bench-precision-344: base config not found: ${BENCH_BASE_CONFIG}" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CASES_DEFAULT="${REPO_ROOT}/testdata/retrieval-bench/ccd-guide-cases.json"
+OVERLAY_DIR="${REPO_ROOT}/testdata/retrieval-bench/chunking-overlays"
+BENCH_CASES="${BENCH_CASES:-${CASES_DEFAULT}}"
+BENCH_OUT_DIR="${BENCH_OUT_DIR:-/tmp/pituitary-bench-344}"
+BENCH_REPORT_MD="${BENCH_REPORT_MD:-${REPO_ROOT}/docs/development/retrieval-precision-344.md}"
+
+mkdir -p "${BENCH_OUT_DIR}"
+
+VARIANTS=(pre338 p338 p344)
+BASE_INDEX_PATH="$(awk -F'=' '/^index_path/ { gsub(/[ "]/, "", $2); print $2; exit }' "${BENCH_BASE_CONFIG}")"
+if [[ -z "${BASE_INDEX_PATH}" ]]; then
+  echo "bench-precision-344: could not read [workspace] index_path from ${BENCH_BASE_CONFIG}" >&2
+  exit 2
+fi
+BASE_INDEX_EXT="${BASE_INDEX_PATH##*.}"
+BASE_INDEX_STEM="${BASE_INDEX_PATH%.*}"
+
+run_variant() {
+  local variant="$1"
+  local overlay="${OVERLAY_DIR}/${variant}.toml"
+  local effective_cfg="${BENCH_OUT_DIR}/${variant}.toml"
+  local variant_index="${BASE_INDEX_STEM}.${variant}.${BASE_INDEX_EXT}"
+  local report="${BENCH_OUT_DIR}/${variant}.json"
+
+  # Rewrite the base config's index_path so the three variants write distinct
+  # snapshots, then append the chunking overlay.
+  awk -v new_path="${variant_index}" '
+    BEGIN { in_ws = 0 }
+    /^\[workspace\][[:space:]]*$/ { in_ws = 1; print; next }
+    in_ws && /^\[/ && !/^\[workspace\]/ { in_ws = 0 }
+    in_ws && /^[[:space:]]*index_path[[:space:]]*=/ {
+      printf "index_path = \"%s\"\n", new_path
+      next
+    }
+    { print }
+  ' "${BENCH_BASE_CONFIG}" > "${effective_cfg}"
+  if [[ -s "${overlay}" ]]; then
+    printf '\n' >> "${effective_cfg}"
+    cat "${overlay}" >> "${effective_cfg}"
+  fi
+
+  echo "==> ${variant}: rebuilding + benching (config: ${effective_cfg}, db: ${variant_index})"
+  PITUITARY_PRECISION_CONFIG="${effective_cfg}" \
+    PITUITARY_PRECISION_CASES="${BENCH_CASES}" \
+    PITUITARY_PRECISION_REPORT="${report}" \
+    PITUITARY_PRECISION_LABEL="${variant}" \
+    go test -tags=precision_bench -run TestRetrievalPrecisionBench -count=1 \
+      -timeout=30m -v ./internal/index/
+}
+
+for v in "${VARIANTS[@]}"; do
+  run_variant "${v}"
+done
+
+# Render a consolidated markdown summary.
+python3 - "${BENCH_REPORT_MD}" "${BENCH_OUT_DIR}" "${VARIANTS[@]}" <<'PY'
+import json, os, sys, datetime
+
+out_path = sys.argv[1]
+out_dir = sys.argv[2]
+variants = sys.argv[3:]
+
+rows = []
+for v in variants:
+    path = os.path.join(out_dir, f"{v}.json")
+    with open(path) as f:
+        r = json.load(f)
+    rows.append((v, r))
+
+os.makedirs(os.path.dirname(out_path), exist_ok=True)
+with open(out_path, "w") as f:
+    f.write("# Retrieval precision benchmark — #344\n\n")
+    f.write(f"Generated: {datetime.datetime.utcnow().isoformat()}Z\n\n")
+    f.write(f"Cases file: `{rows[0][1]['cases_path']}`\n\n")
+    f.write(f"Case count: {rows[0][1]['case_count']}\n\n")
+    f.write("| variant | p@5   | p@10  | recall@10 | MRR   |\n")
+    f.write("|---------|-------|-------|-----------|-------|\n")
+    for v, r in rows:
+        f.write(
+            f"| {v} "
+            f"| {r['mean_precision_at_5']:.3f} "
+            f"| {r['mean_precision_at_10']:.3f} "
+            f"| {r['mean_recall_at_10']:.3f} "
+            f"| {r['mean_reciprocal_rank']:.3f} |\n"
+        )
+    baseline = rows[0][1]
+    f.write("\n## Deltas vs pre-#338 baseline\n\n")
+    f.write("| variant | Δp@5  | Δp@10 | Δrecall@10 | ΔMRR  |\n")
+    f.write("|---------|-------|-------|------------|-------|\n")
+    for v, r in rows:
+        f.write(
+            f"| {v} "
+            f"| {r['mean_precision_at_5']-baseline['mean_precision_at_5']:+.3f} "
+            f"| {r['mean_precision_at_10']-baseline['mean_precision_at_10']:+.3f} "
+            f"| {r['mean_recall_at_10']-baseline['mean_recall_at_10']:+.3f} "
+            f"| {r['mean_reciprocal_rank']-baseline['mean_reciprocal_rank']:+.3f} |\n"
+        )
+    f.write("\n## Per-variant raw reports\n\n")
+    for v, r in rows:
+        f.write(f"- `{v}`: `{os.path.join(out_dir, v + '.json')}`\n")
+PY
+
+echo "==> wrote consolidated markdown: ${BENCH_REPORT_MD}"

--- a/scripts/bench-precision-344.sh
+++ b/scripts/bench-precision-344.sh
@@ -37,7 +37,29 @@ BENCH_REPORT_MD="${BENCH_REPORT_MD:-${REPO_ROOT}/docs/development/retrieval-prec
 mkdir -p "${BENCH_OUT_DIR}"
 
 VARIANTS=(pre338 p338 p344)
-BASE_INDEX_PATH="$(awk -F'=' '/^index_path/ { gsub(/[ "]/, "", $2); print $2; exit }' "${BENCH_BASE_CONFIG}")"
+
+# Read [workspace].index_path from the base config. Scoped to the
+# [workspace] table (TOML is order-sensitive per-table but other tables
+# can also define `index_path = ...`, so scan must stop at the next
+# table header), with leading whitespace tolerated to match how most
+# operators actually write TOML.
+read_workspace_index_path() {
+  local cfg="$1"
+  awk '
+    BEGIN { in_ws = 0 }
+    /^\[workspace\][[:space:]]*$/ { in_ws = 1; next }
+    in_ws && /^\[/ { in_ws = 0 }
+    in_ws && /^[[:space:]]*index_path[[:space:]]*=/ {
+      sub(/^[^=]*=[[:space:]]*/, "")
+      gsub(/^"|"[[:space:]]*$|^'\''|'\''[[:space:]]*$/, "")
+      sub(/[[:space:]]+$/, "")
+      print
+      exit
+    }
+  ' "${cfg}"
+}
+
+BASE_INDEX_PATH="$(read_workspace_index_path "${BENCH_BASE_CONFIG}")"
 if [[ -z "${BASE_INDEX_PATH}" ]]; then
   echo "bench-precision-344: could not read [workspace] index_path from ${BENCH_BASE_CONFIG}" >&2
   exit 2

--- a/testdata/retrieval-bench/README.md
+++ b/testdata/retrieval-bench/README.md
@@ -1,0 +1,26 @@
+# Retrieval precision bench — #344
+
+Ground-truth labels and runner scaffolding for the precision@k benchmark that
+gates #344 (default docs to `LateChunkPolicy`).
+
+## Files
+
+- `ccd-guide-cases.json` — hand-curated query → relevant doc refs.
+- `chunking-overlays/*.toml` — three chunking config overlays appended to a
+  base pituitary config by `scripts/bench-precision-344.sh`:
+  - `pre338.toml` — empty; pre-#338 baseline (no router, stroma `MarkdownPolicy` default).
+  - `p338.toml` — router active, both kinds on `MarkdownPolicy`.
+  - `p344.toml` — spec `MarkdownPolicy` + doc `LateChunkPolicy` with tuned P/C tokens.
+
+## Running
+
+Requires a reachable embedder (default config assumes the m2-router nomic-embed
+at `http://100.92.91.40:1234/v1`).
+
+```
+BENCH_BASE_CONFIG=/path/to/pituitary.toml \
+  scripts/bench-precision-344.sh
+```
+
+Outputs three JSON reports under `/tmp/pituitary-bench-344/` and a consolidated
+markdown summary at `docs/development/retrieval-precision-344.md`.

--- a/testdata/retrieval-bench/ccd-guide-cases.json
+++ b/testdata/retrieval-bench/ccd-guide-cases.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "quickstart_bootstrap",
+    "query": "how do I bootstrap a new CCD session for the first time",
+    "relevant_doc_refs": [
+      "doc://guide/02-quickstart",
+      "doc://reference/bootstrap-prompt"
+    ]
+  },
+  {
+    "id": "handoff_semantics",
+    "query": "what goes into a handoff and how does it get surfaced to the next session",
+    "relevant_doc_refs": [
+      "doc://guide/05-memory-architecture",
+      "doc://reference/cheatsheet"
+    ]
+  },
+  {
+    "id": "execution_gate_lifecycle",
+    "query": "when does an execution gate fire and how is it cleared",
+    "relevant_doc_refs": [
+      "doc://guide/07-guardrails",
+      "doc://guide/08-patterns"
+    ]
+  },
+  {
+    "id": "memory_promotion_flow",
+    "query": "how memories get promoted from session to profile scope",
+    "relevant_doc_refs": [
+      "doc://guide/05-memory-architecture"
+    ]
+  },
+  {
+    "id": "guardrails_why",
+    "query": "why do I need guardrails around autonomous agents",
+    "relevant_doc_refs": [
+      "doc://guide/07-guardrails",
+      "doc://guide/01-why"
+    ]
+  }
+]

--- a/testdata/retrieval-bench/chunking-overlays/p338.toml
+++ b/testdata/retrieval-bench/chunking-overlays/p338.toml
@@ -1,0 +1,9 @@
+# #338 plumbing default: router active, both kinds explicitly on
+# MarkdownPolicy. Exercises the KindRouterPolicy seam without changing
+# chunk shapes vs pre-#338.
+
+[runtime.chunking.spec]
+policy = "markdown"
+
+[runtime.chunking.doc]
+policy = "markdown"

--- a/testdata/retrieval-bench/chunking-overlays/p344.toml
+++ b/testdata/retrieval-bench/chunking-overlays/p344.toml
@@ -1,0 +1,12 @@
+# #344 proposed default: specs keep the tighter MarkdownPolicy; docs
+# switch to LateChunkPolicy with tuned parent/child tokens so long-form
+# docs get a parent+leaf hierarchy feeding ExpandContext.
+
+[runtime.chunking.spec]
+policy = "markdown"
+
+[runtime.chunking.doc]
+policy = "late_chunk"
+max_tokens = 2048
+child_max_tokens = 384
+child_overlap_tokens = 48

--- a/testdata/retrieval-bench/chunking-overlays/pre338.toml
+++ b/testdata/retrieval-bench/chunking-overlays/pre338.toml
@@ -1,0 +1,3 @@
+# pre-#338 baseline: no router, no chunking config at all.
+# `chunk.Resolve` returns a nil policy, so stroma applies its default
+# MarkdownPolicy to every kind — byte-identical to the pre-router pipeline.


### PR DESCRIPTION
## Summary

- Flip zero-config doc default to `LateChunkPolicy` (tuned 2048/384/48); specs stay on `MarkdownPolicy`; explicit `[runtime.chunking.doc] policy = "markdown"` opts back.
- Add `resolver_defaults_version` to the chunking fingerprint so default flips force rebuild, and reject pre-fingerprint snapshots once defaults advance past v1 (blocks the legacy-snapshot mixed-generation path Codex flagged).
- Validate doc parent chain after rebuild/update under LateChunkPolicy: same-record linkage + one-level-deep (schema-trigger only covers the first).
- Refresh `result.ChunkCount` from `Snapshot.Stats()` after rebuild/update so operators see real chunk growth instead of the Markdown-based undercount.
- Add a `precision_bench`-tagged retrieval-precision harness (`internal/index/retrieval_precision_bench_test.go`), three chunking overlays, a 5-case seed, and `scripts/bench-precision-344.sh` that renders a three-config delta markdown.

## Not yet in this PR (tracked for follow-up on the same branch or issue)

- Precision@k numbers themselves — require live m2-router + a 15–20-case curated set. Seed cases are explicitly marked as seed.
- `ExpandContext(IncludeParent)` retrieval wiring — AC defers this to a separate issue.

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean, including `-tags=precision_bench ./internal/index/`
- [x] `make fmt` clean
- [x] New regression tests:
  - `TestChunkingConfigFingerprintIncludesResolverDefaultsVersion`
  - `TestChunkingConfigFingerprintDifferentiatesResolverDefaults`
  - `TestValidateStoredChunkingConfigRejectsLegacyMissingFingerprint`
  - `TestRebuildChunkCountReflectsLateChunkLeaves`
  - `TestDocLateChunkActive`
  - `TestValidateDocParentChainContextRejectsMultiLevelChain`
  - `TestResolve_ZeroConfigDefaultsDocsToLateChunk`
  - `TestResolve_ExplicitMarkdownDocOverridesDefault`
  - `TestResolve_SpecOnlyPinsSpecAndKeepsDocDefault`
- [ ] Publish precision@k numbers before closing #344

Closes #344 once numbers are published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)