### PR TITLE
Wire cfg.MaxRetries through embedder via stroma v2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.9
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/dusk-network/stroma/v2 v2.1.0
+	github.com/dusk-network/stroma/v2 v2.2.0
 	github.com/google/go-github/v79 v79.0.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dusk-network/stroma/v2 v2.1.0 h1:7aaFy9SdvSimU9VqV+qoQBJp15jEmyUaX6iEdok6Tw8=
-github.com/dusk-network/stroma/v2 v2.1.0/go.mod h1:n2Gf3cvgh8QuvJzQD/rkQMzXmq81dxu2hvpApFYLRwg=
+github.com/dusk-network/stroma/v2 v2.2.0 h1:ufPSM+5eFSuPGjR6WHMyFB9wo7mq7noCH9Q7v2sKlkQ=
+github.com/dusk-network/stroma/v2 v2.2.0/go.mod h1:n2Gf3cvgh8QuvJzQD/rkQMzXmq81dxu2hvpApFYLRwg=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/index/openai_embedder.go
+++ b/internal/index/openai_embedder.go
@@ -66,16 +66,16 @@ func newOpenAICompatibleEmbedder(cfg config.RuntimeProvider) (Embedder, error) {
 		timeout = time.Duration(cfg.TimeoutMS) * time.Millisecond
 	}
 
-	// stroma's embed.OpenAI does not yet expose MaxRetries
-	// (dusk-network/stroma#73); until it does, the outer batch loop here
-	// handles the 413/5xx case via adaptive split, and transient-network
-	// retries rely on the caller. This wrapper is retained precisely so
-	// that future knob lands with a one-line wire-through.
+	// Transient-failure retries (429/5xx/transport) are delegated to stroma
+	// via MaxRetries. The outer batch loop here still owns the adaptive
+	// 413/5xx split that halves a rejected batch — a behavior stroma does
+	// not provide at the substrate level.
 	client := stembed.NewOpenAI(stembed.OpenAIConfig{
 		BaseURL:      endpoint,
 		Model:        strings.TrimSpace(cfg.Model),
 		APIToken:     token,
 		Timeout:      timeout,
+		MaxRetries:   cfg.MaxRetries,
 		MaxBatchSize: openAICompatibleEmbeddingBatchSize,
 	})
 


### PR DESCRIPTION
## Summary

- Bump `stroma/v2` to `v2.2.0`, which adds `MaxRetries` to `embed.OpenAIConfig` (dusk-network/stroma#73, merged as dusk-network/stroma#74).
- Pass `config.RuntimeProvider.MaxRetries` through to the stroma embed client so transient-failure retries (429 / 5xx / transport) land on the shared provider substrate — same path stroma chat already uses.
- Update the comment that previously flagged the pending upstream knob.

The outer 8-batch loop still owns the adaptive 413/5xx split. Stroma's embed does not split a rejected sub-batch; splitting stays Pituitary-side.

Restores the pre-#365 retry posture for the OpenAI rate-limit / transient-network path without reintroducing the duplicated HTTP plumbing that #365 deleted.

## Test plan

- [x] `make fmt` clean
- [x] `make vet` clean
- [x] `make test` — full suite green
- [x] `go test -race ./internal/index/` — 12.4s, clean (no regression from the added retry loop)

## Refs

- Follows up #339 / #365
- Closes the "pending upstream" follow-up recorded in the #365 PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)