### PR TITLE
[codex] Extract AST inference behind inferer boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ vet:
 		echo 'internal/ must not import extensions/'; \
 		exit 1; \
 	}
+	@! grep -R --include='*.go' -n '"github.com/dusk-network/pituitary/internal/ast' internal/index/ internal/analysis/ >/dev/null || { \
+		echo 'internal/index and internal/analysis must not import internal/ast; use internal/codeinfer'; \
+		exit 1; \
+	}
 	$(GO) vet ./...
 
 analyze:

--- a/cmd/extensions.go
+++ b/cmd/extensions.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	_ "github.com/dusk-network/pituitary/extensions/astinfer"
 	_ "github.com/dusk-network/pituitary/extensions/github"
 	_ "github.com/dusk-network/pituitary/extensions/json"
 )

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
 )
 
 func TestRunIndexValidatesConfig(t *testing.T) {
@@ -106,6 +107,66 @@ domain_pointer = "/meta/domain"
 	}
 	if _, err := os.Stat(filepath.Join(repo, ".pituitary", "pituitary.db")); err != nil {
 		t.Fatalf("runIndex() did not create database: %v", err)
+	}
+}
+
+func TestRunIndexInfersASTEdgesThroughRegisteredExtension(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteIndexFixture(t, repo, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+infer_applies_to = true
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "rate-limit", "spec.toml"), `id = "SPEC-042"
+title = "Rate Limiting"
+status = "accepted"
+domain = "api"
+authors = ["test"]
+body = "body.md"
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "rate-limit", "body.md"), `## Overview
+
+This spec governs SlidingWindowLimiter.
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "src", "limiter.go"), `package limiter
+
+type SlidingWindowLimiter struct {
+	window int
+}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runIndex([]string{"--rebuild"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runIndex() exit code = %d, want 0 (stderr: %q)", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "inference: enabled (1 inferred edge(s))") {
+		t.Fatalf("runIndex() output %q does not contain inferred edge summary", stdout.String())
+	}
+
+	result, err := index.GovernedByContext(t.Context(), filepath.Join(repo, ".pituitary", "pituitary.db"), "src/limiter.go", "", "")
+	if err != nil {
+		t.Fatalf("GovernedByContext() error = %v", err)
+	}
+	if len(result.Specs) != 1 || result.Specs[0].Ref != "SPEC-042" || result.Specs[0].Source != "inferred" {
+		t.Fatalf("governed-by specs = %+v, want inferred SPEC-042", result.Specs)
 	}
 }
 

--- a/extensions/astinfer/inferer.go
+++ b/extensions/astinfer/inferer.go
@@ -1,0 +1,121 @@
+package astinfer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dusk-network/pituitary/internal/ast"
+	"github.com/dusk-network/pituitary/internal/codeinfer"
+)
+
+const defaultMaxFileSizeBytes = 1 << 20 // 1 MB
+
+func init() {
+	codeinfer.Register(codeinfer.DefaultInfererName, func() codeinfer.AppliesToInferer {
+		return Inferer{}
+	})
+}
+
+// Inferer is the first-party tree-sitter-backed applies_to inferer.
+type Inferer struct{}
+
+func (Inferer) Name() string {
+	return codeinfer.DefaultInfererName
+}
+
+func (Inferer) InferAppliesTo(ctx context.Context, req codeinfer.Request) (*codeinfer.Result, error) {
+	if req.WorkspaceRoot == "" {
+		return &codeinfer.Result{}, nil
+	}
+	if !hasMatchableSpecIdentifiers(req.Specs) {
+		return &codeinfer.Result{}, nil
+	}
+
+	codePaths, err := ast.WalkWorkspace(req.WorkspaceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("walk workspace for AST extraction: %w", err)
+	}
+	if len(codePaths) == 0 {
+		return &codeinfer.Result{}, nil
+	}
+
+	cachedData := previousCacheByHash(req.PreviousCache)
+	maxFileSize := req.Limits.MaxFileSizeBytes
+	if maxFileSize <= 0 {
+		maxFileSize = defaultMaxFileSizeBytes
+	}
+
+	fileSymbols := make(map[string][]codeinfer.Symbol, len(codePaths))
+	cacheEntries := make([]codeinfer.CacheEntry, 0, len(codePaths))
+	for _, relPath := range codePaths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		fullPath := filepath.Join(req.WorkspaceRoot, relPath)
+		info, err := os.Stat(fullPath)
+		if err != nil || info.Size() > maxFileSize {
+			continue
+		}
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			continue
+		}
+
+		hash := ast.ContentHash(content, relPath)
+		if cached, ok := cachedData[hash]; ok {
+			fileSymbols[relPath] = cached.Symbols
+			cacheEntries = append(cacheEntries, codeinfer.CacheEntry{
+				ContentHash: hash,
+				Path:        relPath,
+				Symbols:     cached.Symbols,
+				Rationale:   cached.Rationale,
+			})
+			continue
+		}
+
+		lang := ast.DetectLanguage(relPath)
+		if lang == "" {
+			continue
+		}
+		symbols, err := ast.ExtractSymbols(content, lang)
+		if err != nil {
+			continue
+		}
+		rationale := ast.ExtractRationale(content, symbols, lang)
+		fileSymbols[relPath] = symbols
+		cacheEntries = append(cacheEntries, codeinfer.CacheEntry{
+			ContentHash: hash,
+			Path:        relPath,
+			Symbols:     symbols,
+			Rationale:   rationale,
+		})
+	}
+
+	return &codeinfer.Result{
+		CacheEntries: cacheEntries,
+		Edges:        ast.InferEdges(fileSymbols, req.Specs),
+	}, nil
+}
+
+func hasMatchableSpecIdentifiers(specs []codeinfer.SpecInput) bool {
+	for _, spec := range specs {
+		if len(ast.ScanSpecIdentifiers(spec.BodyText)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func previousCacheByHash(entries []codeinfer.CacheEntry) map[string]codeinfer.CacheEntry {
+	result := make(map[string]codeinfer.CacheEntry, len(entries))
+	for _, entry := range entries {
+		if entry.ContentHash == "" {
+			continue
+		}
+		result[entry.ContentHash] = entry
+	}
+	return result
+}

--- a/extensions/astinfer/inferer_test.go
+++ b/extensions/astinfer/inferer_test.go
@@ -1,0 +1,60 @@
+package astinfer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/codeinfer"
+)
+
+func TestInfererInfersEdgesAndRationale(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	srcPath := filepath.Join(root, "src", "limiter.go")
+	if err := os.MkdirAll(filepath.Dir(srcPath), 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(srcPath, []byte(`package limiter
+
+// WHY: preserve burst behavior while enforcing sustained rate limits.
+type SlidingWindowLimiter struct {
+	window int
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	result, err := (Inferer{}).InferAppliesTo(context.Background(), codeinfer.Request{
+		WorkspaceRoot: root,
+		Specs: []codeinfer.SpecInput{
+			{
+				Ref:      "SPEC-042",
+				BodyText: "This spec governs SlidingWindowLimiter.",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InferAppliesTo() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("InferAppliesTo() result = nil")
+	}
+	if len(result.Edges) != 1 {
+		t.Fatalf("edges = %+v, want one inferred edge", result.Edges)
+	}
+	if result.Edges[0].SpecRef != "SPEC-042" || result.Edges[0].FilePath != "src/limiter.go" {
+		t.Fatalf("edge = %+v, want SPEC-042 -> src/limiter.go", result.Edges[0])
+	}
+	if len(result.CacheEntries) != 1 {
+		t.Fatalf("cache entries = %+v, want one entry", result.CacheEntries)
+	}
+	if len(result.CacheEntries[0].Symbols) == 0 {
+		t.Fatalf("cache symbols = empty, want extracted symbols")
+	}
+	if len(result.CacheEntries[0].Rationale) == 0 {
+		t.Fatalf("cache rationale = empty, want WHY rationale")
+	}
+}

--- a/internal/ast/extract.go
+++ b/internal/ast/extract.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dusk-network/pituitary/internal/codeinfer"
 	"github.com/odvcencio/gotreesitter"
 )
 
@@ -13,21 +14,16 @@ import (
 // goroutine-safe, even through ParserPool.
 var parserMu sync.Mutex
 
-// SymbolKind classifies an extracted code symbol.
-type SymbolKind string
+type SymbolKind = codeinfer.SymbolKind
 
 const (
-	SymbolFunction SymbolKind = "function"
-	SymbolMethod   SymbolKind = "method"
-	SymbolType     SymbolKind = "type"
-	SymbolImport   SymbolKind = "import"
+	SymbolFunction = codeinfer.SymbolFunction
+	SymbolMethod   = codeinfer.SymbolMethod
+	SymbolType     = codeinfer.SymbolType
+	SymbolImport   = codeinfer.SymbolImport
 )
 
-// Symbol is a named code element extracted from a source file via tree-sitter.
-type Symbol struct {
-	Name string     `json:"name"`
-	Kind SymbolKind `json:"kind"`
-}
+type Symbol = codeinfer.Symbol
 
 // queryPatterns maps each language to its tree-sitter query for symbol extraction.
 var queryPatterns = map[LangID]string{

--- a/internal/ast/infer.go
+++ b/internal/ast/infer.go
@@ -4,21 +4,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
+
+	"github.com/dusk-network/pituitary/internal/codeinfer"
 )
 
-// SpecSummary is the minimal spec data needed for inference matching.
-type SpecSummary struct {
-	Ref             string
-	Body            string
-	ManualAppliesTo []string // existing manual applies_to refs (e.g. "code://path")
-}
+type SpecSummary = codeinfer.SpecInput
 
-// InferredEdge is one inferred applies_to link from a spec to a code file.
-type InferredEdge struct {
-	SpecRef   string   `json:"spec_ref"`
-	FilePath  string   `json:"file_path"`
-	MatchedOn []string `json:"matched_on"`
-}
+type InferredEdge = codeinfer.InferredEdge
 
 // FileSymbols pairs a file path with its content hash and extracted symbols.
 type FileSymbols struct {
@@ -52,7 +44,7 @@ func InferEdges(fileSymbols map[string][]Symbol, specs []SpecSummary) []Inferred
 	var edges []InferredEdge
 	for _, spec := range specs {
 		manualSet := manualPathSet(spec.ManualAppliesTo)
-		specIdentifiers := ScanSpecIdentifiers(spec.Body)
+		specIdentifiers := ScanSpecIdentifiers(spec.BodyText)
 
 		// Track matches per file path.
 		fileMatches := make(map[string][]string)

--- a/internal/ast/infer_test.go
+++ b/internal/ast/infer_test.go
@@ -20,12 +20,12 @@ func TestInferEdges(t *testing.T) {
 	specs := []SpecSummary{
 		{
 			Ref:             "SPEC-042",
-			Body:            "This spec governs the SlidingWindowLimiter. Use NewSlidingWindowLimiter to create instances.",
+			BodyText:        "This spec governs the SlidingWindowLimiter. Use NewSlidingWindowLimiter to create instances.",
 			ManualAppliesTo: []string{"code://src/api/middleware/ratelimiter.go"},
 		},
 		{
-			Ref:  "SPEC-099",
-			Body: "The ConfigStore handles all runtime configuration loading.",
+			Ref:      "SPEC-099",
+			BodyText: "The ConfigStore handles all runtime configuration loading.",
 		},
 	}
 
@@ -56,7 +56,7 @@ func TestInferEdgesSkipsShortSymbols(t *testing.T) {
 		},
 	}
 	specs := []SpecSummary{
-		{Ref: "SPEC-001", Body: "Run the main loop."},
+		{Ref: "SPEC-001", BodyText: "Run the main loop."},
 	}
 
 	edges := InferEdges(fileSymbols, specs)
@@ -75,8 +75,8 @@ func TestInferEdgesMultipleSpecsSameFile(t *testing.T) {
 		},
 	}
 	specs := []SpecSummary{
-		{Ref: "SPEC-A", Body: "The AuthHandler validates tokens."},
-		{Ref: "SPEC-B", Body: "The TokenValidator checks expiry."},
+		{Ref: "SPEC-A", BodyText: "The AuthHandler validates tokens."},
+		{Ref: "SPEC-B", BodyText: "The TokenValidator checks expiry."},
 	}
 
 	edges := InferEdges(fileSymbols, specs)

--- a/internal/ast/rationale.go
+++ b/internal/ast/rationale.go
@@ -4,29 +4,23 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/dusk-network/pituitary/internal/codeinfer"
 )
 
-// RationaleKind classifies the type of rationale comment.
-type RationaleKind string
+type RationaleKind = codeinfer.RationaleKind
 
 const (
-	RationaleWhy       RationaleKind = "why"
-	RationaleRationale RationaleKind = "rationale"
-	RationaleNote      RationaleKind = "note"
-	RationaleHack      RationaleKind = "hack"
-	RationaleFixme     RationaleKind = "fixme"
-	RationaleTodo      RationaleKind = "todo"
-	RationaleDecision  RationaleKind = "decision"
+	RationaleWhy       = codeinfer.RationaleWhy
+	RationaleRationale = codeinfer.RationaleRationale
+	RationaleNote      = codeinfer.RationaleNote
+	RationaleHack      = codeinfer.RationaleHack
+	RationaleFixme     = codeinfer.RationaleFixme
+	RationaleTodo      = codeinfer.RationaleTodo
+	RationaleDecision  = codeinfer.RationaleDecision
 )
 
-// Rationale is a structured comment extracted from a source file that
-// documents a deliberate decision or known deviation.
-type Rationale struct {
-	Kind          RationaleKind `json:"kind"`
-	Text          string        `json:"text"`
-	Line          int           `json:"line"`
-	NearestSymbol string        `json:"nearest_symbol,omitempty"`
-}
+type Rationale = codeinfer.Rationale
 
 // tagPatterns match explicit rationale tags at the start of a comment.
 var tagPatterns = []struct {

--- a/internal/codeinfer/codeinfer.go
+++ b/internal/codeinfer/codeinfer.go
@@ -1,0 +1,185 @@
+package codeinfer
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const DefaultInfererName = "ast"
+
+// SymbolKind classifies an extracted code symbol.
+type SymbolKind string
+
+const (
+	SymbolFunction SymbolKind = "function"
+	SymbolMethod   SymbolKind = "method"
+	SymbolType     SymbolKind = "type"
+	SymbolImport   SymbolKind = "import"
+)
+
+// Symbol is a named code element extracted from a source file.
+type Symbol struct {
+	Name string     `json:"name"`
+	Kind SymbolKind `json:"kind"`
+}
+
+// RationaleKind classifies the type of rationale comment.
+type RationaleKind string
+
+const (
+	RationaleWhy       RationaleKind = "why"
+	RationaleRationale RationaleKind = "rationale"
+	RationaleNote      RationaleKind = "note"
+	RationaleHack      RationaleKind = "hack"
+	RationaleFixme     RationaleKind = "fixme"
+	RationaleTodo      RationaleKind = "todo"
+	RationaleDecision  RationaleKind = "decision"
+)
+
+// Rationale is a structured comment extracted from a source file that
+// documents a deliberate decision or known deviation.
+type Rationale struct {
+	Kind          RationaleKind `json:"kind"`
+	Text          string        `json:"text"`
+	Line          int           `json:"line"`
+	NearestSymbol string        `json:"nearest_symbol,omitempty"`
+}
+
+// SpecInput is the minimal spec data needed by an applies_to inferer.
+type SpecInput struct {
+	Ref             string
+	BodyText        string
+	ManualAppliesTo []string
+}
+
+// CacheEntry is one code-scan cache row exchanged between the kernel and an
+// applies_to inferer.
+type CacheEntry struct {
+	ContentHash string
+	Path        string
+	Symbols     []Symbol
+	Rationale   []Rationale
+}
+
+// InferredEdge is one inferred applies_to link from a spec to a code file.
+type InferredEdge struct {
+	SpecRef   string   `json:"spec_ref"`
+	FilePath  string   `json:"file_path"`
+	MatchedOn []string `json:"matched_on"`
+}
+
+// Limits bounds inference work. Zero values ask the inferer to use its own
+// conservative defaults.
+type Limits struct {
+	MaxFileSizeBytes int64
+}
+
+// Request is the kernel-owned input contract for applies_to inference.
+type Request struct {
+	WorkspaceRoot string
+	Specs         []SpecInput
+	PreviousCache []CacheEntry
+	Limits        Limits
+}
+
+// Result is the structured output returned by an applies_to inferer. The
+// kernel owns all persistence of these values.
+type Result struct {
+	CacheEntries []CacheEntry
+	Edges        []InferredEdge
+}
+
+// AppliesToInferer generates inferred applies_to edges and refreshed code-scan
+// cache entries.
+type AppliesToInferer interface {
+	Name() string
+	InferAppliesTo(ctx context.Context, req Request) (*Result, error)
+}
+
+// Factory creates an applies_to inferer.
+type Factory func() AppliesToInferer
+
+var (
+	mu       sync.RWMutex
+	inferers = map[string]Factory{}
+)
+
+// Register registers an applies_to inferer factory. It is safe to call from
+// init.
+func Register(name string, factory Factory) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		panic("codeinfer: empty inferer name")
+	}
+	if factory == nil {
+		panic(fmt.Sprintf("codeinfer: nil factory for %q", name))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if _, exists := inferers[name]; exists {
+		panic(fmt.Sprintf("codeinfer: inferer %q already registered", name))
+	}
+	inferers[name] = factory
+}
+
+// Lookup returns a new inferer instance by name.
+func Lookup(name string) (AppliesToInferer, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, false
+	}
+
+	mu.RLock()
+	factory, ok := inferers[name]
+	mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return factory(), true
+}
+
+// RegisteredNames returns registered inferer names in stable order.
+func RegisteredNames() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	names := make([]string, 0, len(inferers))
+	for name := range inferers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ReplaceForTest swaps one registry entry and returns a restore function. It is
+// intended for kernel tests that need to exercise inference without importing a
+// concrete extension package.
+func ReplaceForTest(name string, factory Factory) func() {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		panic("codeinfer: empty test inferer name")
+	}
+
+	mu.Lock()
+	previous, hadPrevious := inferers[name]
+	if factory == nil {
+		delete(inferers, name)
+	} else {
+		inferers[name] = factory
+	}
+	mu.Unlock()
+
+	return func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if hadPrevious {
+			inferers[name] = previous
+			return
+		}
+		delete(inferers, name)
+	}
+}

--- a/internal/index/freshness_test.go
+++ b/internal/index/freshness_test.go
@@ -266,7 +266,7 @@ func TestInspectFreshnessReturnsSourceMismatchBeforeReloadingWorkspaceContent(t 
 }
 
 func TestInspectFreshnessReportsIncompatibleWhenInferAppliesToFlips(t *testing.T) {
-	t.Parallel()
+	installCodeInfererForTest(t, noopInferer{})
 
 	cases := []struct {
 		name       string
@@ -279,8 +279,6 @@ func TestInspectFreshnessReportsIncompatibleWhenInferAppliesToFlips(t *testing.T
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			dir := t.TempDir()
 			indexPath := filepath.Join(dir, ".pituitary", "pituitary.db")
 			configPath := filepath.Join(dir, "pituitary.toml")

--- a/internal/index/rationale.go
+++ b/internal/index/rationale.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dusk-network/pituitary/internal/ast"
+	"github.com/dusk-network/pituitary/internal/codeinfer"
 )
 
 // FileRationale holds rationale entries for one code file.
 type FileRationale struct {
-	Path      string          `json:"path"`
-	Rationale []ast.Rationale `json:"rationale"`
+	Path      string                `json:"path"`
+	Rationale []codeinfer.Rationale `json:"rationale"`
 }
 
 // QueryRationaleContext returns rationale entries for the given file paths
@@ -59,7 +59,7 @@ func QueryRationaleContext(ctx context.Context, dbPath string, paths []string) (
 		if err := rows.Scan(&path, &rationaleJSON); err != nil {
 			return nil, fmt.Errorf("scan rationale: %w", err)
 		}
-		var rationale []ast.Rationale
+		var rationale []codeinfer.Rationale
 		if err := json.Unmarshal([]byte(rationaleJSON), &rationale); err != nil {
 			return nil, fmt.Errorf("decode rationale_json for path %q: %w", path, err)
 		}
@@ -71,8 +71,8 @@ func QueryRationaleContext(ctx context.Context, dbPath string, paths []string) (
 }
 
 // queryRationaleDBContext queries rationale from an already-open database connection.
-func queryRationaleDBContext(ctx context.Context, db *sql.DB, paths []string) (map[string][]ast.Rationale, error) {
-	result := make(map[string][]ast.Rationale)
+func queryRationaleDBContext(ctx context.Context, db *sql.DB, paths []string) (map[string][]codeinfer.Rationale, error) {
+	result := make(map[string][]codeinfer.Rationale)
 	if len(paths) == 0 {
 		return result, nil
 	}
@@ -106,7 +106,7 @@ func queryRationaleDBContext(ctx context.Context, db *sql.DB, paths []string) (m
 		if err := rows.Scan(&path, &rationaleJSON); err != nil {
 			continue
 		}
-		var rationale []ast.Rationale
+		var rationale []codeinfer.Rationale
 		if err := json.Unmarshal([]byte(rationaleJSON), &rationale); err != nil {
 			continue
 		}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dusk-network/pituitary/internal/ast"
 	pchunk "github.com/dusk-network/pituitary/internal/chunk"
+	"github.com/dusk-network/pituitary/internal/codeinfer"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
@@ -978,9 +978,9 @@ func chunkingConfigFingerprint(cfg config.ChunkingConfig) string {
 	return fingerprint(parts)
 }
 
-// inferASTEdgesContext walks the workspace for code files, extracts symbols via
-// tree-sitter, matches them against spec body text, and inserts inferred
-// applies_to edges into the staging database.
+// inferASTEdgesContext asks the registered code inferer for inferred
+// applies_to edges and refreshed code-scan cache entries, then persists them
+// through the kernel-owned index transaction.
 func inferASTEdgesContext(ctx context.Context, tx *sql.Tx, edgeStmt *sql.Stmt, cfg *config.Config, specs []model.SpecRecord, validFrom *string) (int, error) {
 	if !cfg.Workspace.InferAppliesTo {
 		return 0, nil
@@ -989,96 +989,64 @@ func inferASTEdgesContext(ctx context.Context, tx *sql.Tx, edgeStmt *sql.Stmt, c
 	if workspaceRoot == "" {
 		return 0, nil
 	}
+	inferer, ok := codeinfer.Lookup(codeinfer.DefaultInfererName)
+	if !ok {
+		return 0, fmt.Errorf("infer_applies_to is enabled but code inferer %q is not registered", codeinfer.DefaultInfererName)
+	}
 
-	// Quick check: if no spec body contains matchable identifiers, skip the
-	// expensive filesystem walk and tree-sitter parsing entirely.
-	hasMatchable := false
-	for _, spec := range specs {
-		if len(ast.ScanSpecIdentifiers(spec.BodyText)) > 0 {
-			hasMatchable = true
-			break
+	specInputs := make([]codeinfer.SpecInput, len(specs))
+	for i, spec := range specs {
+		specInputs[i] = codeinfer.SpecInput{
+			Ref:             spec.Ref,
+			BodyText:        spec.BodyText,
+			ManualAppliesTo: spec.AppliesTo,
 		}
 	}
-	if !hasMatchable {
-		return 0, nil
-	}
 
-	codePaths, err := ast.WalkWorkspace(workspaceRoot)
+	result, err := inferer.InferAppliesTo(ctx, codeinfer.Request{
+		WorkspaceRoot: workspaceRoot,
+		Specs:         specInputs,
+		PreviousCache: loadCachedASTData(ctx, cfg.Workspace.ResolvedIndexPath),
+		Limits: codeinfer.Limits{
+			MaxFileSizeBytes: 1 << 20,
+		},
+	})
 	if err != nil {
-		return 0, fmt.Errorf("walk workspace for AST extraction: %w", err)
+		return 0, err
 	}
-	if len(codePaths) == 0 {
+	if result == nil {
 		return 0, nil
 	}
 
-	// Prepare cache insert statement.
 	cacheStmt, err := tx.PrepareContext(ctx, `INSERT OR REPLACE INTO ast_cache (content_hash, path, symbols_json, rationale_json) VALUES (?, ?, ?, ?)`)
 	if err != nil {
 		return 0, fmt.Errorf("prepare ast_cache insert: %w", err)
 	}
 	defer cacheStmt.Close()
 
-	// Load cached symbols from the previous index if available.
-	cachedData := loadCachedASTData(ctx, cfg.Workspace.ResolvedIndexPath)
-
-	// Extract symbols and rationale from each code file.
-	const maxFileSize = 1 << 20 // 1 MB — skip minified bundles and generated files
-	fileSymbols := make(map[string][]ast.Symbol, len(codePaths))
-	for _, relPath := range codePaths {
-		if err := ctx.Err(); err != nil {
-			return 0, err
-		}
-		fullPath := filepath.Join(workspaceRoot, relPath)
-		info, err := os.Stat(fullPath)
-		if err != nil || info.Size() > maxFileSize {
-			continue
-		}
-		content, err := os.ReadFile(fullPath)
+	for _, entry := range result.CacheEntries {
+		normalizedPath, err := normalizeInferredCodePath(entry.Path)
 		if err != nil {
-			continue
+			return 0, fmt.Errorf("invalid inferred cache path %q: %w", entry.Path, err)
 		}
-
-		hash := ast.ContentHash(content, relPath)
-
-		// Check cache first.
-		if cached, ok := cachedData[hash]; ok {
-			fileSymbols[relPath] = cached.Symbols
-			if err := insertASTCacheWithRationale(ctx, cacheStmt, hash, relPath, cached.Symbols, cached.Rationale); err != nil {
-				return 0, err
-			}
-			continue
+		if strings.TrimSpace(entry.ContentHash) == "" {
+			return 0, fmt.Errorf("invalid inferred cache path %q: content hash is required", entry.Path)
 		}
-
-		lang := ast.DetectLanguage(relPath)
-		if lang == "" {
-			continue
-		}
-		symbols, err := ast.ExtractSymbols(content, lang)
-		if err != nil {
-			continue
-		}
-		rationale := ast.ExtractRationale(content, symbols, lang)
-		fileSymbols[relPath] = symbols
-		if err := insertASTCacheWithRationale(ctx, cacheStmt, hash, relPath, symbols, rationale); err != nil {
+		if err := insertASTCacheWithRationale(ctx, cacheStmt, entry.ContentHash, normalizedPath, entry.Symbols, entry.Rationale); err != nil {
 			return 0, err
 		}
 	}
 
-	// Build spec summaries for matching.
-	specSummaries := make([]ast.SpecSummary, len(specs))
-	for i, spec := range specs {
-		specSummaries[i] = ast.SpecSummary{
-			Ref:             spec.Ref,
-			Body:            spec.BodyText,
-			ManualAppliesTo: spec.AppliesTo,
-		}
-	}
-
-	// Run inference and insert edges.
-	inferred := ast.InferEdges(fileSymbols, specSummaries)
 	count := 0
-	for _, edge := range inferred {
-		ref := "code://" + edge.FilePath
+	for _, edge := range result.Edges {
+		if strings.TrimSpace(edge.SpecRef) == "" {
+			return count, fmt.Errorf("invalid inferred edge: spec ref is required")
+		}
+		normalizedPath, err := normalizeInferredCodePath(edge.FilePath)
+		if err != nil {
+			return count, fmt.Errorf("invalid inferred edge path %q: %w", edge.FilePath, err)
+		}
+		ref := "code://" + normalizedPath
 		if err := insertEdgeContext(ctx, edgeStmt, edge.SpecRef, ref, "applies_to", "inferred", validFrom, nil, ConfidenceInferred); err != nil {
 			// INSERT OR IGNORE means duplicate-key errors won't happen,
 			// but handle unexpected errors.
@@ -1089,14 +1057,32 @@ func inferASTEdgesContext(ctx context.Context, tx *sql.Tx, edgeStmt *sql.Stmt, c
 	return count, nil
 }
 
-// cachedASTEntry holds both symbols and rationale from the ast_cache.
-type cachedASTEntry struct {
-	Symbols   []ast.Symbol
-	Rationale []ast.Rationale
+func normalizeInferredCodePath(raw string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if strings.Contains(path, "://") {
+		return "", fmt.Errorf("path must be workspace-relative, not a URI")
+	}
+	if strings.Contains(path, ":") {
+		return "", fmt.Errorf("path must be a slash-separated workspace path")
+	}
+	if strings.Contains(path, `\`) {
+		return "", fmt.Errorf("path must use slash separators")
+	}
+	if filepath.IsAbs(path) {
+		return "", fmt.Errorf("path must be workspace-relative, not absolute")
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("path must stay within the workspace")
+	}
+	return cleaned, nil
 }
 
-func loadCachedASTData(ctx context.Context, indexPath string) map[string]cachedASTEntry {
-	result := make(map[string]cachedASTEntry)
+func loadCachedASTData(ctx context.Context, indexPath string) []codeinfer.CacheEntry {
+	result := []codeinfer.CacheEntry{}
 	if indexPath == "" {
 		return result
 	}
@@ -1123,9 +1109,9 @@ func loadCachedASTData(ctx context.Context, indexPath string) map[string]cachedA
 		hasRationale = true
 	}
 
-	query := `SELECT content_hash, symbols_json FROM ast_cache`
+	query := `SELECT content_hash, path, symbols_json FROM ast_cache`
 	if hasRationale {
-		query = `SELECT content_hash, symbols_json, rationale_json FROM ast_cache`
+		query = `SELECT content_hash, path, symbols_json, rationale_json FROM ast_cache`
 	}
 
 	rows, err := db.QueryContext(ctx, query)
@@ -1134,39 +1120,44 @@ func loadCachedASTData(ctx context.Context, indexPath string) map[string]cachedA
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var hash, symbolsJSON string
+		var hash, path, symbolsJSON string
 		var rationaleJSON string
 		var scanErr error
 		if hasRationale {
-			scanErr = rows.Scan(&hash, &symbolsJSON, &rationaleJSON)
+			scanErr = rows.Scan(&hash, &path, &symbolsJSON, &rationaleJSON)
 		} else {
-			scanErr = rows.Scan(&hash, &symbolsJSON)
+			scanErr = rows.Scan(&hash, &path, &symbolsJSON)
 		}
 		if scanErr != nil {
 			continue
 		}
-		var symbols []ast.Symbol
+		var symbols []codeinfer.Symbol
 		if err := json.Unmarshal([]byte(symbolsJSON), &symbols); err != nil {
 			continue
 		}
-		var rationale []ast.Rationale
+		var rationale []codeinfer.Rationale
 		if rationaleJSON != "" {
 			if err := json.Unmarshal([]byte(rationaleJSON), &rationale); err != nil {
 				continue
 			}
 		}
-		result[hash] = cachedASTEntry{Symbols: symbols, Rationale: rationale}
+		result = append(result, codeinfer.CacheEntry{
+			ContentHash: hash,
+			Path:        path,
+			Symbols:     symbols,
+			Rationale:   rationale,
+		})
 	}
 	return result
 }
 
-func insertASTCacheWithRationale(ctx context.Context, stmt *sql.Stmt, hash, path string, symbols []ast.Symbol, rationale []ast.Rationale) error {
+func insertASTCacheWithRationale(ctx context.Context, stmt *sql.Stmt, hash, path string, symbols []codeinfer.Symbol, rationale []codeinfer.Rationale) error {
 	symbolData, err := json.Marshal(symbols)
 	if err != nil {
 		return fmt.Errorf("marshal AST symbols for cache: %w", err)
 	}
 	if rationale == nil {
-		rationale = []ast.Rationale{}
+		rationale = []codeinfer.Rationale{}
 	}
 	rationaleData, err := json.Marshal(rationale)
 	if err != nil {

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -7,10 +7,12 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/dusk-network/pituitary/internal/codeinfer"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
@@ -347,7 +349,7 @@ func TestPrepareRebuildAcceptsSymlinkedStaleStagePathLikeRebuild(t *testing.T) {
 }
 
 func TestRebuildInfersASTEdges(t *testing.T) {
-	t.Parallel()
+	installCodeInfererForTest(t, testInferer{})
 
 	dir := t.TempDir()
 	indexPath := filepath.Join(dir, ".pituitary", "pituitary.db")
@@ -459,6 +461,190 @@ func NewSlidingWindowLimiter(w int) *SlidingWindowLimiter {
 	}
 }
 
+func TestRebuildErrorsWhenInferAppliesToEnabledWithoutRegisteredInferer(t *testing.T) {
+	restoreInferer := codeinfer.ReplaceForTest(codeinfer.DefaultInfererName, nil)
+	defer restoreInferer()
+
+	cfg, records := minimalInferAppliesToFixture(t, true)
+	_, err := Rebuild(cfg, records)
+	if err == nil {
+		t.Fatal("Rebuild() error = nil, want missing inferer error")
+	}
+	if !strings.Contains(err.Error(), `code inferer "ast" is not registered`) {
+		t.Fatalf("Rebuild() error = %q, want missing inferer message", err)
+	}
+}
+
+func TestRebuildRejectsInvalidInferencePaths(t *testing.T) {
+	cases := []struct {
+		name     string
+		inferer  codeinfer.AppliesToInferer
+		wantText string
+	}{
+		{
+			name:     "cache_absolute_path",
+			inferer:  invalidPathInferer{cachePath: "/tmp/outside.go"},
+			wantText: "invalid inferred cache path",
+		},
+		{
+			name:     "edge_uri_path",
+			inferer:  invalidPathInferer{edgePath: "code://src/limiter.go"},
+			wantText: "invalid inferred edge path",
+		},
+		{
+			name:     "edge_parent_traversal",
+			inferer:  invalidPathInferer{edgePath: "../outside.go"},
+			wantText: "invalid inferred edge path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installCodeInfererForTest(t, tc.inferer)
+
+			cfg, records := minimalInferAppliesToFixture(t, true)
+			_, err := Rebuild(cfg, records)
+			if err == nil {
+				t.Fatal("Rebuild() error = nil, want invalid path error")
+			}
+			if !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("Rebuild() error = %q, want substring %q", err, tc.wantText)
+			}
+		})
+	}
+}
+
+type testInferer struct{}
+
+func (testInferer) Name() string {
+	return codeinfer.DefaultInfererName
+}
+
+func (testInferer) InferAppliesTo(ctx context.Context, req codeinfer.Request) (*codeinfer.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for _, spec := range req.Specs {
+		if spec.Ref != "SPEC-042" || !strings.Contains(spec.BodyText, "SlidingWindowLimiter") {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(req.WorkspaceRoot, "src", "limiter.go")); err != nil {
+			return &codeinfer.Result{}, nil
+		}
+		return &codeinfer.Result{
+			CacheEntries: []codeinfer.CacheEntry{
+				{
+					ContentHash: "test-cache",
+					Path:        "src/limiter.go",
+					Symbols: []codeinfer.Symbol{
+						{Name: "SlidingWindowLimiter", Kind: codeinfer.SymbolType},
+					},
+				},
+			},
+			Edges: []codeinfer.InferredEdge{
+				{
+					SpecRef:   "SPEC-042",
+					FilePath:  "src/limiter.go",
+					MatchedOn: []string{"SlidingWindowLimiter"},
+				},
+			},
+		}, nil
+	}
+	return &codeinfer.Result{}, nil
+}
+
+type noopInferer struct{}
+
+func (noopInferer) Name() string {
+	return codeinfer.DefaultInfererName
+}
+
+func (noopInferer) InferAppliesTo(ctx context.Context, req codeinfer.Request) (*codeinfer.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &codeinfer.Result{}, nil
+}
+
+type invalidPathInferer struct {
+	cachePath string
+	edgePath  string
+}
+
+func (invalidPathInferer) Name() string {
+	return codeinfer.DefaultInfererName
+}
+
+func (i invalidPathInferer) InferAppliesTo(ctx context.Context, req codeinfer.Request) (*codeinfer.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	result := &codeinfer.Result{}
+	if i.cachePath != "" {
+		result.CacheEntries = append(result.CacheEntries, codeinfer.CacheEntry{
+			ContentHash: "bad-cache",
+			Path:        i.cachePath,
+		})
+	}
+	if i.edgePath != "" {
+		result.Edges = append(result.Edges, codeinfer.InferredEdge{
+			SpecRef:  "SPEC-042",
+			FilePath: i.edgePath,
+		})
+	}
+	return result, nil
+}
+
+func installCodeInfererForTest(t testing.TB, inferer codeinfer.AppliesToInferer) {
+	t.Helper()
+	restore := codeinfer.ReplaceForTest(codeinfer.DefaultInfererName, func() codeinfer.AppliesToInferer {
+		return inferer
+	})
+	t.Cleanup(restore)
+}
+
+func minimalInferAppliesToFixture(t testing.TB, inferAppliesTo bool) (*config.Config, *source.LoadResult) {
+	t.Helper()
+
+	dir := t.TempDir()
+	indexPath := filepath.Join(dir, ".pituitary", "pituitary.db")
+	configPath := filepath.Join(dir, "pituitary.toml")
+	mustWriteFile(t, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(dir)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+infer_applies_to = `+strconv.FormatBool(inferAppliesTo)+`
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	mustWriteFile(t, filepath.Join(dir, "specs", "rate-limit", "spec.toml"), `id = "SPEC-042"
+title = "Rate Limiting"
+status = "accepted"
+domain = "api"
+authors = ["test"]
+body = "body.md"
+`)
+	mustWriteFile(t, filepath.Join(dir, "specs", "rate-limit", "body.md"), "body text\n")
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig: %v", err)
+	}
+	return cfg, records
+}
+
 func TestPrepareRebuildReflectsInferAppliesToFromConfig(t *testing.T) {
 	t.Parallel()
 
@@ -524,7 +710,7 @@ body = "body.md"
 }
 
 func TestRebuildResultReflectsInferAppliesToFromConfig(t *testing.T) {
-	t.Parallel()
+	installCodeInfererForTest(t, noopInferer{})
 
 	cases := []struct {
 		name         string
@@ -538,8 +724,6 @@ func TestRebuildResultReflectsInferAppliesToFromConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			dir := t.TempDir()
 			indexPath := filepath.Join(dir, ".pituitary", "pituitary.db")
 

--- a/internal/index/status_test.go
+++ b/internal/index/status_test.go
@@ -54,7 +54,7 @@ func TestReadStatusReadsFixtureCounts(t *testing.T) {
 }
 
 func TestReadStatusReportsInferAppliesToEnabled(t *testing.T) {
-	t.Parallel()
+	installCodeInfererForTest(t, noopInferer{})
 
 	cases := []struct {
 		name     string
@@ -67,8 +67,6 @@ func TestReadStatusReportsInferAppliesToEnabled(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			dir := t.TempDir()
 			indexPath := filepath.Join(dir, ".pituitary", "pituitary.db")
 


### PR DESCRIPTION
## Summary

- Introduces `internal/codeinfer` as the kernel-owned inference contract and registry.
- Moves the tree-sitter AST implementation behind a first-party `extensions/astinfer` inferer.
- Keeps CLI behavior intact via an explicit extension import, while tests install fake inferers directly.
- Adds path/cache validation and a vet guard so kernel indexing does not import `internal/ast` again.

Tracks #367.

## Behavior

`workspace.infer_applies_to = true` now requires the `ast` inferer to be registered. The CLI registers the first-party inferer; kernel tests use explicit test inferers.

## Validation

- `go test ./internal/ast ./internal/index ./extensions/astinfer`
- `go test ./cmd ./internal/app ./internal/analysis ./internal/mcp`
- `go test ./cmd ./internal/index ./extensions/astinfer`
- `go test ./...`
- `go test -race ./internal/index ./extensions/astinfer`
- `make fmt-check`
- `make vet`
- `git diff --minimal --check`