### PR TITLE
Improve config recovery guidance

### DIFF
--- a/cmd/config_error.go
+++ b/cmd/config_error.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/dusk-network/pituitary/internal/app"
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+func configErrorIssue(message string) cliIssue {
+	return cliIssue{
+		Code:    app.CodeConfigError,
+		Message: message,
+	}
+}
+
+func configLoadIssue(message string, resolution *configResolution) cliIssue {
+	return enrichSelectedConfigLoadIssue(cliIssue{
+		Code:    app.CodeConfigError,
+		Message: message,
+		Details: map[string]any{
+			app.IssueDetailPhase: app.IssuePhaseConfigLoad,
+		},
+	}, resolution)
+}
+
+func enrichAppConfigLoadIssue(issue cliIssue, resolution *configResolution) cliIssue {
+	if !isConfigLoadIssue(issue) {
+		return issue
+	}
+	return enrichSelectedConfigLoadIssue(issue, resolution)
+}
+
+func isConfigLoadIssue(issue cliIssue) bool {
+	if issue.Code != app.CodeConfigError || issue.Details == nil {
+		return false
+	}
+	phase, _ := issue.Details[app.IssueDetailPhase].(string)
+	return phase == app.IssuePhaseConfigLoad
+}
+
+func enrichSelectedConfigLoadIssue(issue cliIssue, resolution *configResolution) cliIssue {
+	if resolution == nil {
+		return issue
+	}
+	selected := selectedConfigCandidate(resolution)
+	alternative, hasAlternative := firstValidShadowedConfigCandidate(resolution)
+	if selected.Path == "" && !hasAlternative {
+		return issue
+	}
+
+	lines := make([]string, 0, 2)
+	if selected.Path != "" {
+		lines = append(lines, selectedConfigLoadLine(selected))
+	}
+	if hasAlternative {
+		lines = append(lines, validShadowedConfigLine(selected, alternative))
+	}
+	if len(lines) == 0 {
+		return issue
+	}
+
+	message := strings.TrimRight(issue.Message, "\n")
+	if message != "" {
+		message += "\n"
+	}
+	issue.Message = message + strings.Join(lines, "\n")
+
+	if issue.Details == nil {
+		issue.Details = make(map[string]any)
+	}
+	issue.Details["config_resolution"] = configResolutionDetails(selected, alternative, hasAlternative)
+	return issue
+}
+
+func selectedConfigCandidate(resolution *configResolution) configResolutionCandidate {
+	if resolution == nil {
+		return configResolutionCandidate{}
+	}
+	for _, candidate := range resolution.Candidates {
+		if candidate.Status == "selected" {
+			return candidate
+		}
+	}
+	return configResolutionCandidate{}
+}
+
+func firstValidShadowedConfigCandidate(resolution *configResolution) (configResolutionCandidate, bool) {
+	if resolution == nil {
+		return configResolutionCandidate{}, false
+	}
+	selected := selectedConfigCandidate(resolution)
+	for _, candidate := range resolution.Candidates {
+		if candidate.Status != "shadowed" || strings.TrimSpace(candidate.Path) == "" {
+			continue
+		}
+		if sameConfigPath(candidate.Path, selected.Path) {
+			continue
+		}
+		if _, err := config.Load(candidate.Path); err == nil {
+			return candidate, true
+		}
+	}
+	return configResolutionCandidate{}, false
+}
+
+func selectedConfigLoadLine(selected configResolutionCandidate) string {
+	if selected.Source == "" {
+		return fmt.Sprintf("selected config: %s", displayConfigPath(selected.Path))
+	}
+	return fmt.Sprintf("selected config from %s: %s", configSourceLabel(selected.Source), displayConfigPath(selected.Path))
+}
+
+func validShadowedConfigLine(selected, alternative configResolutionCandidate) string {
+	if selected.Source == configSourceDiscovery && alternative.Source == configSourceDiscovery {
+		return fmt.Sprintf("shadowed config also loads; retry with `--config %s`", displayConfigPath(alternative.Path))
+	}
+	return fmt.Sprintf("another config candidate also loads; inspect it or retry with `--config %s`", displayConfigPath(alternative.Path))
+}
+
+func configResolutionDetails(selected, alternative configResolutionCandidate, hasAlternative bool) map[string]any {
+	details := make(map[string]any)
+	if strings.TrimSpace(selected.Path) != "" {
+		details["selected"] = configResolutionCandidateDetail(selected)
+	}
+	if hasAlternative {
+		details["valid_shadowed"] = configResolutionCandidateDetail(alternative)
+	}
+	return details
+}
+
+func configResolutionCandidateDetail(candidate configResolutionCandidate) map[string]any {
+	detail := map[string]any{
+		"path":   filepath.ToSlash(candidate.Path),
+		"source": candidate.Source,
+		"status": candidate.Status,
+	}
+	if candidate.Precedence != 0 {
+		detail["precedence"] = candidate.Precedence
+	}
+	return detail
+}
+
+func displayConfigPath(path string) string {
+	return filepath.ToSlash(path)
+}
+
+func sameConfigPath(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if absA, err := filepath.Abs(a); err == nil {
+		a = absA
+	}
+	if absB, err := filepath.Abs(b); err == nil {
+		b = absB
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}

--- a/cmd/config_path_test.go
+++ b/cmd/config_path_test.go
@@ -3,11 +3,14 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
 )
 
 func TestRunIndexSupportsGlobalConfigFlag(t *testing.T) {
@@ -323,6 +326,172 @@ func TestResolveCommandConfigPathExplainsDiscoveredShadowedConfig(t *testing.T) 
 	if !strings.Contains(resolution.Reason, filepath.ToSlash(filepath.Join(resolvedRepo, ".pituitary", "pituitary.toml"))) ||
 		!strings.Contains(resolution.Reason, filepath.ToSlash(filepath.Join(resolvedRepo, "pituitary.toml"))) {
 		t.Fatalf("reason = %q, want selected and shadowed discovered paths", resolution.Reason)
+	}
+}
+
+func mustWriteBasicPituitaryConfigCmd(t *testing.T, path string, schemaVersion int) {
+	t.Helper()
+
+	schemaLine := ""
+	if schemaVersion > 0 {
+		schemaLine = fmt.Sprintf("schema_version = %d\n\n", schemaVersion)
+	}
+	mustWriteFileCmd(t, path, schemaLine+`
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+}
+
+func TestStatusConfigErrorSuggestsValidShadowedConfig(t *testing.T) {
+	repo := t.TempDir()
+	resolvedRepo, resolveErr := filepath.EvalSymlinks(repo)
+	if resolveErr != nil {
+		t.Fatalf("filepath.EvalSymlinks(%q) error = %v", repo, resolveErr)
+	}
+	olderSchemaVersion := config.CurrentSchemaVersion - 1
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(repo, ".pituitary", "pituitary.toml"), olderSchemaVersion)
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(repo, "pituitary.toml"), config.CurrentSchemaVersion)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runStatus([]string{}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runStatus() exit code = %d, want 2", exitCode)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, fmt.Sprintf("unsupported schema_version %d", olderSchemaVersion)) {
+		t.Fatalf("stderr = %q, want unsupported schema detail", out)
+	}
+	if !strings.Contains(out, "selected config from working-directory search: "+filepath.ToSlash(filepath.Join(resolvedRepo, ".pituitary", "pituitary.toml"))) {
+		t.Fatalf("stderr = %q, want selected config detail", out)
+	}
+	if !strings.Contains(out, "shadowed config also loads; retry with `--config "+filepath.ToSlash(filepath.Join(resolvedRepo, "pituitary.toml"))+"`") {
+		t.Fatalf("stderr = %q, want valid shadowed config hint", out)
+	}
+	if strings.Contains(out, "migrate-config") {
+		t.Fatalf("stderr = %q, want no migrate-config hint for unsupported schema", out)
+	}
+}
+
+func TestSharedCommandConfigErrorSuggestsValidShadowedConfig(t *testing.T) {
+	repo := t.TempDir()
+	resolvedRepo, resolveErr := filepath.EvalSymlinks(repo)
+	if resolveErr != nil {
+		t.Fatalf("filepath.EvalSymlinks(%q) error = %v", repo, resolveErr)
+	}
+	olderSchemaVersion := config.CurrentSchemaVersion - 1
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(repo, ".pituitary", "pituitary.toml"), olderSchemaVersion)
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(repo, "pituitary.toml"), config.CurrentSchemaVersion)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runSearchSpecs([]string{"--query", "rate limiting"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runSearchSpecs() exit code = %d, want 2", exitCode)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, fmt.Sprintf("unsupported schema_version %d", olderSchemaVersion)) {
+		t.Fatalf("stderr = %q, want unsupported schema detail", out)
+	}
+	if !strings.Contains(out, "shadowed config also loads; retry with `--config "+filepath.ToSlash(filepath.Join(resolvedRepo, "pituitary.toml"))+"`") {
+		t.Fatalf("stderr = %q, want valid shadowed config hint", out)
+	}
+}
+
+func TestExplicitConfigErrorSuggestsAlternativeWithoutShadowedWording(t *testing.T) {
+	repo := t.TempDir()
+	resolvedRepo, resolveErr := filepath.EvalSymlinks(repo)
+	if resolveErr != nil {
+		t.Fatalf("filepath.EvalSymlinks(%q) error = %v", repo, resolveErr)
+	}
+	badConfigPath := filepath.Join(resolvedRepo, "stale.toml")
+	mustWriteBasicPituitaryConfigCmd(t, badConfigPath, config.CurrentSchemaVersion-1)
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(resolvedRepo, "pituitary.toml"), config.CurrentSchemaVersion)
+	mustMkdirAllCmd(t, filepath.Join(resolvedRepo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, resolvedRepo, func() int {
+		return runStatus([]string{"--config", badConfigPath}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runStatus() exit code = %d, want 2", exitCode)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "selected config from command-local --config: "+filepath.ToSlash(badConfigPath)) {
+		t.Fatalf("stderr = %q, want explicit selected config detail", out)
+	}
+	if !strings.Contains(out, "another config candidate also loads; inspect it or retry with `--config "+filepath.ToSlash(filepath.Join(resolvedRepo, "pituitary.toml"))+"`") {
+		t.Fatalf("stderr = %q, want non-presumptive alternative config hint", out)
+	}
+	if strings.Contains(out, "shadowed config is valid") {
+		t.Fatalf("stderr = %q, want no generic shadowed-is-valid wording for explicit config", out)
+	}
+}
+
+func TestMigrateConfigErrorDoesNotSuggestShadowedConfig(t *testing.T) {
+	repo := t.TempDir()
+	olderSchemaVersion := config.CurrentSchemaVersion - 1
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(repo, ".pituitary", "pituitary.toml"), olderSchemaVersion)
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(repo, "pituitary.toml"), config.CurrentSchemaVersion)
+	mustMkdirAllCmd(t, filepath.Join(repo, "specs"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runMigrateConfig([]string{"--path", ".pituitary/pituitary.toml"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runMigrateConfig() exit code = %d, want 2", exitCode)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, fmt.Sprintf("cannot migrate unsupported schema_version %d automatically", olderSchemaVersion)) {
+		t.Fatalf("stderr = %q, want unsupported migration detail", out)
+	}
+	if strings.Contains(out, "--config") || strings.Contains(out, "selected config") {
+		t.Fatalf("stderr = %q, want no config-resolution recovery hint", out)
+	}
+}
+
+func TestMissingIndexConfigErrorDoesNotSuggestShadowedConfig(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(repo, ".pituitary", "pituitary.toml"), config.CurrentSchemaVersion)
+	mustWriteBasicPituitaryConfigCmd(t, filepath.Join(repo, "pituitary.toml"), config.CurrentSchemaVersion)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "checkout", "spec.toml"), `
+id = "checkout"
+title = "Checkout"
+status = "accepted"
+domain = "payments"
+`)
+	mustWriteFileCmd(t, filepath.Join(repo, "specs", "checkout", "body.md"), "# Checkout\n")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := withWorkingDir(t, repo, func() int {
+		return runReviewSpec([]string{"--path", "specs/checkout/body.md"}, &stdout, &stderr)
+	})
+	if exitCode != 2 {
+		t.Fatalf("runReviewSpec() exit code = %d, want 2", exitCode)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "index") {
+		t.Fatalf("stderr = %q, want missing-index detail", out)
+	}
+	if strings.Contains(out, "--config") || strings.Contains(out, "selected config") {
+		t.Fatalf("stderr = %q, want no config-resolution recovery hint", out)
 	}
 }
 

--- a/cmd/explain_file.go
+++ b/cmd/explain_file.go
@@ -39,6 +39,7 @@ func runExplainFileContext(ctx context.Context, args []string, stdout, stderr io
 					return req, nil, &app.Issue{
 						Code:     "config_error",
 						Message:  "invalid config:\n" + err.Error(),
+						Details:  map[string]any{app.IssueDetailPhase: app.IssuePhaseConfigLoad},
 						ExitCode: 2,
 					}
 				}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -111,21 +111,16 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 		}, 2)
 	}
 
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	resolvedConfigPath, resolution, err := resolveCommandConfigPathWithResolution(ctx, configPath)
 	if err != nil {
-		return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
+		return writeCLIError(stdout, stderr, format, "index", request, configErrorIssue(err.Error()), 2)
 	}
 
 	cfg, err := config.Load(resolvedConfigPath)
 	if err != nil {
-		return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
-			Code:    "config_error",
-			Message: "invalid config:\n" + err.Error(),
-		}, 2)
+		return writeCLIError(stdout, stderr, format, "index", request, configLoadIssue("invalid config:\n"+err.Error(), resolution), 2)
 	}
+	emitMultirepoShadowWarning(resolution)
 	records, err := source.LoadFromConfigWithOptions(cfg, source.LoadOptions{Logger: cliLoggerFromContext(ctx)})
 	if err != nil {
 		return writeCLIError(stdout, stderr, format, "index", request, cliIssue{

--- a/cmd/preview_sources.go
+++ b/cmd/preview_sources.go
@@ -56,21 +56,16 @@ func runPreviewSourcesContext(ctx context.Context, args []string, stdout, stderr
 
 	request := previewSourcesRequest{Verbose: verbose}
 
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	resolvedConfigPath, resolution, err := resolveCommandConfigPathWithResolution(ctx, configPath)
 	if err != nil {
-		return writeCLIError(stdout, stderr, format, "preview-sources", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
+		return writeCLIError(stdout, stderr, format, "preview-sources", request, configErrorIssue(err.Error()), 2)
 	}
 
 	cfg, err := config.Load(resolvedConfigPath)
 	if err != nil {
-		return writeCLIError(stdout, stderr, format, "preview-sources", request, cliIssue{
-			Code:    "config_error",
-			Message: "invalid config:\n" + err.Error(),
-		}, 2)
+		return writeCLIError(stdout, stderr, format, "preview-sources", request, configLoadIssue("invalid config:\n"+err.Error(), resolution), 2)
 	}
+	emitMultirepoShadowWarning(resolution)
 
 	result, err := source.PreviewFromConfigWithOptions(cfg, source.PreviewOptions{
 		Logger:  cliLoggerFromContext(ctx),

--- a/cmd/run_command.go
+++ b/cmd/run_command.go
@@ -118,7 +118,13 @@ func (e *cliIssueError) Error() string {
 // default validation_error.
 func configLoadError(err error) error {
 	return &cliIssueError{
-		issue:    cliIssue{Code: "config_error", Message: err.Error()},
+		issue: cliIssue{
+			Code:    app.CodeConfigError,
+			Message: err.Error(),
+			Details: map[string]any{
+				app.IssueDetailPhase: app.IssuePhaseConfigLoad,
+			},
+		},
 		exitCode: 2,
 	}
 }
@@ -230,15 +236,12 @@ func runCommand[Req any, Res any](
 		}, 2)
 	}
 
-	resolvedConfigPath, err := resolveCommandConfigPath(ctx, configPath)
+	resolvedConfigPath, resolution, err := resolveCommandConfigPathWithResolution(ctx, configPath)
 	if err != nil {
 		// Standalone commands tolerate a missing workspace config; callbacks
 		// that can opportunistically use a config must handle an empty path.
 		if !plan.Options.Standalone {
-			return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
-				Code:    "config_error",
-				Message: err.Error(),
-			}, 2)
+			return writeCLIError(stdout, stderr, format, plan.Name, nil, configErrorIssue(err.Error()), 2)
 		}
 		resolvedConfigPath = ""
 	}
@@ -256,10 +259,7 @@ func runCommand[Req any, Res any](
 		if plan.Options.ConfigForFile {
 			loaded, cfgErr := config.Load(resolvedConfigPath)
 			if cfgErr != nil {
-				return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
-					Code:    "config_error",
-					Message: cfgErr.Error(),
-				}, 2)
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, configLoadIssue(cfgErr.Error(), resolution), 2)
 			}
 			cfg = loaded
 		}
@@ -270,7 +270,7 @@ func runCommand[Req any, Res any](
 				envelopeReq = *loaded
 			}
 			if issue, exitCode, ok := asCliIssue(loadErr); ok {
-				return writeCLIError(stdout, stderr, format, plan.Name, envelopeReq, issue, exitCode)
+				return writeCLIError(stdout, stderr, format, plan.Name, envelopeReq, enrichAppConfigLoadIssue(issue, resolution), exitCode)
 			}
 			return writeCLIError(stdout, stderr, format, plan.Name, envelopeReq, cliIssue{
 				Code:    "validation_error",
@@ -292,17 +292,14 @@ func runCommand[Req any, Res any](
 		if plan.Options.ConfigForFlags {
 			loaded, cfgErr := config.Load(resolvedConfigPath)
 			if cfgErr != nil {
-				return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
-					Code:    "config_error",
-					Message: cfgErr.Error(),
-				}, 2)
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, configLoadIssue(cfgErr.Error(), resolution), 2)
 			}
 			cfg = loaded
 		}
 		request, err = plan.BuildRequest(ctx, cfg, resolvedConfigPath, positional)
 		if err != nil {
 			if issue, exitCode, ok := asCliIssue(err); ok {
-				return writeCLIError(stdout, stderr, format, plan.Name, nil, issue, exitCode)
+				return writeCLIError(stdout, stderr, format, plan.Name, nil, enrichAppConfigLoadIssue(issue, resolution), exitCode)
 			}
 			return writeCLIError(stdout, stderr, format, plan.Name, nil, cliIssue{
 				Code:    "validation_error",
@@ -315,7 +312,7 @@ func runCommand[Req any, Res any](
 		normalized, normErr := plan.Normalize(ctx, request, format)
 		if normErr != nil {
 			if issue, exitCode, ok := asCliIssue(normErr); ok {
-				return writeCLIError(stdout, stderr, format, plan.Name, normalized, issue, exitCode)
+				return writeCLIError(stdout, stderr, format, plan.Name, normalized, enrichAppConfigLoadIssue(issue, resolution), exitCode)
 			}
 			return writeCLIError(stdout, stderr, format, plan.Name, normalized, cliIssue{
 				Code:    "validation_error",
@@ -329,7 +326,7 @@ func runCommand[Req any, Res any](
 
 	enrichedReq, result, issue := plan.Execute(execCtx, resolvedConfigPath, request, format)
 	if issue != nil {
-		return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, cliIssueFromAppIssue(issue), issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, plan.Name, enrichedReq, enrichAppConfigLoadIssue(cliIssueFromAppIssue(issue), resolution), issue.ExitCode)
 	}
 
 	if plan.PostProcess != nil {
@@ -343,5 +340,6 @@ func runCommand[Req any, Res any](
 		result = postResult
 	}
 
+	emitMultirepoShadowWarning(resolution)
 	return writeCLISuccessWithTimings(stdout, stderr, format, plan.Name, enrichedReq, result, nil, snapshotCommandTimings(tracker, started))
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -134,15 +134,12 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 
 	resolvedConfigPath, resolution, err := resolveCommandConfigPathWithResolution(ctx, configPath)
 	if err != nil {
-		return writeCLIError(stdout, stderr, format, "status", request, cliIssue{
-			Code:    "config_error",
-			Message: err.Error(),
-		}, 2)
+		return writeCLIError(stdout, stderr, format, "status", request, configErrorIssue(err.Error()), 2)
 	}
 
 	response := app.Status(ctx, resolvedConfigPath, app.StatusRequest{CheckRuntime: scope})
 	if response.Issue != nil {
-		return writeCLIError(stdout, stderr, format, "status", request, cliIssueFromAppIssue(response.Issue), response.Issue.ExitCode)
+		return writeCLIError(stdout, stderr, format, "status", request, enrichAppConfigLoadIssue(cliIssueFromAppIssue(response.Issue), resolution), response.Issue.ExitCode)
 	}
 	result := response.Result
 
@@ -161,6 +158,7 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 		}
 	}
 
+	emitMultirepoShadowWarning(resolution)
 	return writeCLISuccess(stdout, stderr, format, "status", request, statusOut, nil)
 }
 

--- a/internal/app/operations.go
+++ b/internal/app/operations.go
@@ -19,6 +19,9 @@ const (
 	CodeNotFound              = "not_found"
 	CodeDependencyUnavailable = "dependency_unavailable"
 	CodeInternalError         = "internal_error"
+
+	IssueDetailPhase     = "phase"
+	IssuePhaseConfigLoad = "config_load"
 )
 
 // Issue is a transport-agnostic operation failure.
@@ -55,7 +58,10 @@ func (e *issueError) Error() string {
 func executeWithConfig[Req any, Res any](ctx context.Context, configPath string, request Req, run func(*config.Config) (*Res, error), classify func(*config.Config, error) *Issue) Response[Req, Res] {
 	cfg, issue := loadConfig(configPath)
 	if issue != nil {
-		return failure[Req, Res](request, issue.Code, issue.Message, issue.ExitCode)
+		return Response[Req, Res]{
+			Request: request,
+			Issue:   issue,
+		}
 	}
 
 	result, err := run(cfg)
@@ -217,6 +223,7 @@ func loadConfig(configPath string) (*config.Config, *Issue) {
 		return nil, &Issue{
 			Code:     CodeConfigError,
 			Message:  err.Error(),
+			Details:  map[string]any{IssueDetailPhase: IssuePhaseConfigLoad},
 			ExitCode: 2,
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -534,12 +534,7 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 	if cfg.SchemaVersion == 0 {
 		cfg.SchemaVersion = CurrentSchemaVersion
 	} else if enforceSchemaVersion && cfg.SchemaVersion != CurrentSchemaVersion {
-		return nil, fmt.Errorf(
-			"unsupported schema_version %d (supported: %d); run `pituitary migrate-config --path %s --write` if this is an older config",
-			cfg.SchemaVersion,
-			CurrentSchemaVersion,
-			filepath.ToSlash(configPath),
-		)
+		return nil, unsupportedSchemaVersionError(cfg.SchemaVersion)
 	}
 
 	if err := validate(cfg); err != nil {
@@ -547,6 +542,14 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 	}
 	cfg.SchemaVersion = CurrentSchemaVersion
 	return cfg, nil
+}
+
+func unsupportedSchemaVersionError(version int) error {
+	base := fmt.Sprintf("unsupported schema_version %d (supported: %d)", version, CurrentSchemaVersion)
+	if version < CurrentSchemaVersion {
+		return fmt.Errorf("%s; this config is older than this Pituitary version and cannot be migrated automatically; choose another config with --config or regenerate/update this config", base)
+	}
+	return fmt.Errorf("%s; this config was written for a newer Pituitary version; upgrade Pituitary", base)
 }
 
 func rawBoolValue(value *bool) bool {

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -62,8 +62,46 @@ path = "specs"
 	if !strings.Contains(err.Error(), "unsupported schema_version 9") {
 		t.Fatalf("Load() error = %q, want schema-version detail", err)
 	}
-	if !strings.Contains(err.Error(), "migrate-config") {
-		t.Fatalf("Load() error = %q, want migrate-config hint", err)
+	if !strings.Contains(err.Error(), "newer Pituitary version") || !strings.Contains(err.Error(), "upgrade Pituitary") {
+		t.Fatalf("Load() error = %q, want newer-version guidance", err)
+	}
+	if strings.Contains(err.Error(), "migrate-config") {
+		t.Fatalf("Load() error = %q, want no migrate-config hint for unsupported schema", err)
+	}
+}
+
+func TestLoadRejectsOlderUnsupportedSchemaVersionWithRecoveryGuidance(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, "specs"))
+	configPath := filepath.Join(repo, "pituitary.toml")
+	writeFile(t, configPath, `
+schema_version = 2
+
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load() error = nil, want schema-version failure")
+	}
+	if !strings.Contains(err.Error(), "unsupported schema_version 2") {
+		t.Fatalf("Load() error = %q, want schema-version detail", err)
+	}
+	if !strings.Contains(err.Error(), "older than this Pituitary version") || !strings.Contains(err.Error(), "cannot be migrated automatically") {
+		t.Fatalf("Load() error = %q, want older-version guidance", err)
+	}
+	if strings.Contains(err.Error(), "migrate-config") {
+		t.Fatalf("Load() error = %q, want no migrate-config hint for unsupported schema", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- limit shadowed-config recovery advice to selected config load failures
- tag app config-load issues so unrelated config_error paths do not get swap guidance
- improve unsupported schema guidance and add regression coverage for explicit config, migrate-config, and missing-index paths

## Validation
- go test ./...
- make vet
- git diff --check