### PR TITLE
Resolve active pituitary analysis issues

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,13 @@ path = "rfcs"
 include = ["**/*.md"]
 ```
 
+Filesystem source selectors use slash-separated paths relative to the source
+`path`. Selectors must not start with `/` or contain empty, `.`, or `..` path
+segments. `files` is an explicit allow-list, while `include` and `exclude` are
+glob selectors: `*` matches within one path segment (`guides/*.md`), and `**`
+matches zero or more whole path segments (`**/*.md` includes root-level and
+nested Markdown files).
+
 `workspace.root` is the primary repo root for the logical workspace. For cross-repo analysis, name it with `workspace.repo_id`, declare additional roots under `[[workspace.repos]]`, and bind a source to a secondary root with `repo = "..."`:
 
 ```toml
@@ -236,7 +243,7 @@ applies_to_pointer = "/x-pituitary/applies_to"
 
 **`markdown_docs`**: Free-form Markdown files such as guides and runbooks. Indexed for drift detection and search.
 
-**`markdown_contract`**: Markdown files treated as inferred specs. Pituitary extracts metadata from `Ref:`, `Status:`, `Domain:`, `Depends On:`, `Supersedes:`, and `Applies To:` lines when present, or falls back to stable workspace-derived refs like `contract://rfcs/auth/session-policy` with status `draft`.
+**`markdown_contract`**: Markdown files treated as inferred specs. Pituitary extracts metadata from `Ref:`, `Status:`, `Domain:`, `Depends On:`, `Supersedes:`, `Relates To:`, and `Applies To:` lines when present, or falls back to stable workspace-derived refs like `contract://rfcs/auth/session-policy` with status `draft`.
 
 **`issue`**: Optional adapter-defined kind used by the built-in GitHub source adapter. GitHub issues labeled like specs/RFCs are normalized as specs; other issues are normalized as docs.
 

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
+	"github.com/dusk-network/pituitary/internal/temporal"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -263,13 +264,17 @@ func CheckComplianceContext(ctx context.Context, cfg *config.Config, request Com
 	if err != nil {
 		return nil, err
 	}
+	normalizedAtDate, err := temporal.NormalizeAtDate(request.AtDate)
+	if err != nil {
+		return nil, err
+	}
 
 	repo, err := openAnalysisRepositoryContext(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 	defer repo.Close()
-	repo.atDate = strings.TrimSpace(request.AtDate)
+	repo.atDate = normalizedAtDate
 	repo.minConfidence = strings.TrimSpace(request.MinConfidence)
 
 	targets, err := loadComplianceTargetsContext(ctx, cfg, request)

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
+	"github.com/dusk-network/pituitary/internal/temporal"
 	stindex "github.com/dusk-network/stroma/v2/index"
 	"golang.org/x/sync/errgroup"
 )
@@ -219,13 +220,17 @@ func CheckDocDriftContext(ctx context.Context, cfg *config.Config, request DocDr
 	if err != nil {
 		return nil, err
 	}
+	normalizedAtDate, err := temporal.NormalizeAtDate(request.AtDate)
+	if err != nil {
+		return nil, err
+	}
 
 	repo, err := openAnalysisRepositoryContext(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 	defer repo.Close()
-	repo.atDate = strings.TrimSpace(request.AtDate)
+	repo.atDate = normalizedAtDate
 	repo.minConfidence = strings.TrimSpace(request.MinConfidence)
 
 	analyzer, err := newQualitativeAnalyzer(cfg.Runtime.Analysis)

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
+	"github.com/dusk-network/pituitary/internal/temporal"
 )
 
 const (
@@ -133,13 +134,17 @@ func AnalyzeImpactContext(ctx context.Context, cfg *config.Config, request Analy
 	if !isValidChangeType(request.ChangeType) {
 		return nil, fmt.Errorf("change_type %q is invalid", request.ChangeType)
 	}
+	normalizedAtDate, err := temporal.NormalizeAtDate(request.AtDate)
+	if err != nil {
+		return nil, err
+	}
 
 	repo, err := openAnalysisRepositoryContext(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 	defer repo.Close()
-	repo.atDate = strings.TrimSpace(request.AtDate)
+	repo.atDate = normalizedAtDate
 
 	candidate, err := loadCandidate(repo, OverlapRequest{
 		SpecRef:    request.SpecRef,

--- a/internal/analysis/impact_test.go
+++ b/internal/analysis/impact_test.go
@@ -63,6 +63,38 @@ func TestAnalyzeImpactFindsDependentSpecsRefsAndDocs(t *testing.T) {
 	}
 }
 
+func TestAnalyzeImpactIncludesOutgoingRelatesToSpecs(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := AnalyzeImpact(cfg, AnalyzeImpactRequest{
+		SpecRef:    "SPEC-055",
+		ChangeType: "accepted",
+	})
+	if err != nil {
+		t.Fatalf("AnalyzeImpact() error = %v", err)
+	}
+
+	for _, spec := range result.AffectedSpecs {
+		if spec.Ref != "SPEC-008" {
+			continue
+		}
+		if got, want := spec.Relationship, string(model.RelationRelatesTo); got != want {
+			t.Fatalf("SPEC-008 relationship = %q, want %q", got, want)
+		}
+		return
+	}
+	t.Fatalf("affected specs = %+v, want SPEC-008 from SPEC-055 relates_to edge", result.AffectedSpecs)
+}
+
 func TestAnalyzeImpactSupportsDraftSpecRecord(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -389,7 +389,7 @@ func loadSpecEdgesContext(ctx context.Context, db *sql.DB, specs map[string]spec
 	builder.WriteString(`
 SELECT from_ref, to_ref, edge_type
 FROM edges
-WHERE edge_type IN ('depends_on', 'supersedes', 'applies_to')`)
+WHERE edge_type IN ('depends_on', 'supersedes', 'relates_to', 'applies_to')`)
 	appendRefFilterClause(&builder, &args, "from_ref", refs)
 	builder.WriteString(`
 ORDER BY from_ref ASC, edge_type ASC, to_ref ASC`)
@@ -416,7 +416,7 @@ ORDER BY from_ref ASC, edge_type ASC, to_ref ASC`)
 		switch edgeType {
 		case "applies_to":
 			document.Record.AppliesTo = append(document.Record.AppliesTo, toRef)
-		case string(model.RelationDependsOn), string(model.RelationSupersedes):
+		case string(model.RelationDependsOn), string(model.RelationSupersedes), string(model.RelationRelatesTo):
 			document.Record.Relations = append(document.Record.Relations, model.Relation{
 				Type: model.RelationType(edgeType),
 				Ref:  toRef,

--- a/internal/analysis/repository_similarity.go
+++ b/internal/analysis/repository_similarity.go
@@ -349,7 +349,7 @@ func appendMinConfidenceEdgeClause(builder *strings.Builder, minConfidence strin
 }
 
 // appendTemporalEdgeClause adds WHERE conditions to filter edges by temporal
-// validity when atDate is non-empty.
+// validity when the normalized YYYY-MM-DD atDate is non-empty.
 func appendTemporalEdgeClause(builder *strings.Builder, args *[]any, atDate string) {
 	if atDate == "" {
 		return

--- a/internal/analysis/temporal_test.go
+++ b/internal/analysis/temporal_test.go
@@ -1,0 +1,70 @@
+package analysis
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/index"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+func TestAnalysisCommandsNormalizeTimestampAtDateAndRejectInvalidDates(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	timestamp := "2030-01-02T03:04:05Z"
+	if _, err := AnalyzeImpact(cfg, AnalyzeImpactRequest{
+		SpecRef:    "SPEC-042",
+		ChangeType: "accepted",
+		AtDate:     timestamp,
+	}); err != nil {
+		t.Fatalf("AnalyzeImpact(timestamp at_date) error = %v", err)
+	}
+	if _, err := CheckDocDrift(cfg, DocDriftRequest{
+		Scope:  "all",
+		AtDate: timestamp,
+	}); err != nil {
+		t.Fatalf("CheckDocDrift(timestamp at_date) error = %v", err)
+	}
+	if _, err := CheckCompliance(cfg, ComplianceRequest{
+		DiffText: complianceTemporalDiff(),
+		AtDate:   timestamp,
+	}); err != nil {
+		t.Fatalf("CheckCompliance(timestamp at_date) error = %v", err)
+	}
+
+	invalid := "2026-02-30"
+	if _, err := AnalyzeImpact(cfg, AnalyzeImpactRequest{SpecRef: "SPEC-042", ChangeType: "accepted", AtDate: invalid}); err == nil || !strings.Contains(err.Error(), "invalid at_date") {
+		t.Fatalf("AnalyzeImpact invalid at_date error = %v, want invalid at_date", err)
+	}
+	if _, err := CheckDocDrift(cfg, DocDriftRequest{Scope: "all", AtDate: invalid}); err == nil || !strings.Contains(err.Error(), "invalid at_date") {
+		t.Fatalf("CheckDocDrift invalid at_date error = %v, want invalid at_date", err)
+	}
+	if _, err := CheckCompliance(cfg, ComplianceRequest{DiffText: complianceTemporalDiff(), AtDate: invalid}); err == nil || !strings.Contains(err.Error(), "invalid at_date") {
+		t.Fatalf("CheckCompliance invalid at_date error = %v, want invalid at_date", err)
+	}
+}
+
+func complianceTemporalDiff() string {
+	return strings.TrimSpace(`
+diff --git a/src/api/middleware/ratelimiter.go b/src/api/middleware/ratelimiter.go
+index 0000000..1111111 100644
+--- a/src/api/middleware/ratelimiter.go
++++ b/src/api/middleware/ratelimiter.go
+@@ -0,0 +1,6 @@
++package middleware
++
++// Apply limits per tenant rather than per API key.
++// Enforce a default limit of 200 requests per minute.
++// Use a sliding-window limiter.
++func buildLimiter() {}
+`)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -852,8 +852,8 @@ func validateSource(cfg *Config, source *Source, index int, errs *validationErro
 	if filesystemSource && len(source.Files) > 0 && strings.TrimSpace(source.Path) == "" {
 		errs.add("%s.files: path is required when files are set", label)
 	}
-	validateSourcePatterns(errs, label, "include", source.Include)
-	validateSourcePatterns(errs, label, "exclude", source.Exclude)
+	validateSourcePatterns(errs, label, "include", source.Include, filesystemSource)
+	validateSourcePatterns(errs, label, "exclude", source.Exclude, filesystemSource)
 
 	if cfg.Workspace.RootPath == "" {
 		return
@@ -892,16 +892,46 @@ func validateSourceFiles(errs *validationErrors, label string, source *Source, f
 	source.Files = files
 }
 
-func validateSourcePatterns(errs *validationErrors, label string, field string, patterns []string) {
+func validateSourcePatterns(errs *validationErrors, label string, field string, patterns []string, filesystemSource bool) {
 	for _, pattern := range patterns {
-		if strings.TrimSpace(pattern) == "" {
+		trimmed := strings.TrimSpace(pattern)
+		if trimmed == "" {
 			errs.add("%s.%s: patterns must not be empty", label, field)
+			continue
+		}
+		if filesystemSource {
+			if err := validateFilesystemSourcePattern(trimmed); err != nil {
+				errs.add("%s.%s: invalid pattern %q: %v", label, field, pattern, err)
+				continue
+			}
 			continue
 		}
 		if _, err := pathpkg.Match(pattern, "placeholder"); err != nil {
 			errs.add("%s.%s: invalid pattern %q: %v", label, field, pattern, err)
 		}
 	}
+}
+
+func validateFilesystemSourcePattern(pattern string) error {
+	normalized := filepath.ToSlash(pattern)
+	if filepath.IsAbs(pattern) || pathpkg.IsAbs(normalized) {
+		return fmt.Errorf("must be relative to the source root")
+	}
+	parts := strings.Split(normalized, "/")
+	for _, part := range parts {
+		switch part {
+		case "":
+			return fmt.Errorf("must not contain empty path segments")
+		case ".", "..":
+			return fmt.Errorf("must not contain %q path segments", part)
+		case "**":
+			continue
+		}
+		if _, err := pathpkg.Match(part, "placeholder"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func resolveAndValidateSourcePaths(cfg *Config, errs *validationErrors, label string, source *Source, primaryRepoID string, filesystemSource bool) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -603,6 +603,63 @@ files = ["../guide.md"]
 	}
 }
 
+func TestLoadRejectsNonRelativeFilesystemSourcePatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{
+			name:    "absolute",
+			pattern: "/**/*.md",
+			want:    `source "docs".include: invalid pattern "/**/*.md": must be relative to the source root`,
+		},
+		{
+			name:    "empty segment",
+			pattern: "guides//*.md",
+			want:    `source "docs".include: invalid pattern "guides//*.md": must not contain empty path segments`,
+		},
+		{
+			name:    "parent segment",
+			pattern: "../*.md",
+			want:    `source "docs".include: invalid pattern "../*.md": must not contain ".." path segments`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := t.TempDir()
+			mustMkdirAll(t, filepath.Join(repo, "docs"))
+			configPath := filepath.Join(repo, "pituitary.toml")
+			writeFile(t, configPath, `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["`+tt.pattern+`"]
+`)
+
+			_, err := Load(configPath)
+			if err == nil {
+				t.Fatal("Load() error = nil, want invalid source pattern error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load() error = %q, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadRejectsJSONSourceWithoutPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/index/governed_by.go
+++ b/internal/index/governed_by.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/dusk-network/pituitary/internal/temporal"
 )
 
 // GoverningSpec reports one accepted spec that governs a set of code/config refs.
@@ -32,6 +34,10 @@ func GovernedByContext(ctx context.Context, dbPath string, path string, atDate s
 	normalized := normalizePath(path)
 	if normalized == "" || normalized == "." {
 		return nil, fmt.Errorf("governed_by requires a non-empty file path")
+	}
+	normalizedAtDate, err := temporal.NormalizeAtDate(atDate)
+	if err != nil {
+		return nil, err
 	}
 
 	db, err := OpenReadOnlyContext(ctx, dbPath)
@@ -88,7 +94,7 @@ WHERE a.kind = 'spec'
 	}
 	builder.WriteString(")")
 	appendMinConfidenceClause(&builder, &args, hasConfidence, minConfidence)
-	appendTemporalClause(&builder, &args, atDate)
+	appendTemporalClause(&builder, &args, normalizedAtDate)
 	if hasSource {
 		builder.WriteString("\nORDER BY e.edge_source, a.ref")
 	} else {
@@ -153,16 +159,11 @@ func ResolveGovernedRefsForPathContext(ctx context.Context, db *sql.DB, path str
 // appendTemporalClause adds a temporal validity filter to the SQL query when
 // atDate is non-empty. It filters for edges active at the given date using:
 // valid_from <= atDate AND (valid_to IS NULL OR valid_to >= atDate).
-// The date is normalized to YYYY-MM-DD for consistent TEXT comparison with
-// stored values.
+// The caller must pass a normalized YYYY-MM-DD value so TEXT comparison remains
+// consistent with stored values.
 func appendTemporalClause(builder *strings.Builder, args *[]any, atDate string) {
-	atDate = strings.TrimSpace(atDate)
 	if atDate == "" {
 		return
-	}
-	// Normalize: truncate to date-only (YYYY-MM-DD) for consistent comparison.
-	if len(atDate) > 10 {
-		atDate = atDate[:10]
 	}
 	builder.WriteString(` AND (e.valid_from IS NULL OR e.valid_from <= ?)`)
 	*args = append(*args, atDate)

--- a/internal/index/rebuild_test.go
+++ b/internal/index/rebuild_test.go
@@ -1258,6 +1258,17 @@ func TestGovernedByTemporalFilter(t *testing.T) {
 		t.Errorf("future query returned %d specs, expected %d", len(futureResult.Specs), len(result.Specs))
 	}
 
+	// Timezone-aware timestamps normalize through UTC so governed-by matches
+	// analysis query semantics.
+	futureTimestamp := futureDate + "T16:33:49Z"
+	timestampResult, err := GovernedByContext(context.Background(), cfg.Workspace.ResolvedIndexPath, "src/api/middleware/ratelimiter.go", futureTimestamp, "")
+	if err != nil {
+		t.Fatalf("GovernedBy (future timestamp): %v", err)
+	}
+	if len(timestampResult.Specs) != len(futureResult.Specs) {
+		t.Errorf("timestamp query returned %d specs, expected %d", len(timestampResult.Specs), len(futureResult.Specs))
+	}
+
 	// With a very old date (before edges existed), should return no results
 	// because valid_from was set to the rebuild timestamp.
 	pastDate := "1970-01-01"
@@ -1267,6 +1278,10 @@ func TestGovernedByTemporalFilter(t *testing.T) {
 	}
 	if len(pastResult.Specs) != 0 {
 		t.Errorf("past query returned %d specs, expected 0", len(pastResult.Specs))
+	}
+
+	if _, err := GovernedByContext(context.Background(), cfg.Workspace.ResolvedIndexPath, "src/api/middleware/ratelimiter.go", "2026-02-30", ""); err == nil {
+		t.Fatal("GovernedBy invalid date error = nil, want validation error")
 	}
 }
 

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -549,6 +549,7 @@ func scoreMarkdownContractCandidate(pathTokens map[string]struct{}, titleLower s
 			strings.HasPrefix(trimmed, "Domain:"),
 			strings.HasPrefix(trimmed, "Depends On:"),
 			strings.HasPrefix(trimmed, "Supersedes:"),
+			strings.HasPrefix(trimmed, "Relates To:"),
 			strings.HasPrefix(trimmed, "Applies To:"):
 			metadataSignals++
 		}

--- a/internal/source/explain.go
+++ b/internal/source/explain.go
@@ -410,11 +410,98 @@ func evaluateSourcePathSelection(source config.Source, relPath string) (sourcePa
 }
 
 func matchSourceSelector(kind, pattern, relPath string) (bool, error) {
-	ok, err := pathpkg.Match(pattern, relPath)
+	ok, err := matchSourceSelectorPattern(pattern, relPath)
 	if err != nil {
 		return false, fmt.Errorf("%s pattern %q is invalid: %w", kind, pattern, err)
 	}
 	return ok, nil
+}
+
+func matchSourceSelectorPattern(pattern, relPath string) (bool, error) {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	relPath = filepath.ToSlash(strings.TrimSpace(relPath))
+	patternParts, err := splitSelectorPath(pattern)
+	if err != nil {
+		return false, err
+	}
+	hasRecursiveSegment := false
+	for _, part := range patternParts {
+		if part == "**" {
+			hasRecursiveSegment = true
+			continue
+		}
+		if _, err := pathpkg.Match(part, "placeholder"); err != nil {
+			return false, err
+		}
+	}
+	if !hasRecursiveSegment {
+		return pathpkg.Match(pattern, relPath)
+	}
+	pathParts, err := splitSelectorPath(relPath)
+	if err != nil {
+		return false, err
+	}
+	return matchSourceSelectorParts(patternParts, pathParts)
+}
+
+func matchSourceSelectorParts(patternParts, pathParts []string) (bool, error) {
+	type matchState struct {
+		patternIndex int
+		pathIndex    int
+	}
+	memo := make(map[matchState]bool)
+	var match func(patternIndex, pathIndex int) (bool, error)
+	match = func(patternIndex, pathIndex int) (bool, error) {
+		state := matchState{patternIndex: patternIndex, pathIndex: pathIndex}
+		if failed, ok := memo[state]; ok && failed {
+			return false, nil
+		}
+		if patternIndex == len(patternParts) {
+			return pathIndex == len(pathParts), nil
+		}
+		if patternParts[patternIndex] == "**" {
+			for nextPathIndex := pathIndex; nextPathIndex <= len(pathParts); nextPathIndex++ {
+				if ok, err := match(patternIndex+1, nextPathIndex); ok || err != nil {
+					return ok, err
+				}
+			}
+			memo[state] = true
+			return false, nil
+		}
+		if pathIndex == len(pathParts) {
+			memo[state] = true
+			return false, nil
+		}
+		ok, err := pathpkg.Match(patternParts[patternIndex], pathParts[pathIndex])
+		if err != nil || !ok {
+			if err == nil {
+				memo[state] = true
+			}
+			return ok, err
+		}
+		ok, err = match(patternIndex+1, pathIndex+1)
+		if err == nil && !ok {
+			memo[state] = true
+		}
+		return ok, err
+	}
+	return match(0, 0)
+}
+
+func splitSelectorPath(value string) ([]string, error) {
+	if value == "" {
+		return nil, fmt.Errorf("value must not be empty")
+	}
+	parts := strings.Split(value, "/")
+	for _, part := range parts {
+		if part == "" {
+			return nil, fmt.Errorf("must be a relative path without empty segments")
+		}
+		if part == "." || part == ".." {
+			return nil, fmt.Errorf("must not contain %q path segments", part)
+		}
+	}
+	return parts, nil
 }
 
 func populateSelectionMatches(explanation *SourceFileExplanation, selection sourcePathSelection) {

--- a/internal/source/explain_test.go
+++ b/internal/source/explain_test.go
@@ -100,6 +100,8 @@ Status: accepted
 Domain: identity
 Depends On:
 - SPEC-042
+Relates To:
+- SPEC-055
 Applies To:
 - code://src/auth/session_policy.go
 
@@ -131,6 +133,9 @@ All interactive sessions must use tenant-scoped policy evaluation.
 	}
 	if got, want := result.Sources[0].InferredSpec.Status, "accepted"; got != want {
 		t.Fatalf("inferred status = %q, want %q", got, want)
+	}
+	if got, want := result.Sources[0].InferredSpec.RelatesTo, []string{"SPEC-055"}; !equalStrings(got, want) {
+		t.Fatalf("inferred relates_to = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -684,6 +684,7 @@ func inferMarkdownContractFields(body []byte) markdownContractFields {
 	fields.Domain = strings.TrimSpace(fields.Domain)
 	fields.DependsOn = uniqueStringValues(fields.DependsOn)
 	fields.Supersedes = uniqueStringValues(fields.Supersedes)
+	fields.RelatesTo = uniqueStringValues(fields.RelatesTo)
 	fields.AppliesTo = uniqueStringValues(fields.AppliesTo)
 	return fields
 }
@@ -697,6 +698,8 @@ func normalizeMarkdownContractKey(key string) string {
 		return "ref"
 	case "dependson", "related", "related_refs":
 		return "depends_on"
+	case "relatesto", "related_to":
+		return "relates_to"
 	case "appliesto":
 		return "applies_to"
 	default:
@@ -706,7 +709,7 @@ func normalizeMarkdownContractKey(key string) string {
 
 func isMarkdownContractField(key string) bool {
 	switch key {
-	case "id", "ref", "status", "domain", "depends_on", "supersedes", "applies_to":
+	case "id", "ref", "status", "domain", "depends_on", "supersedes", "relates_to", "applies_to":
 		return true
 	default:
 		return false
@@ -715,7 +718,7 @@ func isMarkdownContractField(key string) bool {
 
 func isMarkdownContractListField(key string) bool {
 	switch key {
-	case "depends_on", "supersedes", "applies_to":
+	case "depends_on", "supersedes", "relates_to", "applies_to":
 		return true
 	default:
 		return false

--- a/internal/source/filesystem_test.go
+++ b/internal/source/filesystem_test.go
@@ -772,6 +772,154 @@ files = ["docs/guides/api-rate-limits.md", "docs/runbooks/rate-limit-rollout.md"
 	}
 }
 
+func TestSourceSelectorsSupportRecursiveDoublestar(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "pituitary.toml"), `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["**/*.md"]
+exclude = ["archive/**"]
+`)
+	mustWriteFile(t, filepath.Join(repo, "docs", "root.md"), "# Root\n")
+	mustWriteFile(t, filepath.Join(repo, "docs", "guides", "api.md"), "# API\n")
+	mustWriteFile(t, filepath.Join(repo, "docs", "guides", "deep", "nested.md"), "# Nested\n")
+	mustWriteFile(t, filepath.Join(repo, "docs", "archive", "old.md"), "# Old\n")
+
+	cfg, err := config.Load(filepath.Join(repo, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("LoadFromConfig() error = %v", err)
+	}
+	refs := make([]string, 0, len(result.Docs))
+	for _, doc := range result.Docs {
+		refs = append(refs, doc.Ref)
+	}
+	sort.Strings(refs)
+	wantRefs := []string{"doc://guides/api", "doc://guides/deep/nested", "doc://root"}
+	if !equalStrings(refs, wantRefs) {
+		t.Fatalf("doc refs = %#v, want %#v", refs, wantRefs)
+	}
+
+	preview, err := PreviewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("PreviewFromConfig() error = %v", err)
+	}
+	paths := make([]string, 0, len(preview.Sources[0].Items))
+	for _, item := range preview.Sources[0].Items {
+		paths = append(paths, item.Path)
+	}
+	sort.Strings(paths)
+	wantPaths := []string{"docs/guides/api.md", "docs/guides/deep/nested.md", "docs/root.md"}
+	if !equalStrings(paths, wantPaths) {
+		t.Fatalf("preview paths = %#v, want %#v", paths, wantPaths)
+	}
+
+	rootExplain, err := ExplainFile(cfg, filepath.Join(repo, "docs", "root.md"))
+	if err != nil {
+		t.Fatalf("ExplainFile(root) error = %v", err)
+	}
+	if got, want := rootExplain.Sources[0].Reason, explainReasonIndexedMarkdownDoc; got != want {
+		t.Fatalf("root explain reason = %q, want %q", got, want)
+	}
+
+	archivedExplain, err := ExplainFile(cfg, filepath.Join(repo, "docs", "archive", "old.md"))
+	if err != nil {
+		t.Fatalf("ExplainFile(archive) error = %v", err)
+	}
+	if got, want := archivedExplain.Sources[0].Reason, explainReasonExcludedBySelector; got != want {
+		t.Fatalf("archive explain reason = %q, want %q", got, want)
+	}
+}
+
+func TestSourceSelectorsKeepSingleStarSegmentLocal(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "pituitary.toml"), `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md"]
+`)
+	mustWriteFile(t, filepath.Join(repo, "docs", "root.md"), "# Root\n")
+	mustWriteFile(t, filepath.Join(repo, "docs", "guides", "api.md"), "# API\n")
+	mustWriteFile(t, filepath.Join(repo, "docs", "guides", "deep", "nested.md"), "# Nested\n")
+
+	cfg, err := config.Load(filepath.Join(repo, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("LoadFromConfig() error = %v", err)
+	}
+	if got, want := len(result.Docs), 1; got != want {
+		t.Fatalf("doc count = %d, want %d", got, want)
+	}
+	if got, want := result.Docs[0].Ref, "doc://guides/api"; got != want {
+		t.Fatalf("doc ref = %q, want %q", got, want)
+	}
+
+	nestedExplain, err := ExplainFile(cfg, filepath.Join(repo, "docs", "guides", "deep", "nested.md"))
+	if err != nil {
+		t.Fatalf("ExplainFile(nested) error = %v", err)
+	}
+	if got, want := nestedExplain.Sources[0].Reason, explainReasonNotMatchedByInclude; got != want {
+		t.Fatalf("nested explain reason = %q, want %q", got, want)
+	}
+}
+
+func TestSourceSelectorsRejectInvalidRelativePatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"/**/*.md",
+		"guides//*.md",
+		"guides/../*.md",
+	}
+	for _, pattern := range tests {
+		pattern := pattern
+		t.Run(pattern, func(t *testing.T) {
+			t.Parallel()
+			if _, err := matchSourceSelector("include", pattern, "guides/api.md"); err == nil {
+				t.Fatalf("matchSourceSelector(%q) error = nil, want invalid pattern error", pattern)
+			}
+		})
+	}
+}
+
+func TestSourceSelectorsMemoizeRepeatedRecursiveSegments(t *testing.T) {
+	t.Parallel()
+
+	ok, err := matchSourceSelectorPattern("**/**/nested.md", "guides/deep/nested.md")
+	if err != nil {
+		t.Fatalf("matchSourceSelectorPattern() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("matchSourceSelectorPattern() = false, want true")
+	}
+}
+
 func TestLoadFromConfigFiltersSpecBundlesByExplicitFiles(t *testing.T) {
 	t.Parallel()
 
@@ -834,6 +982,9 @@ domain: identity
 supersedes: SPEC-008
 depends_on:
   - SPEC-042
+relates_to:
+  - SPEC-055
+  - SPEC-055
 applies_to:
   - code://src/auth/session_policy.go
   - config://config/auth/session.yaml
@@ -875,6 +1026,12 @@ All interactive sessions must use tenant-scoped policy evaluation.
 	}
 	if !hasRelation(spec.Relations, model.RelationDependsOn, "SPEC-042") {
 		t.Fatalf("relations = %+v, want depends_on SPEC-042", spec.Relations)
+	}
+	if !hasRelation(spec.Relations, model.RelationRelatesTo, "SPEC-055") {
+		t.Fatalf("relations = %+v, want relates_to SPEC-055", spec.Relations)
+	}
+	if got, want := relationCount(spec.Relations, model.RelationRelatesTo, "SPEC-055"), 1; got != want {
+		t.Fatalf("relates_to SPEC-055 relation count = %d, want %d", got, want)
 	}
 	if got, want := spec.AppliesTo, []string{"code://src/auth/session_policy.go", "config://config/auth/session.yaml"}; !equalStrings(got, want) {
 		t.Fatalf("applies_to = %#v, want %#v", got, want)
@@ -1176,12 +1333,17 @@ func mustWriteFile(t *testing.T, path, content string) {
 }
 
 func hasRelation(relations []model.Relation, typ model.RelationType, ref string) bool {
+	return relationCount(relations, typ, ref) > 0
+}
+
+func relationCount(relations []model.Relation, typ model.RelationType, ref string) int {
+	count := 0
 	for _, relation := range relations {
 		if relation.Type == typ && relation.Ref == ref {
-			return true
+			count++
 		}
 	}
-	return false
+	return count
 }
 
 func equalStrings(got, want []string) bool {

--- a/internal/temporal/at_date.go
+++ b/internal/temporal/at_date.go
@@ -1,0 +1,62 @@
+package temporal
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const atDateLayout = "2006-01-02"
+
+// NormalizeAtDate normalizes point-in-time query input to YYYY-MM-DD.
+// It accepts plain dates and timezone-aware timestamps. Timestamps are
+// converted to UTC before extracting the comparison date.
+func NormalizeAtDate(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", nil
+	}
+	if len(trimmed) == len(atDateLayout) {
+		parsed, err := time.Parse(atDateLayout, trimmed)
+		if err != nil || parsed.Format(atDateLayout) != trimmed {
+			return "", invalidAtDateError(value)
+		}
+		return trimmed, nil
+	}
+
+	parsed, err := parseAtDateTimestamp(normalizeTimestampSeparator(trimmed))
+	if err != nil {
+		return "", invalidAtDateError(value)
+	}
+	return parsed.UTC().Format(atDateLayout), nil
+}
+
+func normalizeTimestampSeparator(value string) string {
+	if len(value) <= len(atDateLayout) || value[len(atDateLayout)] != 't' {
+		return value
+	}
+	normalized := []byte(value)
+	normalized[len(atDateLayout)] = 'T'
+	return string(normalized)
+}
+
+func parseAtDateTimestamp(value string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05Z07:00",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05 Z07:00",
+		"2006-01-02 15:04:05.999999999 Z07:00",
+	}
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported timestamp")
+}
+
+func invalidAtDateError(value string) error {
+	return fmt.Errorf("invalid at_date %q: expected YYYY-MM-DD or a timezone-aware timestamp", value)
+}

--- a/internal/temporal/at_date_test.go
+++ b/internal/temporal/at_date_test.go
@@ -1,0 +1,50 @@
+package temporal
+
+import "testing"
+
+func TestNormalizeAtDate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "plain date", input: "2026-04-29", want: "2026-04-29"},
+		{name: "trimmed plain date", input: " 2026-04-29 ", want: "2026-04-29"},
+		{name: "rfc3339 timestamp", input: "2026-04-29T16:33:49Z", want: "2026-04-29"},
+		{name: "lowercase t timestamp", input: "2026-04-29t16:33:49Z", want: "2026-04-29"},
+		{name: "space timestamp with zone", input: "2026-04-29 16:33:49+02:00", want: "2026-04-29"},
+		{name: "timestamp normalized to previous UTC date", input: "2026-04-29T00:30:00+02:00", want: "2026-04-28"},
+		{name: "timestamp normalized to next UTC date", input: "2026-04-29T23:30:00-02:00", want: "2026-04-30"},
+		{name: "fractional timestamp", input: "2026-04-29T16:33:49.123456789Z", want: "2026-04-29"},
+		{name: "invalid text", input: "not-a-date", wantErr: true},
+		{name: "invalid calendar date", input: "2026-02-30", wantErr: true},
+		{name: "compact date", input: "20260429", wantErr: true},
+		{name: "bad timestamp separator", input: "2026-04-29x16:33:49Z", wantErr: true},
+		{name: "timezone missing", input: "2026-04-29 16:33:49", wantErr: true},
+		{name: "malformed timestamp suffix", input: "2026-04-29Tgarbage", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NormalizeAtDate(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeAtDate(%q) error = nil, want error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeAtDate(%q) error = %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeAtDate(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- rehydrate relates_to edges into analysis spec records so impact can traverse outgoing relates_to relationships
- add recursive filesystem selector support with explicit relative-pattern validation and memoized ** matching
- share at_date normalization across analysis and governed-by, including timezone-aware UTC timestamp handling
- infer relates_to metadata from markdown_contract sources and update configuration docs

Fixes #374
Fixes #376
Fixes #380

## Tests
- go test ./...