### PR TITLE
Fix MCP registry OIDC audience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,8 +155,9 @@ jobs:
           VERSION="${TAG#v}"
 
           # Pin mcp-publisher to a specific version with integrity check.
-          MCP_PUBLISHER_VERSION="v1.5.0"
-          MCP_PUBLISHER_SHA256="79bbb73ba048c5906034f73ef6286d7763bd53cf368ea0b358fc593ed360cbd5"
+          MCP_PUBLISHER_VERSION="v1.7.6"
+          MCP_PUBLISHER_SHA256="bcc96ca630cae4cf503b4550bd4a17462d42ad4819273bee56f4385bb059ddee"
+          MCP_REGISTRY_URL="https://registry.modelcontextprotocol.io"
           curl -sL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" -o mcp-publisher.tar.gz
           echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c
           tar xzf mcp-publisher.tar.gz
@@ -186,5 +187,5 @@ jobs:
 
           cat server.json
           ./mcp-publisher validate
-          ./mcp-publisher login github-oidc
+          ./mcp-publisher login github-oidc --registry "$MCP_REGISTRY_URL"
           ./mcp-publisher publish


### PR DESCRIPTION
## Summary

- Upgrade the pinned MCP publisher used by release automation from v1.5.0 to v1.7.6.
- Pass the production MCP registry URL explicitly during GitHub OIDC login so the requested audience matches the registry.

## Backlog / Issue

- Release follow-up for the failed v1.0.0-beta.9 MCP registry publish step.

## Core Trust Surface

- Does this PR touch a core write path or authoritative-state contract? No.

## Validation

- [ ] I ran make ci
- [ ] I added or updated tests where needed

Validation run:
- make fmt
- git diff --check -- .github/workflows/release.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "valid yaml"'

## Notes

- Go tests were not run because this is release workflow-only.