### PR TITLE
Publish #344 precision@k benchmark with null-result framing

### DIFF
--- a/docs/development/retrieval-precision-344.md
+++ b/docs/development/retrieval-precision-344.md
@@ -35,7 +35,7 @@ The issue body anticipated this: "`ExpandContext` wiring is explicitly called ou
 
 ## Variants
 
-The script appends one of three overlays from [`testdata/retrieval-bench/chunking-overlays/`](../../testdata/retrieval-bench/chunking-overlays/) to the base config:
+The script appends one of three overlays from `testdata/retrieval-bench/chunking-overlays/` to the base config:
 
 - **pre338** — no `[runtime.chunking]` block. `chunk.Resolve` returns `nil`, stroma falls back to its default `MarkdownPolicy` for every kind. Byte-identical to the pre-router pipeline.
 - **p338** — `KindRouterPolicy` active, both `spec` and `doc` kinds explicitly on `MarkdownPolicy`. Exercises the router seam without changing chunk shapes.

--- a/docs/development/retrieval-precision-344.md
+++ b/docs/development/retrieval-precision-344.md
@@ -1,0 +1,78 @@
+# Retrieval precision benchmark — #344
+
+Measured precision@k / recall@10 / MRR for the doc arm of the retrieval index across three chunking configurations, gating the #344 default flip from `MarkdownPolicy` to `LateChunkPolicy` for doc records.
+
+- **Run date:** 2026-04-19
+- **Pituitary CLI:** built from `7502146` (post-#344 merge)
+- **Cases:** [`testdata/retrieval-bench/ccd-guide-cases.json`](../../testdata/retrieval-bench/ccd-guide-cases.json) — 20 hand-curated queries with labeled relevant doc refs
+- **Corpus:** `~/devel/ccd-guide` pinned at `8854090` (12 indexed docs across `docs/guide/`, `docs/reference/`, `docs/operations/`, `docs/archive/`)
+- **Embedder:** mlx-router @ `http://100.92.91.40:1234/v1`, model `nomic-embed-text-v1.5` (768-dim)
+- **Runner:** [`scripts/bench-precision-344.sh`](../../scripts/bench-precision-344.sh) (rebuilds the snapshot once per variant, then runs the `precision_bench`-tagged test)
+
+## Headline
+
+| variant | p@5   | p@10  | recall@10 | MRR   |
+|---------|-------|-------|-----------|-------|
+| pre338  | 0.220 | 0.110 | 0.950     | 0.864 |
+| p338    | 0.220 | 0.110 | 0.950     | 0.862 |
+| p344    | 0.220 | 0.110 | 0.950     | 0.864 |
+
+| variant | Δp@5   | Δp@10  | Δrecall@10 | ΔMRR    |
+|---------|--------|--------|------------|---------|
+| pre338  | +0.000 | +0.000 | +0.000     | +0.000  |
+| p338    | +0.000 | +0.000 | +0.000     | -0.002  |
+| p344    | +0.000 | +0.000 | +0.000     | +0.000  |
+
+**Result: null precision delta on this corpus + this benchmark shape.** The two missed cases (`handoff_semantics`, `session_loop_phases`) are identical across all three variants — each is a multi-doc query where `reference/cheatsheet` legitimately belongs in the relevance set but does not surface in top-10 regardless of chunking policy.
+
+## What this benchmark can and cannot measure
+
+This benchmark measures top-10 **doc-level** retrieval: `evaluatePrecisionCase` collapses retrieved hits to unique doc refs in rank order before computing precision/recall/MRR. Whether `LateChunkPolicy` produces one chunk or five leaf chunks per doc, only the *first* hit per doc counts.
+
+The product value `LateChunkPolicy` is supposed to deliver — per the #344 issue body — is the `parent_chunk_id` lineage feeding `ExpandContext(IncludeParent)`: when a leaf chunk is the top hit, the agent gets the surrounding parent context too. **That benefit is downstream of this metric and structurally invisible to it.** The null delta here is therefore *not* evidence the default flip is inert; it is evidence that top-10 doc-level precision on this corpus is insensitive to chunk granularity, which is a different claim.
+
+The issue body anticipated this: "`ExpandContext` wiring is explicitly called out as the next lever (tracked separately)." Validating the `LateChunkPolicy → ExpandContext` product benefit requires a separate, structurally different benchmark (see "Next-iteration shape" below).
+
+## Variants
+
+The script appends one of three overlays from [`testdata/retrieval-bench/chunking-overlays/`](../../testdata/retrieval-bench/chunking-overlays/) to the base config:
+
+- **pre338** — no `[runtime.chunking]` block. `chunk.Resolve` returns `nil`, stroma falls back to its default `MarkdownPolicy` for every kind. Byte-identical to the pre-router pipeline.
+- **p338** — `KindRouterPolicy` active, both `spec` and `doc` kinds explicitly on `MarkdownPolicy`. Exercises the router seam without changing chunk shapes.
+- **p344** — `spec` on `MarkdownPolicy`; `doc` on `LateChunkPolicy` with `max_tokens = 2048`, `child_max_tokens = 384`, `child_overlap_tokens = 48`. The defaults flipped in #344.
+
+Each variant rebuilds a separate snapshot so chunk lineage never bleeds across runs.
+
+## Why the delta is null on *this* benchmark
+
+Three compounding reasons, in order of weight:
+
+1. **Doc-level scoring elides chunk granularity** (see "What this benchmark can and cannot measure" above).
+2. **Corpus is too small to stress retrieval.** 12 indexed docs vs 20 cases means the right doc is almost always findable by any embedding model on any chunking — the retrieval problem is below the difficulty floor where chunking strategy matters.
+3. **Queries align with doc TL;DRs.** The cases were curated against headings and TL;DR blocks that already match well under `MarkdownPolicy`. A harder set — questions whose answer lives in mid-doc body text far from any heading — would be a better stress test.
+
+## Reproducing
+
+```
+cp testdata/retrieval-bench/base-config.example.toml /tmp/pituitary-bench-base.toml
+# edit [workspace].root to your corpus, [runtime.embedder].endpoint to a reachable embedder
+BENCH_BASE_CONFIG=/tmp/pituitary-bench-base.toml \
+  scripts/bench-precision-344.sh
+```
+
+To reproduce the specific numbers in this report, the corpus must be `~/devel/ccd-guide` checked out at `8854090`, and the embedder must be an OpenAI-compatible endpoint serving `nomic-embed-text-v1.5`.
+
+Per-variant JSON reports land in `/tmp/pituitary-bench-344/` (override with `BENCH_OUT_DIR`).
+
+## Next-iteration shape
+
+If/when we want to *demonstrate* a `LateChunkPolicy` win in numbers (rather than cite the ExpandContext story qualitatively), four changes are needed. None gate #344; they're material for the next chunking/retrieval benchmark issue:
+
+1. **Larger corpus** — index a real-world docs surface (Pituitary's own `docs/`, plus a sibling repo's docs) so retrieval has to discriminate among 50+ docs.
+2. **Chunk-level metric** — score on whether the returned chunk is the *answering* chunk, not just whether the right doc appears anywhere in top-10. Requires per-chunk-id labels.
+3. **Mid-body queries** — curate questions whose answer is in body text far from any heading, where chunk boundaries actually shift which fragment ranks first.
+4. **ExpandContext-on metric** — measure whether parent-chunk inclusion improves answer quality on a small set of LLM-graded RAG queries.
+
+## Relationship to issue acceptance
+
+The #344 acceptance criterion reads "Precision@k benchmark published with before/after numbers on a representative corpus." This report satisfies that literal requirement: numbers are published, the corpus and methodology are documented, and the repro is portable. It does *not* on its own validate that the `LateChunkPolicy` default flip improves retrieval quality — that validation requires the next-iteration benchmark shape above, tracked separately.

--- a/testdata/retrieval-bench/README.md
+++ b/testdata/retrieval-bench/README.md
@@ -6,21 +6,26 @@ gates #344 (default docs to `LateChunkPolicy`).
 ## Files
 
 - `ccd-guide-cases.json` — hand-curated query → relevant doc refs.
-- `chunking-overlays/*.toml` — three chunking config overlays appended to a
-  base pituitary config by `scripts/bench-precision-344.sh`:
+- `base-config.example.toml` — portable template for the base pituitary config
+  the runner consumes. Copy, edit `[workspace].root` and `[runtime.embedder].endpoint`
+  for your environment.
+- `chunking-overlays/*.toml` — three chunking config overlays appended to the
+  base config by `scripts/bench-precision-344.sh`:
   - `pre338.toml` — empty; pre-#338 baseline (no router, stroma `MarkdownPolicy` default).
   - `p338.toml` — router active, both kinds on `MarkdownPolicy`.
   - `p344.toml` — spec `MarkdownPolicy` + doc `LateChunkPolicy` with tuned P/C tokens.
 
 ## Running
 
-Requires a reachable embedder (default config assumes the m2-router nomic-embed
-at `http://100.92.91.40:1234/v1`).
+Requires a reachable OpenAI-compatible embedder.
 
 ```
-BENCH_BASE_CONFIG=/path/to/pituitary.toml \
+cp testdata/retrieval-bench/base-config.example.toml /tmp/pituitary-bench-base.toml
+# edit [workspace].root, [workspace].index_path, [runtime.embedder].endpoint
+BENCH_BASE_CONFIG=/tmp/pituitary-bench-base.toml \
   scripts/bench-precision-344.sh
 ```
 
-Outputs three JSON reports under `/tmp/pituitary-bench-344/` and a consolidated
-markdown summary at `docs/development/retrieval-precision-344.md`.
+Outputs three JSON reports under `/tmp/pituitary-bench-344/` (override with
+`BENCH_OUT_DIR`) and a consolidated markdown summary at
+`docs/development/retrieval-precision-344.md` (override with `BENCH_REPORT_MD`).

--- a/testdata/retrieval-bench/base-config.example.toml
+++ b/testdata/retrieval-bench/base-config.example.toml
@@ -1,0 +1,93 @@
+# Example base config consumed by scripts/bench-precision-344.sh.
+#
+# Copy to a writable path, then update:
+#   - [workspace].root → absolute path of the corpus you want to bench
+#   - [workspace].index_path → absolute path for variant snapshots
+#   - [runtime.embedder].endpoint → reachable OpenAI-compatible /v1 base URL
+#   - [[sources]] entries → match the corpus layout
+#
+# The script appends one of three chunking overlays from
+# testdata/retrieval-bench/chunking-overlays/, so this file MUST NOT
+# include a [runtime.chunking] block.
+#
+# The published 2026-04-19 run used:
+#   - corpus: ~/devel/ccd-guide @ 8854090 (`docs(rfc): correct RFC 0006 §6 ...`)
+#   - embedder: mlx-router @ http://100.92.91.40:1234/v1, model nomic-embed-text-v1.5
+
+[workspace]
+root = "/absolute/path/to/your/corpus"
+index_path = "/tmp/pituitary-bench-344/corpus.db"
+
+[runtime.embedder]
+provider = "openai_compatible"
+endpoint = "http://localhost:1234/v1"
+model = "nomic-embed-text-v1.5"
+timeout_ms = 30000
+max_retries = 1
+
+# Below: the source list used for the published ccd-guide run. Replace
+# with sources matching your own corpus layout.
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+files = [
+  "autonomous-escalation-and-approval-policy/spec.toml",
+  "autonomous-memory-governance/spec.toml",
+  "autonomous-session-lifecycle/spec.toml",
+  "backlog-extension/spec.toml",
+  "continuity-history-and-focus-recommendation/spec.toml",
+  "concurrent-state-and-ownership/spec.toml",
+  "execution-gates/spec.toml",
+  "machine-runtime-api/spec.toml",
+  "mid-session-context-refresh/spec.toml",
+  "memory-compaction-replay/spec.toml",
+  "memory-entry-format/spec.toml",
+  "memory-ingest-sync-provider-contract/spec.toml",
+  "memory-recall-provider-contract/spec.toml",
+  "memory-promotion/spec.toml",
+  "optimization-reintroduction/spec.toml",
+  "pod-identity-and-cross-machine-coordination/spec.toml",
+  "pod-identity-model/spec.toml",
+  "projection-compiler-cache/spec.toml",
+  "reference-adapter-hermes/spec.toml",
+  "reference-adapter-openclaw/spec.toml",
+  "repo-identity-linking/spec.toml",
+  "runtime-state-contract/spec.toml",
+  "session-intent-signals/spec.toml",
+  "session-workflow/spec.toml",
+  "skill-sync-distribution/spec.toml",
+  "state-model-core/spec.toml",
+  "substrate-abstraction/spec.toml",
+]
+
+[[sources]]
+name = "contracts"
+adapter = "filesystem"
+kind = "markdown_contract"
+path = "."
+files = [
+  "KERNEL_CONTRACT.md",
+]
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+files = [
+  "archive/specs/cli/2026-03-08-ccd-guide-compliance-audit.md",
+  "guide/01-why.md",
+  "guide/02-quickstart.md",
+  "guide/03-adoption-ladder.md",
+  "guide/04-process.md",
+  "guide/05-memory-architecture.md",
+  "guide/06-infrastructure.md",
+  "guide/07-guardrails.md",
+  "guide/08-patterns.md",
+  "operations/README.md",
+  "reference/bootstrap-prompt.md",
+  "reference/cheatsheet.md",
+]

--- a/testdata/retrieval-bench/ccd-guide-cases.json
+++ b/testdata/retrieval-bench/ccd-guide-cases.json
@@ -34,8 +34,113 @@
     "id": "guardrails_why",
     "query": "why do I need guardrails around autonomous agents",
     "relevant_doc_refs": [
-      "doc://guide/07-guardrails",
+      "doc://guide/07-guardrails"
+    ]
+  },
+  {
+    "id": "why_problem_statement",
+    "query": "what problem does CCD solve and why do AI sessions lose context between runs",
+    "relevant_doc_refs": [
       "doc://guide/01-why"
+    ]
+  },
+  {
+    "id": "adoption_ladder_levels",
+    "query": "what are the CCD adoption levels and when should I move from level 1 to level 2",
+    "relevant_doc_refs": [
+      "doc://guide/03-adoption-ladder"
+    ]
+  },
+  {
+    "id": "machine_team_lead_role",
+    "query": "what does becoming a machine team lead mean for the developer's role",
+    "relevant_doc_refs": [
+      "doc://guide/03-adoption-ladder"
+    ]
+  },
+  {
+    "id": "session_state_boundaries",
+    "query": "what is the difference between project truth, operator state, and workspace state",
+    "relevant_doc_refs": [
+      "doc://guide/04-process"
+    ]
+  },
+  {
+    "id": "session_loop_phases",
+    "query": "what are the explicit phases of a CCD session loop",
+    "relevant_doc_refs": [
+      "doc://guide/04-process",
+      "doc://reference/cheatsheet"
+    ]
+  },
+  {
+    "id": "memory_scope_layout",
+    "query": "where on disk does CCD store profile, repo, branch, and workspace memory files",
+    "relevant_doc_refs": [
+      "doc://guide/05-memory-architecture"
+    ]
+  },
+  {
+    "id": "infrastructure_level2_signals",
+    "query": "when should I add deterministic source ordering and stronger review loops",
+    "relevant_doc_refs": [
+      "doc://guide/06-infrastructure"
+    ]
+  },
+  {
+    "id": "ai_doc_sync_runtimes",
+    "query": "how do I keep CLAUDE.md, GEMINI.md, and AGENTS.md aligned across runtimes",
+    "relevant_doc_refs": [
+      "doc://guide/06-infrastructure"
+    ]
+  },
+  {
+    "id": "fail_closed_principle",
+    "query": "why does CCD fail closed when a gate is missing or ambiguous",
+    "relevant_doc_refs": [
+      "doc://guide/07-guardrails"
+    ]
+  },
+  {
+    "id": "deterministic_vs_prompt",
+    "query": "why prefer hard-coded validators over prompt-based instructions for guardrails",
+    "relevant_doc_refs": [
+      "doc://guide/07-guardrails"
+    ]
+  },
+  {
+    "id": "session_patterns_recipes",
+    "query": "operational recipes for starting, executing, and closing a session cleanly",
+    "relevant_doc_refs": [
+      "doc://guide/08-patterns"
+    ]
+  },
+  {
+    "id": "doc_accuracy_patterns",
+    "query": "patterns for keeping documentation accurate as the system evolves",
+    "relevant_doc_refs": [
+      "doc://guide/08-patterns"
+    ]
+  },
+  {
+    "id": "compliance_audit_changes",
+    "query": "what state model alignment changes did the 2026-03 audit require in the guide",
+    "relevant_doc_refs": [
+      "doc://archive/specs/cli/2026-03-08-ccd-guide-compliance-audit"
+    ]
+  },
+  {
+    "id": "cheatsheet_daily",
+    "query": "where is the daily quick reference for the CCD kernel loop",
+    "relevant_doc_refs": [
+      "doc://reference/cheatsheet"
+    ]
+  },
+  {
+    "id": "bootstrap_without_skill_md",
+    "query": "how do I bootstrap CCD in a tool without SKILL.md support",
+    "relevant_doc_refs": [
+      "doc://reference/bootstrap-prompt"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

- Closes the publication side of #344's acceptance criterion: ships the precision@k benchmark report alongside the curated cases file and a portable repro template.
- Headline numbers (run 2026-04-19, ccd-guide @ `8854090`, mlx-router `nomic-embed-text-v1.5`):

  | variant | p@5 | p@10 | recall@10 | MRR |
  |---|---|---|---|---|
  | pre338 | 0.220 | 0.110 | 0.950 | 0.864 |
  | p338 | 0.220 | 0.110 | 0.950 | 0.862 |
  | p344 | 0.220 | 0.110 | 0.950 | 0.864 |

- **Null delta across all three variants.** The report explicitly carves the literal AC ("publish numbers") from product-benefit validation: this metric scores top-10 doc-level retrieval, which structurally cannot see the `parent_chunk_id` / `ExpandContext` lineage that is the actual `LateChunkPolicy` lever — and the issue body already tracks `ExpandContext` as a separate next lever. The report frames the null honestly rather than leaning on it to imply the default flip is inert.

## What's in the diff

- `testdata/retrieval-bench/ccd-guide-cases.json` — expanded 5 → 20 hand-curated queries covering all 11 indexed ccd-guide doc surfaces.
- `testdata/retrieval-bench/base-config.example.toml` — portable copy-and-edit base config so anyone can repro without writing one from scratch.
- `testdata/retrieval-bench/README.md` — updated invocation and override docs.
- `docs/development/retrieval-precision-344.md` — published report with headline, deltas, methodology, can/cannot-measure framing, repro instructions, and next-iteration shape.

## Codex adversarial-review findings (pre-commit, all addressed)

- **High: closure overclaim** — first draft treated "numbers published" as equivalent to "default flip validated." Reframed to make the literal-AC-met / product-benefit-not-validated split explicit.
- **Medium: reproducibility was host-local** — first draft cited `/tmp/pituitary-bench-344-base.toml` and `~/devel/ccd-guide` directly. Added `base-config.example.toml`, pinned ccd-guide commit `8854090` in the report, and updated the README with a portable invocation.
- **Medium: over-broad multi-doc labels** — `guardrails_why` and `machine_team_lead_role` had `doc://guide/01-why` as a secondary relevant doc, but neither query's actual answer lives there. Tightened both to single-doc labels and re-ran scoring on the existing snapshots. Recall@10 climbed 0.900 → 0.950 across all variants; null delta still holds.

## Test plan

- [x] `go build ./...` clean
- [x] `scripts/bench-precision-344.sh` runs end-to-end against ccd-guide + mlx-router with the new cases file
- [x] All three variants produce identical p@5 / p@10 / recall@10 (null-delta confirmed deterministic across reruns)
- [ ] Reviewer can repro by copying `testdata/retrieval-bench/base-config.example.toml`, editing `[workspace].root` and `[runtime.embedder].endpoint`, and running `BENCH_BASE_CONFIG=... scripts/bench-precision-344.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)