### PR TITLE
[codex] Default AST inference for code-targeted specs

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	_ "github.com/dusk-network/pituitary/extensions/astinfer"
 	"github.com/dusk-network/pituitary/internal/analysis"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -71,6 +71,7 @@ func TestRunBenchmarksCapturesAnalysisRuntimeTraffic(t *testing.T) {
 [workspace]
 root = "."
 index_path = ".pituitary/pituitary.db"
+infer_applies_to = false
 
 [runtime.embedder]
 provider = "fixture"

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -110,13 +110,12 @@ domain_pointer = "/meta/domain"
 	}
 }
 
-func TestRunIndexInfersASTEdgesThroughRegisteredExtension(t *testing.T) {
+func TestRunIndexDefaultsASTInferenceThroughRegisteredExtension(t *testing.T) {
 	repo := t.TempDir()
 	mustWriteIndexFixture(t, repo, `
 [workspace]
 root = "."
 index_path = ".pituitary/pituitary.db"
-infer_applies_to = true
 
 [runtime.embedder]
 provider = "fixture"
@@ -136,6 +135,7 @@ status = "accepted"
 domain = "api"
 authors = ["test"]
 body = "body.md"
+applies_to = ["code://src/manual.go"]
 `)
 	mustWriteFileCmd(t, filepath.Join(repo, "specs", "rate-limit", "body.md"), `## Overview
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,8 @@ Pituitary keeps source paths repo-relative, adds `repo` to search/drift/impact/s
 
 Important path-resolution rule: `workspace.root` and `[[workspace.repos]].root` resolve relative to the config file's base directory, not the current working directory. That matters when you keep a scratch config outside the repo, for example `/tmp/pit-fake.toml` with `root = ".."`. In that case `..` resolves relative to `/tmp`, not relative to the shell directory where you invoked `pituitary`. If the resolved root is wrong, Pituitary now reports the derived absolute path in the validation error so the cause is visible immediately.
 
+AST-inferred `applies_to` links are enabled automatically when the loaded specs declare at least one `code://...` target. Set `workspace.infer_applies_to = false` to opt out, or `workspace.infer_applies_to = true` to force inference. When inference is enabled but the AST inferer is not registered, rebuild fails fast instead of silently producing a degraded index.
+
 ### Runtime Profiles
 
 Runtime config also supports reusable named profiles under `[runtime.profiles.<name>]`. Select one from `[runtime.embedder]` or `[runtime.analysis]` with `profile = "..."`, then override only the fields that differ:

--- a/internal/analysis/compare_test.go
+++ b/internal/analysis/compare_test.go
@@ -209,6 +209,7 @@ func loadCompareFixtureConfig(t *testing.T) *config.Config {
 [workspace]
 root = "."
 index_path = ".pituitary/pituitary.db"
+infer_applies_to = false
 
 [runtime.embedder]
 provider = "fixture"

--- a/internal/analysis/compliance_runtime_test.go
+++ b/internal/analysis/compliance_runtime_test.go
@@ -114,6 +114,7 @@ func HandleCreate() {
 [workspace]
 root = %q
 index_path = %q
+infer_applies_to = false
 
 [runtime.embedder]
 provider = "fixture"

--- a/internal/analysis/overlap_test.go
+++ b/internal/analysis/overlap_test.go
@@ -153,6 +153,7 @@ func loadFixtureConfig(tb testing.TB) *config.Config {
 [workspace]
 root = "`+filepath.ToSlash(repoRoot)+`"
 index_path = "`+filepath.ToSlash(indexPath)+`"
+infer_applies_to = false
 
 [runtime.embedder]
 provider = "fixture"

--- a/internal/app/operations_test.go
+++ b/internal/app/operations_test.go
@@ -550,6 +550,7 @@ max_retries = 0
 [workspace]
 root = "."
 index_path = ".pituitary/pituitary.db"
+infer_applies_to = false
 
 `+runtimeEmbedder+runtimeAnalysis+`
 [[sources]]

--- a/internal/codeinfer/codeinfer.go
+++ b/internal/codeinfer/codeinfer.go
@@ -142,6 +142,20 @@ func Lookup(name string) (AppliesToInferer, bool) {
 	return factory(), true
 }
 
+// Registered reports whether an inferer factory is registered by name without
+// constructing an inferer instance.
+func Registered(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+
+	mu.RLock()
+	_, ok := inferers[name]
+	mu.RUnlock()
+	return ok
+}
+
 // RegisteredNames returns registered inferer names in stable order.
 func RegisteredNames() []string {
 	mu.RLock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,7 @@ type Workspace struct {
 	IndexPath         string
 	ResolvedIndexPath string
 	InferAppliesTo    bool
+	InferAppliesToSet bool
 	Repos             []WorkspaceRepo
 }
 
@@ -278,7 +279,7 @@ type rawWorkspace struct {
 	Root           string             `toml:"root"`
 	RepoID         string             `toml:"repo_id"`
 	IndexPath      string             `toml:"index_path"`
-	InferAppliesTo bool               `toml:"infer_applies_to"`
+	InferAppliesTo *bool              `toml:"infer_applies_to"`
 	Repos          []rawWorkspaceRepo `toml:"repos"`
 }
 
@@ -475,11 +476,12 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 		ConfigPath:    configPath,
 		ConfigDir:     configBaseDir(configPath),
 		Workspace: Workspace{
-			Root:           raw.Workspace.Root,
-			RepoID:         strings.TrimSpace(raw.Workspace.RepoID),
-			IndexPath:      raw.Workspace.IndexPath,
-			InferAppliesTo: raw.Workspace.InferAppliesTo,
-			Repos:          make([]WorkspaceRepo, 0, len(raw.Workspace.Repos)),
+			Root:              raw.Workspace.Root,
+			RepoID:            strings.TrimSpace(raw.Workspace.RepoID),
+			IndexPath:         raw.Workspace.IndexPath,
+			InferAppliesTo:    rawBoolValue(raw.Workspace.InferAppliesTo),
+			InferAppliesToSet: raw.Workspace.InferAppliesTo != nil,
+			Repos:             make([]WorkspaceRepo, 0, len(raw.Workspace.Repos)),
 		},
 		Runtime: Runtime{
 			Profiles: make(map[string]RuntimeProvider, len(raw.Runtime.Profiles)),
@@ -544,6 +546,10 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 	}
 	cfg.SchemaVersion = CurrentSchemaVersion
 	return cfg, nil
+}
+
+func rawBoolValue(value *bool) bool {
+	return value != nil && *value
 }
 
 func configBaseDir(configPath string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,56 @@ path = "docs"
 	}
 }
 
+func TestLoadTracksExplicitInferAppliesTo(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		line    string
+		want    bool
+		wantSet bool
+	}{
+		{name: "omitted", want: false, wantSet: false},
+		{name: "enabled", line: "infer_applies_to = true", want: true, wantSet: true},
+		{name: "disabled", line: "infer_applies_to = false", want: false, wantSet: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := t.TempDir()
+			workspace := filepath.Join(repo, "workspace")
+			mustMkdirAll(t, filepath.Join(workspace, "specs"))
+
+			configPath := filepath.Join(repo, "pituitary.toml")
+			writeFile(t, configPath, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+`+tc.line+`
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+			cfg, err := Load(configPath)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Workspace.InferAppliesTo != tc.want {
+				t.Fatalf("InferAppliesTo = %v, want %v", cfg.Workspace.InferAppliesTo, tc.want)
+			}
+			if cfg.Workspace.InferAppliesToSet != tc.wantSet {
+				t.Fatalf("InferAppliesToSet = %v, want %v", cfg.Workspace.InferAppliesToSet, tc.wantSet)
+			}
+		})
+	}
+}
+
 func TestLoadResolvesMultiRepoSources(t *testing.T) {
 	t.Parallel()
 
@@ -1233,6 +1283,48 @@ func TestRenderRoundTripsSourceRole(t *testing.T) {
 	}
 	if got, want := loaded.Sources[0].Role, SourceRoleMirror; got != want {
 		t.Fatalf("loaded role = %q, want %q", got, want)
+	}
+}
+
+func TestRenderPreservesExplicitInferAppliesToFalse(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	cfg := &Config{
+		SchemaVersion: CurrentSchemaVersion,
+		ConfigPath:    configPath,
+		ConfigDir:     repo,
+		Workspace: Workspace{
+			Root:              ".",
+			IndexPath:         ".pituitary/pituitary.db",
+			InferAppliesTo:    false,
+			InferAppliesToSet: true,
+		},
+		Sources: []Source{
+			{
+				Name:    "specs",
+				Adapter: AdapterFilesystem,
+				Kind:    SourceKindSpecBundle,
+				Path:    "specs",
+			},
+		},
+	}
+
+	rendered, err := Render(cfg)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if !strings.Contains(rendered, "infer_applies_to = false") {
+		t.Fatalf("rendered config %q does not preserve explicit infer_applies_to false", rendered)
+	}
+	loaded, err := LoadFromText(rendered, configPath)
+	if err != nil {
+		t.Fatalf("LoadFromText() error = %v", err)
+	}
+	if !loaded.Workspace.InferAppliesToSet || loaded.Workspace.InferAppliesTo {
+		t.Fatalf("loaded infer_applies_to = (%v, set=%v), want false set explicitly", loaded.Workspace.InferAppliesTo, loaded.Workspace.InferAppliesToSet)
 	}
 }
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -22,6 +22,9 @@ func Render(cfg *Config) (string, error) {
 		fmt.Fprintf(&builder, "repo_id = %s\n", strconv.Quote(repoID))
 	}
 	fmt.Fprintf(&builder, "index_path = %s\n", strconv.Quote(cfg.Workspace.IndexPath))
+	if cfg.Workspace.InferAppliesToSet || cfg.Workspace.InferAppliesTo {
+		fmt.Fprintf(&builder, "infer_applies_to = %t\n", cfg.Workspace.InferAppliesTo)
+	}
 	for _, repo := range cfg.Workspace.Repos {
 		builder.WriteString("\n[[workspace.repos]]\n")
 		fmt.Fprintf(&builder, "id = %s\n", strconv.Quote(repo.ID))

--- a/internal/index/freshness.go
+++ b/internal/index/freshness.go
@@ -179,19 +179,9 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 		})
 	}
 
-	currentInferAppliesTo := strconv.FormatBool(cfg.Workspace.InferAppliesTo)
-	switch stored := strings.TrimSpace(metadata["infer_applies_to_enabled"]); {
-	case stored == "":
-		// Legacy indexes without the metadata key predate the visibility fix;
-		// treat the absence as not-a-mismatch rather than flagging every
-		// pre-existing index as incompatible. A subsequent rebuild fills it in.
-	case !strings.EqualFold(stored, currentInferAppliesTo):
-		issues = append(issues, FreshnessIssue{
-			Kind:    "infer_applies_to_mismatch",
-			Message: fmt.Sprintf("index infer_applies_to %q does not match current workspace infer_applies_to %q; --update cannot regenerate inferred edges, run `pituitary index --rebuild`", stored, currentInferAppliesTo),
-			Indexed: stored,
-			Current: currentInferAppliesTo,
-		})
+	storedInferAppliesTo := strings.TrimSpace(metadata["infer_applies_to_enabled"])
+	if cfg.Workspace.InferAppliesToSet {
+		issues = appendInferAppliesToFreshnessIssue(issues, storedInferAppliesTo, cfg.Workspace.InferAppliesTo)
 	}
 
 	switch stored := strings.TrimSpace(metadata["source_fingerprint"]); {
@@ -224,6 +214,9 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 	if err != nil {
 		return nil, fmt.Errorf("load current sources for freshness check: %w", err)
 	}
+	if !cfg.Workspace.InferAppliesToSet {
+		issues = appendInferAppliesToFreshnessIssue(issues, storedInferAppliesTo, effectiveInferAppliesTo(cfg, records.Specs))
+	}
 	currentContentFingerprint := contentFingerprint(records)
 
 	switch stored := strings.TrimSpace(metadata["content_fingerprint"]); {
@@ -245,6 +238,24 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 	status.State = deriveFreshnessState(issues)
 	status.Action = freshnessAction(status.State)
 	return status, nil
+}
+
+func appendInferAppliesToFreshnessIssue(issues []FreshnessIssue, stored string, current bool) []FreshnessIssue {
+	currentInferAppliesTo := strconv.FormatBool(current)
+	switch {
+	case stored == "":
+		// Legacy indexes without the metadata key predate the visibility fix;
+		// treat the absence as not-a-mismatch rather than flagging every
+		// pre-existing index as incompatible. A subsequent rebuild fills it in.
+	case !strings.EqualFold(stored, currentInferAppliesTo):
+		issues = append(issues, FreshnessIssue{
+			Kind:    "infer_applies_to_mismatch",
+			Message: fmt.Sprintf("index infer_applies_to %q does not match current effective workspace infer_applies_to %q; --update cannot regenerate inferred edges, run `pituitary index --rebuild`", stored, currentInferAppliesTo),
+			Indexed: stored,
+			Current: currentInferAppliesTo,
+		})
+	}
+	return issues
 }
 
 func freshnessAction(state string) string {

--- a/internal/index/freshness_test.go
+++ b/internal/index/freshness_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dusk-network/pituitary/internal/codeinfer"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
 )
@@ -356,6 +357,71 @@ body = "body.md"
 	}
 }
 
+func TestInspectFreshnessComparesEffectiveDefaultInferAppliesTo(t *testing.T) {
+	installCodeInfererForTest(t, noopInferer{})
+
+	cfg, records := inferAppliesToFixture(t, "false", true)
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	mustWriteFile(t, cfg.ConfigPath, `
+[workspace]
+root = "`+filepath.ToSlash(cfg.Workspace.RootPath)+`"
+index_path = "`+filepath.ToSlash(cfg.Workspace.ResolvedIndexPath)+`"
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+	cfg2, err := config.Load(cfg.ConfigPath)
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	status, err := InspectFreshnessContext(context.Background(), cfg2)
+	if err != nil {
+		t.Fatalf("InspectFreshnessContext() error = %v", err)
+	}
+	if status.State != freshnessStateIncompatible {
+		t.Fatalf("freshness.state = %q, want %q", status.State, freshnessStateIncompatible)
+	}
+	if len(status.Issues) == 0 || status.Issues[0].Kind != "infer_applies_to_mismatch" {
+		t.Fatalf("freshness.issues = %+v, want infer_applies_to_mismatch", status.Issues)
+	}
+	if status.Issues[0].Current != "true" {
+		t.Fatalf("freshness current infer_applies_to = %q, want true", status.Issues[0].Current)
+	}
+}
+
+func TestInspectFreshnessDefaultInferAppliesToDoesNotDependOnRegisteredInferer(t *testing.T) {
+	restoreInferer := codeinfer.ReplaceForTest(codeinfer.DefaultInfererName, func() codeinfer.AppliesToInferer {
+		return noopInferer{}
+	})
+	cfg, records := inferAppliesToFixture(t, "", true)
+	if _, err := Rebuild(cfg, records); err != nil {
+		restoreInferer()
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+	restoreInferer()
+	restoreMissingInferer := codeinfer.ReplaceForTest(codeinfer.DefaultInfererName, nil)
+	defer restoreMissingInferer()
+
+	status, err := InspectFreshnessContext(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("InspectFreshnessContext() error = %v", err)
+	}
+	if status.State != freshnessStateFresh {
+		t.Fatalf("freshness.state = %q, want %q; issues=%+v", status.State, freshnessStateFresh, status.Issues)
+	}
+}
+
 func loadFreshnessFixtureConfig(tb testing.TB) *config.Config {
 	tb.Helper()
 
@@ -369,6 +435,7 @@ func loadFreshnessFixtureConfig(tb testing.TB) *config.Config {
 [workspace]
 root = "."
 index_path = ".pituitary/pituitary.db"
+infer_applies_to = false
 
 [runtime.embedder]
 provider = "fixture"

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -117,7 +117,10 @@ func PrepareRebuildContextWithOptions(ctx context.Context, cfg *config.Config, r
 	result := summarizeRebuild(records, dimension, reuseState, options)
 	result.IndexPath = cfg.Workspace.ResolvedIndexPath
 	result.DryRun = true
-	result.InferAppliesToEnabled = cfg.Workspace.InferAppliesTo
+	result.InferAppliesToEnabled = effectiveInferAppliesTo(cfg, records.Specs)
+	if err := requireInfererRegistered(result.InferAppliesToEnabled); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -458,7 +461,8 @@ func finalizeBusinessIndexContext(ctx context.Context, db *sql.DB, cfg *config.C
 		}
 	}
 
-	inferredCount, err := inferASTEdgesContext(ctx, tx, edgeStmt, cfg, records.Specs, rebuildTimePtr)
+	inferAppliesToEnabled := effectiveInferAppliesTo(cfg, records.Specs)
+	inferredCount, err := inferASTEdgesContext(ctx, tx, edgeStmt, cfg, records.Specs, inferAppliesToEnabled, rebuildTimePtr)
 	if err != nil {
 		return fmt.Errorf("infer AST edges: %w", err)
 	}
@@ -486,7 +490,7 @@ func finalizeBusinessIndexContext(ctx context.Context, db *sql.DB, cfg *config.C
 	if err := upsertMetadataContext(ctx, tx, "chunking_config_fingerprint", chunkingConfigFingerprint(cfg.Runtime.Chunking)); err != nil {
 		return err
 	}
-	if err := upsertMetadataContext(ctx, tx, "infer_applies_to_enabled", strconv.FormatBool(cfg.Workspace.InferAppliesTo)); err != nil {
+	if err := upsertMetadataContext(ctx, tx, "infer_applies_to_enabled", strconv.FormatBool(inferAppliesToEnabled)); err != nil {
 		return err
 	}
 	if manifest := sourceManifestJSON(cfg); manifest != "" {
@@ -514,7 +518,7 @@ func finalizeBusinessIndexContext(ctx context.Context, db *sql.DB, cfg *config.C
 
 	result.EdgeCount = edgeCount
 	result.InferredEdgeCount = inferredCount
-	result.InferAppliesToEnabled = cfg.Workspace.InferAppliesTo
+	result.InferAppliesToEnabled = inferAppliesToEnabled
 	return nil
 }
 
@@ -981,8 +985,8 @@ func chunkingConfigFingerprint(cfg config.ChunkingConfig) string {
 // inferASTEdgesContext asks the registered code inferer for inferred
 // applies_to edges and refreshed code-scan cache entries, then persists them
 // through the kernel-owned index transaction.
-func inferASTEdgesContext(ctx context.Context, tx *sql.Tx, edgeStmt *sql.Stmt, cfg *config.Config, specs []model.SpecRecord, validFrom *string) (int, error) {
-	if !cfg.Workspace.InferAppliesTo {
+func inferASTEdgesContext(ctx context.Context, tx *sql.Tx, edgeStmt *sql.Stmt, cfg *config.Config, specs []model.SpecRecord, inferAppliesToEnabled bool, validFrom *string) (int, error) {
+	if !inferAppliesToEnabled {
 		return 0, nil
 	}
 	workspaceRoot := cfg.Workspace.RootPath
@@ -1055,6 +1059,37 @@ func inferASTEdgesContext(ctx context.Context, tx *sql.Tx, edgeStmt *sql.Stmt, c
 		count++
 	}
 	return count, nil
+}
+
+func effectiveInferAppliesTo(cfg *config.Config, specs []model.SpecRecord) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.Workspace.InferAppliesToSet {
+		return cfg.Workspace.InferAppliesTo
+	}
+	if !specsDeclareCodeAppliesTo(specs) {
+		return false
+	}
+	return true
+}
+
+func requireInfererRegistered(inferAppliesToEnabled bool) error {
+	if !inferAppliesToEnabled || codeinfer.Registered(codeinfer.DefaultInfererName) {
+		return nil
+	}
+	return fmt.Errorf("infer_applies_to is enabled but code inferer %q is not registered", codeinfer.DefaultInfererName)
+}
+
+func specsDeclareCodeAppliesTo(specs []model.SpecRecord) bool {
+	for _, spec := range specs {
+		for _, ref := range spec.AppliesTo {
+			if strings.HasPrefix(strings.TrimSpace(ref), "code://") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func normalizeInferredCodePath(raw string) (string, error) {

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -475,6 +476,82 @@ func TestRebuildErrorsWhenInferAppliesToEnabledWithoutRegisteredInferer(t *testi
 	}
 }
 
+func TestRebuildDefaultsInferAppliesToOnForCodeTargetsWhenInfererRegistered(t *testing.T) {
+	installCodeInfererForTest(t, testInferer{})
+
+	cfg, records := inferAppliesToFixture(t, "", true)
+	result, err := Rebuild(cfg, records)
+	if err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+	if !result.InferAppliesToEnabled {
+		t.Fatal("result.InferAppliesToEnabled = false, want true")
+	}
+	if result.InferredEdgeCount == 0 {
+		t.Fatal("result.InferredEdgeCount = 0, want inferred edge")
+	}
+
+	db := mustOpenReadOnly(t, cfg.Workspace.ResolvedIndexPath)
+	defer db.Close()
+	assertMetadataValue(t, db, "infer_applies_to_enabled", "true")
+	var cacheCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM ast_cache`).Scan(&cacheCount); err != nil {
+		t.Fatalf("count ast_cache: %v", err)
+	}
+	if cacheCount == 0 {
+		t.Fatal("ast_cache count = 0, want cache rows from registered inferer")
+	}
+}
+
+func TestRebuildDefaultInferAppliesToErrorsForCodeTargetsWithoutRegisteredInferer(t *testing.T) {
+	restoreInferer := codeinfer.ReplaceForTest(codeinfer.DefaultInfererName, nil)
+	defer restoreInferer()
+
+	cfg, records := inferAppliesToFixture(t, "", true)
+	_, err := Rebuild(cfg, records)
+	if err != nil {
+		if !strings.Contains(err.Error(), `code inferer "ast" is not registered`) {
+			t.Fatalf("Rebuild() error = %q, want missing inferer message", err)
+		}
+		return
+	}
+	t.Fatal("Rebuild() error = nil, want missing inferer error")
+}
+
+func TestRebuildDefaultNoCodeTargetsDoesNotCallRegisteredInferer(t *testing.T) {
+	installCodeInfererForTest(t, unexpectedInferer{})
+
+	cfg, records := inferAppliesToFixture(t, "", false)
+	result, err := Rebuild(cfg, records)
+	if err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+	if result.InferAppliesToEnabled {
+		t.Fatal("result.InferAppliesToEnabled = true, want false")
+	}
+
+	db := mustOpenReadOnly(t, cfg.Workspace.ResolvedIndexPath)
+	defer db.Close()
+	assertMetadataValue(t, db, "infer_applies_to_enabled", "false")
+}
+
+func TestRebuildExplicitInferAppliesToFalseSuppressesCodeTargetDefault(t *testing.T) {
+	installCodeInfererForTest(t, unexpectedInferer{})
+
+	cfg, records := inferAppliesToFixture(t, "false", true)
+	result, err := Rebuild(cfg, records)
+	if err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+	if result.InferAppliesToEnabled {
+		t.Fatal("result.InferAppliesToEnabled = true, want false")
+	}
+
+	db := mustOpenReadOnly(t, cfg.Workspace.ResolvedIndexPath)
+	defer db.Close()
+	assertMetadataValue(t, db, "infer_applies_to_enabled", "false")
+}
+
 func TestRebuildRejectsInvalidInferencePaths(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -566,6 +643,19 @@ func (noopInferer) InferAppliesTo(ctx context.Context, req codeinfer.Request) (*
 	return &codeinfer.Result{}, nil
 }
 
+type unexpectedInferer struct{}
+
+func (unexpectedInferer) Name() string {
+	return codeinfer.DefaultInfererName
+}
+
+func (unexpectedInferer) InferAppliesTo(ctx context.Context, req codeinfer.Request) (*codeinfer.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, errors.New("inferer should not be called")
+}
+
 type invalidPathInferer struct {
 	cachePath string
 	edgePath  string
@@ -606,14 +696,24 @@ func installCodeInfererForTest(t testing.TB, inferer codeinfer.AppliesToInferer)
 func minimalInferAppliesToFixture(t testing.TB, inferAppliesTo bool) (*config.Config, *source.LoadResult) {
 	t.Helper()
 
+	return inferAppliesToFixture(t, strconv.FormatBool(inferAppliesTo), false)
+}
+
+func inferAppliesToFixture(t testing.TB, inferAppliesToFlag string, codeTarget bool) (*config.Config, *source.LoadResult) {
+	t.Helper()
+
 	dir := t.TempDir()
 	indexPath := filepath.Join(dir, ".pituitary", "pituitary.db")
 	configPath := filepath.Join(dir, "pituitary.toml")
+	flagLine := ""
+	if strings.TrimSpace(inferAppliesToFlag) != "" {
+		flagLine = "infer_applies_to = " + strings.TrimSpace(inferAppliesToFlag) + "\n"
+	}
 	mustWriteFile(t, configPath, `
 [workspace]
 root = "`+filepath.ToSlash(dir)+`"
 index_path = "`+filepath.ToSlash(indexPath)+`"
-infer_applies_to = `+strconv.FormatBool(inferAppliesTo)+`
+`+flagLine+`
 
 [runtime.embedder]
 provider = "fixture"
@@ -631,8 +731,18 @@ status = "accepted"
 domain = "api"
 authors = ["test"]
 body = "body.md"
+`+specAppliesToLine(codeTarget)+`
 `)
-	mustWriteFile(t, filepath.Join(dir, "specs", "rate-limit", "body.md"), "body text\n")
+	mustWriteFile(t, filepath.Join(dir, "specs", "rate-limit", "body.md"), `## Overview
+
+This spec governs the SlidingWindowLimiter implementation.
+`)
+	mustWriteFile(t, filepath.Join(dir, "src", "limiter.go"), `package limiter
+
+type SlidingWindowLimiter struct {
+	window int
+}
+`)
 
 	cfg, err := config.Load(configPath)
 	if err != nil {
@@ -645,8 +755,15 @@ body = "body.md"
 	return cfg, records
 }
 
+func specAppliesToLine(enabled bool) string {
+	if !enabled {
+		return ""
+	}
+	return `applies_to = ["code://src/manual.go"]`
+}
+
 func TestPrepareRebuildReflectsInferAppliesToFromConfig(t *testing.T) {
-	t.Parallel()
+	installCodeInfererForTest(t, noopInferer{})
 
 	cases := []struct {
 		name     string
@@ -659,8 +776,6 @@ func TestPrepareRebuildReflectsInferAppliesToFromConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			dir := t.TempDir()
 			indexPath := filepath.Join(dir, ".pituitary", "pituitary.db")
 
@@ -706,6 +821,33 @@ body = "body.md"
 				t.Errorf("PrepareRebuild result.InferAppliesToEnabled = %v, want %v", result.InferAppliesToEnabled, tc.want)
 			}
 		})
+	}
+}
+
+func TestPrepareRebuildDefaultsInferAppliesToFromCodeTargets(t *testing.T) {
+	installCodeInfererForTest(t, noopInferer{})
+
+	cfg, records := inferAppliesToFixture(t, "", true)
+	result, err := PrepareRebuild(cfg, records)
+	if err != nil {
+		t.Fatalf("PrepareRebuild() error = %v", err)
+	}
+	if !result.InferAppliesToEnabled {
+		t.Fatal("PrepareRebuild result.InferAppliesToEnabled = false, want true")
+	}
+}
+
+func TestPrepareRebuildDefaultInferAppliesToErrorsForCodeTargetsWithoutRegisteredInferer(t *testing.T) {
+	restoreInferer := codeinfer.ReplaceForTest(codeinfer.DefaultInfererName, nil)
+	defer restoreInferer()
+
+	cfg, records := inferAppliesToFixture(t, "", true)
+	_, err := PrepareRebuild(cfg, records)
+	if err == nil {
+		t.Fatal("PrepareRebuild() error = nil, want missing inferer error")
+	}
+	if !strings.Contains(err.Error(), `code inferer "ast" is not registered`) {
+		t.Fatalf("PrepareRebuild() error = %q, want missing inferer message", err)
 	}
 }
 
@@ -796,6 +938,7 @@ func loadFixtureConfigWithIndexPath(tb testing.TB, indexPath string) *config.Con
 [workspace]
 root = "`+filepath.ToSlash(repoRoot)+`"
 index_path = "`+filepath.ToSlash(indexPath)+`"
+infer_applies_to = false
 
 [runtime.embedder]
 provider = "fixture"

--- a/internal/index/status_test.go
+++ b/internal/index/status_test.go
@@ -330,6 +330,7 @@ func loadGovernanceHotspotFixtureConfig(tb testing.TB) *config.Config {
 [workspace]
 root = "%s"
 index_path = "%s"
+infer_applies_to = false
 
 [runtime.embedder]
 provider = "fixture"

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -933,6 +933,7 @@ func writeMCPWorkspaceWithRuntime(t *testing.T, runtimeEmbedder string) string {
 [workspace]
 root = "."
 index_path = ".pituitary/pituitary.db"
+infer_applies_to = false
 
 `+strings.TrimSpace(runtimeEmbedder)+`
 


### PR DESCRIPTION
## Summary

- Defaults AST `applies_to` inference on when loaded specs declare `code://...` targets.
- Preserves explicit `workspace.infer_applies_to = false` as an opt-out and explicit `true` as a fail-fast requirement.
- Makes missing inferer behavior deterministic: enabled inference errors clearly instead of silently producing a degraded index.
- Tracks the effective inference state in rebuild/status/freshness metadata, including stable freshness behavior across processes without the inferer registered.
- Registers the AST inferer in the bench binary and pins unrelated test fixtures to opt out where inference is not under test.

Tracks #372.

## Validation

- `go test ./...`
- `go test -race ./...`
- `make fmt-check`
- `make vet`
- `make docs-check`
- `make smoke-sqlite-vec`
- `git diff --minimal --check`