### PR TITLE
Add outline-guided review context

### DIFF
--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -25,7 +25,7 @@ func TestRunCommandHelpAcrossSurface(t *testing.T) {
 		"check-compliance":  {"usage: pituitary [--config PATH] check-compliance (--path PATH... | --diff-file PATH|- | --request-file PATH|-) [--format FORMAT]", "shared config resolution:", "--path VALUE", "--diff-file VALUE", "--request-file VALUE"},
 		"check-doc-drift":   {"usage: pituitary [--config PATH] check-doc-drift ([--doc-ref REF | --path PATH]... | [--scope all] | [--diff-file PATH|-]) [--request-file PATH|-] [--format FORMAT]", "shared config resolution:", "--doc-ref VALUE", "--path VALUE", "--scope VALUE", "--diff-file VALUE", "--request-file VALUE"},
 		"fix":               {"usage: pituitary [--config PATH] fix (--path PATH | --scope VALUE) [--dry-run] [--yes] [--format FORMAT]", "shared config resolution:", "--path VALUE", "--scope VALUE", "--dry-run", "--yes"},
-		"review-spec":       {"usage: pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]", "shared config resolution:", "--path VALUE", "--spec-record-file VALUE", "--request-file VALUE"},
+		"review-spec":       {"usage: pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--outline-context] [--format FORMAT]", "shared config resolution:", "--path VALUE", "--spec-record-file VALUE", "--outline-context", "--request-file VALUE"},
 		"schema":            {"usage: pituitary schema [COMMAND] [--format FORMAT]", "--format VALUE"},
 		"serve":             {"usage: pituitary [--config PATH] serve", "shared config resolution:", "--transport VALUE"},
 	}

--- a/cmd/review_spec.go
+++ b/cmd/review_spec.go
@@ -18,16 +18,18 @@ func runReviewSpec(args []string, stdout, stderr io.Writer) int {
 
 func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	var (
-		specRef        string
-		specPath       string
-		specRecordFile string
+		specRef             string
+		specPath            string
+		specRecordFile      string
+		outlineContext      bool
+		outlineContextLimit int
 	)
 
 	return runCommand[analysis.ReviewRequest, analysis.ReviewResult](
 		ctx, args, stdout, stderr,
 		commandRun[analysis.ReviewRequest, analysis.ReviewResult]{
 			Name:  "review-spec",
-			Usage: "pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--format FORMAT]",
+			Usage: "pituitary [--config PATH] review-spec (--path PATH | --spec-ref REF | --spec-record-file PATH|- | --request-file PATH|-) [--outline-context] [--format FORMAT]",
 			Options: commandRunOptions{
 				RequestFile:   true,
 				ConfigForFile: true,
@@ -36,11 +38,15 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 				fs.StringVar(&specRef, "spec-ref", "", "indexed spec ref")
 				fs.StringVar(&specPath, "path", "", "workspace-relative or absolute path to an indexed spec")
 				fs.StringVar(&specRecordFile, "spec-record-file", "", "path to canonical spec_record JSON, or - for stdin")
+				fs.BoolVar(&outlineContext, "outline-context", false, "include bounded outline-guided context in the result")
+				fs.IntVar(&outlineContextLimit, "outline-context-limit", 0, "maximum outline-context candidate records")
 			},
 			InlineFlagsSet: func(_ *flag.FlagSet) bool {
 				return strings.TrimSpace(specRef) != "" ||
 					strings.TrimSpace(specPath) != "" ||
-					strings.TrimSpace(specRecordFile) != ""
+					strings.TrimSpace(specRecordFile) != "" ||
+					outlineContext ||
+					outlineContextLimit != 0
 			},
 			LoadRequestFile: autoLoadWorkspaceRequest[analysis.ReviewRequest],
 			BuildRequest: func(ctx context.Context, _ *config.Config, resolvedConfigPath string, _ []string) (analysis.ReviewRequest, error) {
@@ -69,7 +75,13 @@ func runReviewSpecContext(ctx context.Context, args []string, stdout, stderr io.
 					}
 					trimmedSpecRef = resolved
 				}
-				return reviewRequestFromFlags(workspaceRoot, trimmedSpecRef, trimmedRecord)
+				request, err := reviewRequestFromFlags(workspaceRoot, trimmedSpecRef, trimmedRecord)
+				if err != nil {
+					return request, err
+				}
+				request.OutlineContext = outlineContext
+				request.OutlineContextLimit = outlineContextLimit
+				return request, nil
 			},
 			Execute: func(ctx context.Context, cfgPath string, req analysis.ReviewRequest, _ string) (analysis.ReviewRequest, *analysis.ReviewResult, *app.Issue) {
 				op := app.ReviewSpec(ctx, cfgPath, req)

--- a/cmd/review_spec_test.go
+++ b/cmd/review_spec_test.go
@@ -159,6 +159,86 @@ func TestRunReviewSpecWithSpecRefJSON(t *testing.T) {
 	}
 }
 
+func TestRunReviewSpecWithOutlineContextJSON(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runReviewSpec([]string{
+			"--spec-ref", "SPEC-042",
+			"--outline-context",
+			"--outline-context-limit", "2",
+			"--format", "json",
+		}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runReviewSpec() exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runReviewSpec() wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request struct {
+			SpecRef             string `json:"spec_ref"`
+			OutlineContext      bool   `json:"outline_context"`
+			OutlineContextLimit int    `json:"outline_context_limit"`
+		} `json:"request"`
+		Result struct {
+			OutlineContext struct {
+				SnapshotFingerprint string `json:"snapshot_fingerprint"`
+				Records             []struct {
+					Ref     string `json:"ref"`
+					Outline []struct {
+						ChunkID int64  `json:"chunk_id"`
+						Heading string `json:"heading"`
+					} `json:"outline"`
+					Selections []struct {
+						ChunkID         int64  `json:"chunk_id"`
+						SelectionSource string `json:"selection_source"`
+						Expanded        []struct {
+							ChunkID int64  `json:"chunk_id"`
+							Role    string `json:"role"`
+							Content string `json:"content"`
+						} `json:"expanded"`
+					} `json:"selections"`
+				} `json:"records"`
+			} `json:"outline_context"`
+		} `json:"result"`
+		Errors []cliIssue `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal review payload: %v", err)
+	}
+	if payload.Request.SpecRef != "SPEC-042" || !payload.Request.OutlineContext || payload.Request.OutlineContextLimit != 2 {
+		t.Fatalf("request = %+v, want outline context request", payload.Request)
+	}
+	if payload.Result.OutlineContext.SnapshotFingerprint == "" {
+		t.Fatal("snapshot_fingerprint is empty")
+	}
+	if len(payload.Result.OutlineContext.Records) == 0 {
+		t.Fatalf("outline_context = %+v, want records", payload.Result.OutlineContext)
+	}
+	first := payload.Result.OutlineContext.Records[0]
+	if first.Ref == "" || len(first.Outline) == 0 || first.Outline[0].ChunkID == 0 {
+		t.Fatalf("first outline-context record = %+v, want outline rows", first)
+	}
+	if len(first.Selections) == 0 || first.Selections[0].SelectionSource != "deterministic" {
+		t.Fatalf("selections = %+v, want deterministic selection", first.Selections)
+	}
+	if len(first.Selections[0].Expanded) == 0 || first.Selections[0].Expanded[0].Content == "" {
+		t.Fatalf("expanded = %+v, want expanded context content", first.Selections[0].Expanded)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+}
+
 func TestRunReviewSpecWithMarkdownContractPathJSON(t *testing.T) {
 	repo := writePathFirstWorkspace(t)
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -70,6 +70,7 @@ pituitary review-spec --path specs/X            # full composite review
 pituitary review-spec --path specs/X --format markdown  # shareable report
 pituitary review-spec --path specs/X --format html      # rich HTML report
 pituitary review-spec --path specs/X --format json      # machine-readable
+pituitary review-spec --path specs/X --outline-context --format json  # outline-guided context
 pituitary compare-specs --request-file request.json --format json  # structured request input
 ```
 

--- a/docs/development/complexity-baseline-2026-05-07.md
+++ b/docs/development/complexity-baseline-2026-05-07.md
@@ -1,0 +1,101 @@
+# Complexity Baseline - 2026-05-07
+
+Baseline captured with the `code-complexity-review` skill and the Nanto skills CLI after moving the working branch to Stroma v3.0.0.
+
+Command:
+
+```sh
+skills complexity-scan --path . --top 20
+```
+
+## Scanner Snapshot
+
+- Packages: 25
+- Go files: 257
+- Functions: 2,390
+- Largest production files:
+  - `internal/analysis/doc_drift.go` - 1,896 lines
+  - `internal/analysis/compliance.go` - 1,872 lines
+  - `internal/config/config.go` - 1,636 lines
+  - `internal/index/rebuild.go` - 1,211 lines
+  - `internal/source/filesystem.go` - 993 lines
+  - `cmd/render_review.go` - 969 lines
+  - `internal/source/discover.go` - 968 lines
+  - `extensions/json/adapter.go` - 861 lines
+  - `internal/analysis/openai_provider.go` - 796 lines
+- Highest production branch scores:
+  - `cmd/run_command.go:161` `runCommand` - score 47
+  - `internal/config/config.go:1177` `validateRuntime` - score 41
+  - `internal/config/parse_toml.go:56` `undecodedKeyMessage` - score 40
+  - `cmd/render_status.go:11` `renderStatusResult` - score 34
+  - `cmd/render_docdrift.go:11` `renderDocDriftResult` - score 32
+  - `internal/index/rebuild.go:419` `finalizeBusinessIndexContext` - score 31
+  - `internal/index/update.go:64` `updateContext` - score 30
+  - `cmd/index.go:40` `runIndexContext` - score 29
+- Highest churn production files:
+  - `cmd/render.go` - 5,801 changed lines
+  - `internal/config/config.go` - 3,431
+  - `internal/index/rebuild.go` - 3,157
+  - `internal/analysis/doc_drift.go` - 2,824
+  - `internal/analysis/compliance.go` - 2,292
+  - `internal/index/update.go` - 1,986
+  - `internal/source/filesystem.go` - 1,985
+  - `internal/analysis/openai_provider.go` - 1,536
+  - `internal/analysis/terminology.go` - 1,224
+  - `internal/index/search.go` - 1,111
+
+## Findings
+
+1. High - Analysis workflows co-locate selection, deterministic scoring, optional model refinement, warning assembly, and remediation output.
+
+   Locations: `internal/analysis/doc_drift.go:214`, `internal/analysis/doc_drift.go:288`, `internal/analysis/doc_drift.go:412`, `internal/analysis/compliance.go:258`, `internal/analysis/compliance.go:325`, `internal/analysis/compliance.go:409`.
+
+   Reader cost: understanding one user-facing result requires keeping source scope, repository loading, relevance selection, deterministic findings, model adjudication, warning propagation, remediation, and final sorting in working memory at once. This is partly domain complexity, but the current locality makes behavior changes expensive.
+
+   Simplification path: keep public result types stable, but split each workflow into explicit phases: input/scope resolution, candidate selection, deterministic evaluation, optional semantic refinement, and result assembly. The existing helper seams are present; the next step is file/module separation around those phases.
+
+2. High - Command lifecycle is centralized behind a large option matrix.
+
+   Location: `cmd/run_command.go:161`.
+
+   Reader cost: `runCommand` owns flag registration, positional validation, config resolution, request-file handling, request building, normalization, timing, execution, post-processing, multirepo warnings, and rendering. Adding one command option requires auditing unrelated branches.
+
+   Simplification path: preserve the generic command contract, but extract `validateCommandPlan`, `parseCommandRequest`, `loadCommandConfig`, and `executeCommandPlan` helpers with small return types. This should reduce branch pressure without duplicating command behavior.
+
+3. Medium - Runtime config validation duplicates provider rules across embedder and analysis providers.
+
+   Location: `internal/config/config.go:1177`.
+
+   Reader cost: profile resolution, provider-specific required fields, endpoint URL validation, and retry/token checks are interleaved twice. The duplicated shape makes future provider changes easy to apply to one runtime surface and miss on the other.
+
+   Simplification path: introduce a small `validateRuntimeProvider(label, provider, supported, requirements)` helper, then keep `validateRuntime` as orchestration over profile resolution plus provider validation.
+
+4. Medium - Index rebuild/update crosses Stroma snapshot state and Pituitary business-index state in several places.
+
+   Locations: `internal/index/rebuild.go:419`, `internal/index/update.go:64`, `internal/index/reuse.go:30`.
+
+   Reader cost: the Stroma v3 upgrade exposed a hidden coupling: Stroma now owns normalized record content hashes, while Pituitary still has its own artifact content hashes. Reuse accounting had to be realigned with Stroma-normalized record identity. Future snapshot API changes can create similar mistakes if the boundary remains implicit.
+
+   Simplification path: make the boundary explicit with a small internal type such as `stromaRecordIdentity` or `snapshotReuseIdentity`, and route rebuild, update, and dry-run reuse accounting through it.
+
+5. Medium - Text renderers are branch-heavy and mix section selection with string formatting.
+
+   Locations: `cmd/render_status.go:11`, `cmd/render_docdrift.go:11`, `cmd/render_review.go`.
+
+   Reader cost: presentation rules, filtering rules, fallback rules, and exact CLI strings are interleaved. These files are user-visible and high-churn, so small output changes carry high regression risk.
+
+   Simplification path: keep output text stable, but extract section-level renderers that accept already-selected view models. Tests can then assert view-model selection separately from exact formatting.
+
+## Domain Complexity To Preserve
+
+- Split-store model: Pituitary business DB plus immutable Stroma snapshot.
+- CLI-first JSON contract and optional MCP wrapper over the same core.
+- Deterministic retrieval before optional provider-backed adjudication.
+- Temporal and confidence-aware governance semantics.
+- Local filesystem scope and explicit source configuration.
+
+## Suggested Next Steps
+
+- Use this file as the baseline for future complexity deltas.
+- Prioritize simplification where high churn overlaps high branch pressure: `internal/analysis/doc_drift.go`, `internal/analysis/compliance.go`, `internal/index/rebuild.go`, and `cmd/run_command.go`.
+- Treat scanner output as leads, not pass/fail gates. A future CI gate should compare trends only after at least one follow-up baseline confirms stability.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -59,6 +59,7 @@ Text output now also promotes the strongest per-finding guidance into a short `T
 | `fix --path PATH --dry-run` | Preview deterministic doc-drift remediations before writing |
 | `fix --scope all --yes` | Apply deterministic doc-drift remediations without prompting |
 | `review-spec --path SPEC` | Full review: overlap + comparison + impact + drift + remediation |
+| `review-spec --path SPEC --outline-context --format json` | Include bounded outline-guided retrieval context with chunk provenance |
 | `schema COMMAND --format json` | Inspect the machine-readable request/response contract for one command |
 | `serve --config FILE` | Start MCP server over stdio |
 
@@ -206,6 +207,8 @@ pituitary check-compliance --request-file request.json --format json
 - remediation suggestions
 
 Use `--format markdown` for PR-friendly reports and `--format html` for a richer shareable report with expandable evidence.
+
+Use `--outline-context --format json` when an agent needs the PageIndex-style context path: candidate record search, outline rows, deterministic section selection, and `ExpandContext` payloads with record refs, chunk ids, headings, snapshot fingerprint, and source spans where available.
 
 `analyze-impact` uses the same pattern for docs it shortlists: each impacted doc can include a `classification`, a source-linked `evidence` object, and `suggested_targets` with likely doc sections to inspect first.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.9
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/dusk-network/stroma/v2 v2.2.0
+	github.com/dusk-network/stroma/v3 v3.0.0
 	github.com/google/go-github/v79 v79.0.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dusk-network/stroma/v2 v2.2.0 h1:ufPSM+5eFSuPGjR6WHMyFB9wo7mq7noCH9Q7v2sKlkQ=
-github.com/dusk-network/stroma/v2 v2.2.0/go.mod h1:n2Gf3cvgh8QuvJzQD/rkQMzXmq81dxu2hvpApFYLRwg=
+github.com/dusk-network/stroma/v3 v3.0.0 h1:6PXlvc5wJSaRvB2qWkmPHmY2z2YBZ03CMBsaq2YcI5c=
+github.com/dusk-network/stroma/v3 v3.0.0/go.mod h1:asaKDy50PUWtSw8RvSueQhmCrUwYGhMDT/boWUuubwo=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -16,7 +16,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
 	"github.com/dusk-network/pituitary/internal/temporal"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/internal/analysis/openai_provider.go
+++ b/internal/analysis/openai_provider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/ranking"
 	"github.com/dusk-network/pituitary/internal/runtimeerr"
-	stchat "github.com/dusk-network/stroma/v2/chat"
+	stchat "github.com/dusk-network/stroma/v3/chat"
 )
 
 type qualitativeAnalyzer interface {

--- a/internal/analysis/overlap.go
+++ b/internal/analysis/overlap.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 const (

--- a/internal/analysis/repository.go
+++ b/internal/analysis/repository.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 type analysisRepository struct {

--- a/internal/analysis/repository_similarity.go
+++ b/internal/analysis/repository_similarity.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/ranking"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 const (
@@ -439,8 +439,8 @@ func shortlistRefProbeLimit(limit int) int {
 
 func shortlistChunkProbeLimit(limit int) int {
 	probeLimit := shortlistRefProbeLimit(limit) * 4
-	if probeLimit > 256 {
-		probeLimit = 256
+	if probeLimit > stindex.MaxSearchLimit {
+		probeLimit = stindex.MaxSearchLimit
 	}
 	return probeLimit
 }

--- a/internal/analysis/review.go
+++ b/internal/analysis/review.go
@@ -3,29 +3,41 @@ package analysis
 import (
 	"context"
 	"fmt"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
 )
 
+const (
+	maxReviewOutlineContextRefs       = 8
+	maxReviewOutlineOverlapRefs       = 2
+	maxReviewOutlineContextQueryBytes = 12000
+)
+
 // ReviewRequest is the normalized review-spec input.
 type ReviewRequest struct {
-	SpecRef    string            `json:"spec_ref,omitempty"`
-	SpecRecord *model.SpecRecord `json:"spec_record,omitempty"`
+	SpecRef             string            `json:"spec_ref,omitempty"`
+	SpecRecord          *model.SpecRecord `json:"spec_record,omitempty"`
+	OutlineContext      bool              `json:"outline_context,omitempty"`
+	OutlineContextLimit int               `json:"outline_context_limit,omitempty"`
 }
 
 // ReviewResult is the composed review-spec response.
 type ReviewResult struct {
-	SpecRef        string                     `json:"spec_ref"`
-	SpecInference  *model.InferenceConfidence `json:"spec_inference,omitempty"`
-	Overlap        *OverlapResult             `json:"overlap"`
-	Comparison     *CompareResult             `json:"comparison"`
-	Impact         *AnalyzeImpactResult       `json:"impact"`
-	DocDrift       *DocDriftResult            `json:"doc_drift"`
-	DocRemediation *DocRemediationResult      `json:"doc_remediation"`
-	Warnings       []Warning                  `json:"warnings,omitempty"`
-	ContentTrust   *resultmeta.ContentTrust   `json:"content_trust,omitempty"`
+	SpecRef        string                      `json:"spec_ref"`
+	SpecInference  *model.InferenceConfidence  `json:"spec_inference,omitempty"`
+	Overlap        *OverlapResult              `json:"overlap"`
+	Comparison     *CompareResult              `json:"comparison"`
+	Impact         *AnalyzeImpactResult        `json:"impact"`
+	DocDrift       *DocDriftResult             `json:"doc_drift"`
+	DocRemediation *DocRemediationResult       `json:"doc_remediation"`
+	OutlineContext *index.OutlineContextResult `json:"outline_context,omitempty"`
+	Warnings       []Warning                   `json:"warnings,omitempty"`
+	ContentTrust   *resultmeta.ContentTrust    `json:"content_trust,omitempty"`
 }
 
 // ReviewSpec composes overlap, comparison, impact, and targeted doc-drift.
@@ -38,7 +50,10 @@ func ReviewSpecContext(ctx context.Context, cfg *config.Config, request ReviewRe
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
-	overlapRequest := OverlapRequest(request)
+	overlapRequest := OverlapRequest{
+		SpecRef:    request.SpecRef,
+		SpecRecord: request.SpecRecord,
+	}
 	if err := validateOverlapRequest(overlapRequest); err != nil {
 		return nil, err
 	}
@@ -55,68 +70,24 @@ func ReviewSpecContext(ctx context.Context, cfg *config.Config, request ReviewRe
 	}
 	analyzer = qualitativeAnalyzerWithTimings(ctx, analyzer)
 
-	candidate, err := loadCandidate(repo, overlapRequest, nil)
+	candidate, overlap, overlapSpecs, err := buildReviewOverlap(repo, overlapRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	overlapTargetRefs, err := repo.overlapTargetRefs(*candidate)
+	comparison, err := buildReviewComparison(ctx, analyzer, candidate, overlap, overlapSpecs)
 	if err != nil {
 		return nil, err
-	}
-	overlapSpecs, err := repo.loadSelectedSpecs(overlapTargetRefs)
-	if err != nil {
-		return nil, err
-	}
-	overlap := buildOverlapResult(candidate, overlapSpecs)
-
-	var comparison *CompareResult
-	if len(overlap.Overlaps) > 0 {
-		primaryOverlapRef := overlap.Overlaps[0].Ref
-		comparison, err = buildCompareResult(ctx, analyzer, candidate, []string{candidate.Record.Ref, primaryOverlapRef}, selectSpecs(overlapSpecs, []string{primaryOverlapRef}))
-		if err != nil {
-			return nil, err
-		}
 	}
 
-	impactSpecRefs, err := repo.impactedSpecRefs(candidate.Record)
+	impact, impactDocs, impactDocRefs, err := buildReviewImpact(repo, candidate)
 	if err != nil {
 		return nil, err
 	}
-	impactSpecs, err := repo.loadSelectedSpecs(impactSpecRefs)
-	if err != nil {
-		return nil, err
-	}
-	impactDocRefs, err := repo.impactedDocRefs(*candidate)
-	if err != nil {
-		return nil, err
-	}
-	impactDocs, err := repo.loadSelectedDocs(impactDocRefs)
-	if err != nil {
-		return nil, err
-	}
-	impact := buildAnalyzeImpactResult(candidate, "accepted", false, impactSpecs, impactDocs)
 
-	docDrift := &DocDriftResult{
-		Scope:      DocDriftScope{Mode: "doc_refs", DocRefs: []string{}},
-		DriftItems: nil,
-		Remediation: &DocRemediationResult{
-			Items: nil,
-		},
-	}
-	if impact != nil && len(impact.AffectedDocs) > 0 {
-		docDriftSpecRefs, err := repo.relevantDocDriftSpecRefs(impactDocs)
-		if err != nil {
-			return nil, err
-		}
-		docDriftSpecs, err := repo.loadSelectedSpecs(docDriftSpecRefs)
-		if err != nil {
-			return nil, err
-		}
-		docDrift, err = buildDocDriftResult(ctx, analyzer, newAnalysisRuntimeUsage(cfg.Runtime.Analysis), DocDriftScope{Mode: "doc_refs", DocRefs: uniqueStrings(impactDocRefs)}, impactDocs, docDriftSpecs, repo.loadAllSpecs)
-		if err != nil {
-			return nil, err
-		}
+	docDrift, err := buildReviewDocDrift(ctx, cfg, repo, analyzer, impact, impactDocs, impactDocRefs)
+	if err != nil {
+		return nil, err
 	}
 
 	docRemediation := &DocRemediationResult{Items: nil}
@@ -124,6 +95,13 @@ func ReviewSpecContext(ctx context.Context, cfg *config.Config, request ReviewRe
 		docRemediation = docDrift.Remediation
 	}
 
+	var outlineContext *index.OutlineContextResult
+	var outlineWarnings []Warning
+	if request.OutlineContext {
+		outlineContext, outlineWarnings = buildReviewOutlineContext(ctx, cfg, repo, request.OutlineContextLimit, *candidate, overlap, impact)
+	}
+
+	warnings := append(reviewWarnings(*candidate, impact, docDrift), outlineWarnings...)
 	return &ReviewResult{
 		SpecRef:        overlap.Candidate.Ref,
 		SpecInference:  candidate.Record.Inference,
@@ -132,9 +110,153 @@ func ReviewSpecContext(ctx context.Context, cfg *config.Config, request ReviewRe
 		Impact:         impact,
 		DocDrift:       docDrift,
 		DocRemediation: docRemediation,
-		Warnings:       reviewWarnings(*candidate, impact, docDrift),
+		OutlineContext: outlineContext,
+		Warnings:       uniqueWarnings(warnings),
 		ContentTrust:   resultmeta.UntrustedWorkspaceText(),
 	}, nil
+}
+
+func buildReviewOverlap(repo *analysisRepository, request OverlapRequest) (*specDocument, *OverlapResult, map[string]specDocument, error) {
+	candidate, err := loadCandidate(repo, request, nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	overlapTargetRefs, err := repo.overlapTargetRefs(*candidate)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	overlapSpecs, err := repo.loadSelectedSpecs(overlapTargetRefs)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return candidate, buildOverlapResult(candidate, overlapSpecs), overlapSpecs, nil
+}
+
+func buildReviewComparison(ctx context.Context, analyzer qualitativeAnalyzer, candidate *specDocument, overlap *OverlapResult, overlapSpecs map[string]specDocument) (*CompareResult, error) {
+	if overlap == nil || len(overlap.Overlaps) == 0 {
+		return nil, nil
+	}
+	primaryOverlapRef := overlap.Overlaps[0].Ref
+	comparison, err := buildCompareResult(ctx, analyzer, candidate, []string{candidate.Record.Ref, primaryOverlapRef}, selectSpecs(overlapSpecs, []string{primaryOverlapRef}))
+	if err != nil {
+		return nil, err
+	}
+	return comparison, nil
+}
+
+func buildReviewImpact(repo *analysisRepository, candidate *specDocument) (*AnalyzeImpactResult, map[string]docDocument, []string, error) {
+	impactSpecRefs, err := repo.impactedSpecRefs(candidate.Record)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	impactSpecs, err := repo.loadSelectedSpecs(impactSpecRefs)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	impactDocRefs, err := repo.impactedDocRefs(*candidate)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	impactDocs, err := repo.loadSelectedDocs(impactDocRefs)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return buildAnalyzeImpactResult(candidate, "accepted", false, impactSpecs, impactDocs), impactDocs, impactDocRefs, nil
+}
+
+func buildReviewDocDrift(ctx context.Context, cfg *config.Config, repo *analysisRepository, analyzer qualitativeAnalyzer, impact *AnalyzeImpactResult, impactDocs map[string]docDocument, impactDocRefs []string) (*DocDriftResult, error) {
+	if impact == nil || len(impact.AffectedDocs) == 0 {
+		return emptyReviewDocDrift(), nil
+	}
+	docDriftSpecRefs, err := repo.relevantDocDriftSpecRefs(impactDocs)
+	if err != nil {
+		return nil, err
+	}
+	docDriftSpecs, err := repo.loadSelectedSpecs(docDriftSpecRefs)
+	if err != nil {
+		return nil, err
+	}
+	return buildDocDriftResult(ctx, analyzer, newAnalysisRuntimeUsage(cfg.Runtime.Analysis), DocDriftScope{Mode: "doc_refs", DocRefs: uniqueStrings(impactDocRefs)}, impactDocs, docDriftSpecs, repo.loadAllSpecs)
+}
+
+func emptyReviewDocDrift() *DocDriftResult {
+	return &DocDriftResult{
+		Scope:      DocDriftScope{Mode: "doc_refs", DocRefs: []string{}},
+		DriftItems: nil,
+		Remediation: &DocRemediationResult{
+			Items: nil,
+		},
+	}
+}
+
+func buildReviewOutlineContext(ctx context.Context, cfg *config.Config, repo *analysisRepository, limit int, candidate specDocument, overlap *OverlapResult, impact *AnalyzeImpactResult) (*index.OutlineContextResult, []Warning) {
+	embedder, err := index.NewEmbedder(cfg.Runtime.Embedder)
+	if err != nil {
+		return nil, []Warning{outlineContextWarning(candidate.Record.Ref, err)}
+	}
+	result, err := index.RetrieveOutlineContextWithSnapshotContext(ctx, cfg, repo.snapshot, embedder, index.OutlineContextQuery{
+		Query:          reviewOutlineContextQuery(candidate),
+		Refs:           reviewOutlineContextRefs(candidate, overlap, impact),
+		Limit:          limit,
+		IncludeParent:  true,
+		NeighborWindow: 1,
+	})
+	if err != nil {
+		return nil, []Warning{outlineContextWarning(candidate.Record.Ref, err)}
+	}
+	return result, nil
+}
+
+func reviewOutlineContextQuery(candidate specDocument) string {
+	query := strings.TrimSpace(candidate.Record.Title + "\n\n" + strings.TrimSpace(candidate.Record.BodyText))
+	return truncateReviewOutlineQuery(query, maxReviewOutlineContextQueryBytes)
+}
+
+func truncateReviewOutlineQuery(content string, maxBytes int) string {
+	if len(content) <= maxBytes {
+		return content
+	}
+	for index, r := range content {
+		next := index + utf8.RuneLen(r)
+		if next > maxBytes {
+			if index == 0 {
+				return content[:next]
+			}
+			return strings.TrimSpace(content[:index])
+		}
+	}
+	return content
+}
+
+func outlineContextWarning(ref string, err error) Warning {
+	return Warning{
+		Code:    "outline_context_unavailable",
+		Message: fmt.Sprintf("outline context unavailable: %v", err),
+		Ref:     ref,
+	}
+}
+
+func reviewOutlineContextRefs(candidate specDocument, overlap *OverlapResult, impact *AnalyzeImpactResult) []string {
+	refs := []string{candidate.Record.Ref}
+	if overlap != nil {
+		addedOverlapRefs := 0
+		for _, item := range overlap.Overlaps {
+			refs = append(refs, item.Ref)
+			addedOverlapRefs++
+			if addedOverlapRefs >= maxReviewOutlineOverlapRefs {
+				break
+			}
+		}
+	}
+	if impact != nil {
+		for _, doc := range impact.AffectedDocs {
+			if len(refs) >= maxReviewOutlineContextRefs {
+				break
+			}
+			refs = append(refs, doc.Ref)
+		}
+	}
+	return uniqueStrings(refs)
 }
 
 func reviewWarnings(candidate specDocument, impact *AnalyzeImpactResult, docDrift *DocDriftResult) []Warning {

--- a/internal/analysis/review_test.go
+++ b/internal/analysis/review_test.go
@@ -2,7 +2,10 @@ package analysis
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
@@ -45,6 +48,130 @@ func TestReviewSpecComposesIndexedWorkflow(t *testing.T) {
 	}
 	if len(result.DocDrift.DriftItems) != 1 || result.DocDrift.DriftItems[0].DocRef != "doc://guides/api-rate-limits" {
 		t.Fatalf("doc_drift items = %+v, want guide drift only", result.DocDrift.DriftItems)
+	}
+}
+
+func TestReviewSpecCanIncludeOutlineContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := ReviewSpec(cfg, ReviewRequest{
+		SpecRef:             "SPEC-042",
+		OutlineContext:      true,
+		OutlineContextLimit: 2,
+	})
+	if err != nil {
+		t.Fatalf("ReviewSpec() error = %v", err)
+	}
+	if result.OutlineContext == nil {
+		t.Fatal("OutlineContext is nil")
+	}
+	if result.OutlineContext.SnapshotFingerprint == "" {
+		t.Fatal("OutlineContext.SnapshotFingerprint is empty")
+	}
+	if len(result.OutlineContext.Records) == 0 {
+		t.Fatalf("OutlineContext = %+v, want records", result.OutlineContext)
+	}
+	first := result.OutlineContext.Records[0]
+	if first.Ref == "" || len(first.Outline) == 0 || len(first.Selections) == 0 {
+		t.Fatalf("first outline-context record = %+v, want outline and selections", first)
+	}
+	if len(first.Selections[0].Expanded) == 0 {
+		t.Fatalf("selection = %+v, want expanded context", first.Selections[0])
+	}
+}
+
+func TestReviewSpecWarnsWhenOutlineContextFails(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := index.Rebuild(cfg, records); err != nil {
+		t.Fatalf("index.Rebuild() error = %v", err)
+	}
+
+	result, err := ReviewSpec(cfg, ReviewRequest{
+		SpecRef:             "SPEC-042",
+		OutlineContext:      true,
+		OutlineContextLimit: 999,
+	})
+	if err != nil {
+		t.Fatalf("ReviewSpec() error = %v, want non-fatal outline-context warning", err)
+	}
+	if result.OutlineContext != nil {
+		t.Fatalf("OutlineContext = %+v, want nil after invalid outline-context request", result.OutlineContext)
+	}
+	var found bool
+	for _, warning := range result.Warnings {
+		if warning.Code == "outline_context_unavailable" && warning.Ref == "SPEC-042" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Warnings = %+v, want outline_context_unavailable", result.Warnings)
+	}
+	if result.Overlap == nil || result.Impact == nil || result.DocDrift == nil {
+		t.Fatalf("result = %+v, want regular review result retained", result)
+	}
+}
+
+func TestReviewOutlineContextRefsAreBounded(t *testing.T) {
+	t.Parallel()
+
+	affectedDocs := make([]ImpactedDoc, 12)
+	for i := range affectedDocs {
+		affectedDocs[i].Ref = fmt.Sprintf("doc://guide/%02d", i)
+	}
+	refs := reviewOutlineContextRefs(
+		specDocument{Record: model.SpecRecord{Ref: "SPEC-042"}},
+		&OverlapResult{Overlaps: []OverlapItem{{Ref: "SPEC-008"}, {Ref: "SPEC-055"}, {Ref: "SPEC-099"}}},
+		&AnalyzeImpactResult{AffectedDocs: affectedDocs},
+	)
+	if len(refs) > maxReviewOutlineContextRefs {
+		t.Fatalf("refs = %v, want at most %d", refs, maxReviewOutlineContextRefs)
+	}
+	for _, want := range []string{"SPEC-042", "SPEC-008", "SPEC-055"} {
+		if !reviewTestContainsString(refs, want) {
+			t.Fatalf("refs = %v, want %s retained", refs, want)
+		}
+	}
+}
+
+func reviewTestContainsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestReviewOutlineContextQueryIsBoundedAndUTF8Safe(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Repeat("é", maxReviewOutlineContextQueryBytes)
+	query := reviewOutlineContextQuery(specDocument{Record: model.SpecRecord{
+		Ref:      "SPEC-042",
+		Title:    "Unicode Spec",
+		BodyText: body,
+	}})
+	if !utf8.ValidString(query) {
+		t.Fatalf("query is invalid UTF-8")
+	}
+	if len(query) > maxReviewOutlineContextQueryBytes+utf8.UTFMax {
+		t.Fatalf("query length = %d, want bounded", len(query))
 	}
 }
 

--- a/internal/analysis/semantic_terminology.go
+++ b/internal/analysis/semantic_terminology.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/index"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 const (

--- a/internal/chunk/contextualizer.go
+++ b/internal/chunk/contextualizer.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	stchunk "github.com/dusk-network/stroma/v2/chunk"
-	stcorpus "github.com/dusk-network/stroma/v2/corpus"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stchunk "github.com/dusk-network/stroma/v3/chunk"
+	stcorpus "github.com/dusk-network/stroma/v3/corpus"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 // PrefixFormat selects the layout of the per-chunk context prefix.

--- a/internal/chunk/contextualizer_test.go
+++ b/internal/chunk/contextualizer_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	stchunk "github.com/dusk-network/stroma/v2/chunk"
-	stcorpus "github.com/dusk-network/stroma/v2/corpus"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stchunk "github.com/dusk-network/stroma/v3/chunk"
+	stcorpus "github.com/dusk-network/stroma/v3/corpus"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 func TestBuildPrefix_TitleAncestry(t *testing.T) {

--- a/internal/chunk/markdown.go
+++ b/internal/chunk/markdown.go
@@ -1,6 +1,6 @@
 package chunk
 
-import stchunk "github.com/dusk-network/stroma/v2/chunk"
+import stchunk "github.com/dusk-network/stroma/v3/chunk"
 
 // Section is one heading-aware Markdown chunk.
 type Section = stchunk.Section

--- a/internal/chunk/policy.go
+++ b/internal/chunk/policy.go
@@ -3,8 +3,8 @@ package chunk
 import (
 	"fmt"
 
-	stchunk "github.com/dusk-network/stroma/v2/chunk"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stchunk "github.com/dusk-network/stroma/v3/chunk"
+	stindex "github.com/dusk-network/stroma/v3/index"
 
 	"github.com/dusk-network/pituitary/sdk"
 )

--- a/internal/chunk/policy_test.go
+++ b/internal/chunk/policy_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	stchunk "github.com/dusk-network/stroma/v2/chunk"
-	stcorpus "github.com/dusk-network/stroma/v2/corpus"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stchunk "github.com/dusk-network/stroma/v3/chunk"
+	stcorpus "github.com/dusk-network/stroma/v3/corpus"
+	stindex "github.com/dusk-network/stroma/v3/index"
 
 	"github.com/dusk-network/pituitary/sdk"
 )

--- a/internal/fusion/fusion.go
+++ b/internal/fusion/fusion.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 const (

--- a/internal/fusion/fusion_test.go
+++ b/internal/fusion/fusion_test.go
@@ -3,7 +3,7 @@ package fusion
 import (
 	"testing"
 
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 func TestResolveZeroConfigReturnsNil(t *testing.T) {

--- a/internal/index/armaware_reranker_test.go
+++ b/internal/index/armaware_reranker_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 // TestArmAwareRerankerBoostsFTSOnlyTerminologyMatch documents the one

--- a/internal/index/corpus_snapshot.go
+++ b/internal/index/corpus_snapshot.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 const stromaSnapshotPathKey = "stroma_snapshot_path"

--- a/internal/index/embedder.go
+++ b/internal/index/embedder.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/config"
-	stembed "github.com/dusk-network/stroma/v2/embed"
+	stembed "github.com/dusk-network/stroma/v3/embed"
 )
 
 // DependencyUnavailableError indicates that a required runtime dependency

--- a/internal/index/openai_embedder.go
+++ b/internal/index/openai_embedder.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/runtimeerr"
-	stembed "github.com/dusk-network/stroma/v2/embed"
+	stembed "github.com/dusk-network/stroma/v3/embed"
 )
 
 const (

--- a/internal/index/openai_embedder_test.go
+++ b/internal/index/openai_embedder_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/dusk-network/pituitary/internal/config"
-	stembed "github.com/dusk-network/stroma/v2/embed"
+	stembed "github.com/dusk-network/stroma/v3/embed"
 )
 
 func TestOpenAICompatibleEmbedderUsesNomicSearchPrefixes(t *testing.T) {

--- a/internal/index/outline_context.go
+++ b/internal/index/outline_context.go
@@ -1,0 +1,650 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/fusion"
+	"github.com/dusk-network/pituitary/internal/model"
+	"github.com/dusk-network/pituitary/internal/ranking"
+	"github.com/dusk-network/pituitary/internal/resultmeta"
+	stchunk "github.com/dusk-network/stroma/v3/chunk"
+	stindex "github.com/dusk-network/stroma/v3/index"
+)
+
+const (
+	defaultOutlineContextLimit        = 5
+	maxOutlineContextLimit            = 10
+	defaultOutlineSelectionsPerRecord = 1
+	maxOutlineSelectionsPerRecord     = 3
+	defaultOutlineRowsPerRecord       = 80
+	maxOutlineRowsPerRecord           = 200
+	defaultOutlineContextSectionBytes = 2400
+	maxOutlineContextSectionBytes     = 12000
+	maxOutlineNeighborWindow          = 3
+)
+
+// OutlineContextSelector optionally replaces deterministic chunk selection.
+// Implementations must return chunk ids from the provided outline. The caller
+// caps accepted selections and falls back to deterministic selection on errors
+// or unusable ids.
+type OutlineContextSelector func(context.Context, OutlineContextSelectionInput) ([]int64, error)
+
+// OutlineContextQuery controls outline-guided retrieval over the indexed corpus.
+type OutlineContextQuery struct {
+	Query                   string                 `json:"query"`
+	Refs                    []string               `json:"refs,omitempty"`
+	Kinds                   []string               `json:"kinds,omitempty"`
+	Limit                   int                    `json:"limit,omitempty"`
+	MaxSelectionsPerRecord  int                    `json:"max_selections_per_record,omitempty"`
+	IncludeParent           bool                   `json:"include_parent,omitempty"`
+	NeighborWindow          int                    `json:"neighbor_window,omitempty"`
+	MaxOutlineRowsPerRecord int                    `json:"max_outline_rows_per_record,omitempty"`
+	MaxSectionBytes         int                    `json:"max_section_bytes,omitempty"`
+	Selector                OutlineContextSelector `json:"-"`
+}
+
+// OutlineContextSelectionInput is the bounded payload passed to an optional
+// selector.
+type OutlineContextSelectionInput struct {
+	Query         string                       `json:"query"`
+	Record        OutlineContextRecordSummary  `json:"record"`
+	Outline       []OutlineContextOutlineRow   `json:"outline"`
+	Contributions []OutlineContextContribution `json:"contributions"`
+	Limit         int                          `json:"limit"`
+}
+
+// OutlineContextResult is the reusable PageIndex-inspired context payload.
+type OutlineContextResult struct {
+	Query               string                   `json:"query"`
+	SnapshotFingerprint string                   `json:"snapshot_fingerprint,omitempty"`
+	Records             []OutlineContextRecord   `json:"records"`
+	Warnings            []string                 `json:"warnings,omitempty"`
+	ContentTrust        *resultmeta.ContentTrust `json:"content_trust,omitempty"`
+}
+
+// OutlineContextRecord groups outline and expanded sections for one record.
+type OutlineContextRecord struct {
+	OutlineContextRecordSummary
+	Score            float64                      `json:"score"`
+	Outline          []OutlineContextOutlineRow   `json:"outline"`
+	OutlineTruncated bool                         `json:"outline_truncated,omitempty"`
+	Contributions    []OutlineContextContribution `json:"contributions,omitempty"`
+	Selections       []OutlineContextSelection    `json:"selections"`
+}
+
+// OutlineContextRecordSummary identifies one retrieved record.
+type OutlineContextRecordSummary struct {
+	Ref       string `json:"ref"`
+	Kind      string `json:"kind"`
+	Title     string `json:"title"`
+	SourceRef string `json:"source_ref"`
+}
+
+// OutlineContextOutlineRow is one structural row from a record outline.
+type OutlineContextOutlineRow struct {
+	ChunkID       int64                     `json:"chunk_id"`
+	Heading       string                    `json:"heading"`
+	ParentChunkID *int64                    `json:"parent_chunk_id,omitempty"`
+	Depth         int                       `json:"depth"`
+	ContextPrefix string                    `json:"context_prefix,omitempty"`
+	SourceSpan    *OutlineContextSourceSpan `json:"source_span,omitempty"`
+}
+
+// OutlineContextContribution records why a record entered the candidate set.
+type OutlineContextContribution struct {
+	ChunkID    int64                     `json:"chunk_id"`
+	Heading    string                    `json:"heading"`
+	Score      float64                   `json:"score"`
+	SourceSpan *OutlineContextSourceSpan `json:"source_span,omitempty"`
+}
+
+// OutlineContextSelection is one selected chunk and its expanded context.
+type OutlineContextSelection struct {
+	ChunkID         int64                     `json:"chunk_id"`
+	Heading         string                    `json:"heading"`
+	Score           float64                   `json:"score,omitempty"`
+	SelectionSource string                    `json:"selection_source"`
+	SourceSpan      *OutlineContextSourceSpan `json:"source_span,omitempty"`
+	Expanded        []OutlineContextSection   `json:"expanded"`
+}
+
+// OutlineContextSection is one bounded section returned by ExpandContext.
+type OutlineContextSection struct {
+	ChunkID          int64                     `json:"chunk_id"`
+	Ref              string                    `json:"ref"`
+	Kind             string                    `json:"kind"`
+	Title            string                    `json:"title"`
+	SourceRef        string                    `json:"source_ref"`
+	Heading          string                    `json:"heading"`
+	Role             string                    `json:"role"`
+	Depth            *int                      `json:"depth,omitempty"`
+	Content          string                    `json:"content"`
+	ContentTruncated bool                      `json:"content_truncated,omitempty"`
+	ContextPrefix    string                    `json:"context_prefix,omitempty"`
+	SourceSpan       *OutlineContextSourceSpan `json:"source_span,omitempty"`
+}
+
+// OutlineContextSourceSpan is a JSON-stable source extent.
+type OutlineContextSourceSpan struct {
+	Unit     string            `json:"unit"`
+	Start    int64             `json:"start"`
+	End      int64             `json:"end"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type outlineContextSelectionPlan struct {
+	chunkIDs []int64
+	source   string
+	warning  string
+}
+
+// RetrieveOutlineContext executes outline-guided context retrieval.
+func RetrieveOutlineContext(cfg *config.Config, query OutlineContextQuery) (*OutlineContextResult, error) {
+	return RetrieveOutlineContextContext(context.Background(), cfg, query)
+}
+
+// RetrieveOutlineContextContext executes outline-guided context retrieval.
+func RetrieveOutlineContextContext(ctx context.Context, cfg *config.Config, query OutlineContextQuery) (*OutlineContextResult, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	query, err := normalizeOutlineContextQuery(query)
+	if err != nil {
+		return nil, err
+	}
+
+	embedder, err := newEmbedder(cfg.Runtime.Embedder)
+	if err != nil {
+		return nil, err
+	}
+	searchCtx, err := openSearchContext(ctx, cfg, embedder)
+	if err != nil {
+		return nil, err
+	}
+	defer searchCtx.Close()
+
+	return RetrieveOutlineContextWithSnapshotContext(ctx, cfg, searchCtx.snapshot, searchCtx.embedder, query)
+}
+
+// RetrieveOutlineContextWithSnapshotContext executes outline-guided context
+// retrieval against a caller-owned snapshot. The caller remains responsible for
+// closing the snapshot.
+func RetrieveOutlineContextWithSnapshotContext(ctx context.Context, cfg *config.Config, snapshot *stindex.Snapshot, embedder Embedder, query OutlineContextQuery) (*OutlineContextResult, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	if snapshot == nil {
+		return nil, fmt.Errorf("stroma snapshot is required")
+	}
+	if embedder == nil {
+		return nil, fmt.Errorf("embedder is required")
+	}
+	query, err := normalizeOutlineContextQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	strategy, err := fusionStrategyFromConfig(cfg.Runtime.Search)
+	if err != nil {
+		return nil, err
+	}
+	hits, err := snapshot.SearchRecords(ctx, stindex.SnapshotRecordSearchQuery{
+		SearchParams: stindex.SearchParams{
+			Text:     query.Query,
+			Limit:    searchCandidateLimit(query.Limit),
+			Kinds:    query.Kinds,
+			Refs:     query.Refs,
+			Embedder: embedder,
+			Fusion:   strategy,
+			Reranker: selectSearchReranker(cfg.Runtime.Search.Reranker, ranking.SearchPrefersHistoricalContext(query.Query)),
+		},
+		Aggregation: stindex.RecordAggregationOptions{Limit: query.Limit},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search outline-context candidates: %w", err)
+	}
+
+	stats, err := snapshot.Stats(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read stroma snapshot stats: %w", err)
+	}
+	groupedOutline, err := loadOutlineContextRows(ctx, snapshot, refsForRecordHits(hits), query.Kinds)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &OutlineContextResult{
+		Query:               query.Query,
+		SnapshotFingerprint: stats.ContentFingerprint,
+		Records:             make([]OutlineContextRecord, 0, len(hits)),
+		ContentTrust:        resultmeta.UntrustedWorkspaceText(),
+	}
+	for _, hit := range hits {
+		record, warnings, err := buildOutlineContextRecord(ctx, snapshot, query, hit, groupedOutline[hit.Ref])
+		if err != nil {
+			return nil, err
+		}
+		result.Warnings = append(result.Warnings, warnings...)
+		result.Records = append(result.Records, record)
+	}
+	return result, nil
+}
+
+func fusionStrategyFromConfig(cfg config.SearchConfig) (stindex.FusionStrategy, error) {
+	strategy, err := fusion.Resolve(fusionConfigFromRuntime(cfg))
+	if err != nil {
+		return nil, fmt.Errorf("resolve search fusion: %w", err)
+	}
+	return strategy, nil
+}
+
+func normalizeOutlineContextQuery(query OutlineContextQuery) (OutlineContextQuery, error) {
+	query.Query = strings.TrimSpace(query.Query)
+	if query.Query == "" {
+		return OutlineContextQuery{}, fmt.Errorf("query is required")
+	}
+	limit, err := normalizeOutlineBoundedLimit(query.Limit, defaultOutlineContextLimit, maxOutlineContextLimit, "limit")
+	if err != nil {
+		return OutlineContextQuery{}, err
+	}
+	selections, err := normalizeOutlineBoundedLimit(query.MaxSelectionsPerRecord, defaultOutlineSelectionsPerRecord, maxOutlineSelectionsPerRecord, "max_selections_per_record")
+	if err != nil {
+		return OutlineContextQuery{}, err
+	}
+	outlineRows, err := normalizeOutlineBoundedLimit(query.MaxOutlineRowsPerRecord, defaultOutlineRowsPerRecord, maxOutlineRowsPerRecord, "max_outline_rows_per_record")
+	if err != nil {
+		return OutlineContextQuery{}, err
+	}
+	sectionBytes, err := normalizeOutlineBoundedLimit(query.MaxSectionBytes, defaultOutlineContextSectionBytes, maxOutlineContextSectionBytes, "max_section_bytes")
+	if err != nil {
+		return OutlineContextQuery{}, err
+	}
+	if query.NeighborWindow < 0 {
+		return OutlineContextQuery{}, fmt.Errorf("neighbor_window must be greater than or equal to zero")
+	}
+	if query.NeighborWindow > maxOutlineNeighborWindow {
+		return OutlineContextQuery{}, fmt.Errorf("neighbor_window must be less than or equal to %d", maxOutlineNeighborWindow)
+	}
+	query.Limit = limit
+	query.MaxSelectionsPerRecord = selections
+	query.MaxOutlineRowsPerRecord = outlineRows
+	query.MaxSectionBytes = sectionBytes
+	query.Kinds = normalizeOutlineKinds(query.Kinds)
+	query.Refs = uniqueTrimmedStrings(query.Refs)
+	return query, nil
+}
+
+func normalizeOutlineBoundedLimit(value, fallback, max int, name string) (int, error) {
+	if value == 0 {
+		return fallback, nil
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("%s must be positive; use 0 to select the default", name)
+	}
+	if value > max {
+		return 0, fmt.Errorf("%s must be less than or equal to %d", name, max)
+	}
+	return value, nil
+}
+
+func normalizeOutlineKinds(kinds []string) []string {
+	kinds = uniqueTrimmedStrings(kinds)
+	if len(kinds) == 0 {
+		return []string{model.ArtifactKindSpec, model.ArtifactKindDoc}
+	}
+	return kinds
+}
+
+func uniqueTrimmedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func refsForRecordHits(hits []stindex.RecordSearchHit) []string {
+	if len(hits) == 0 {
+		return nil
+	}
+	refs := make([]string, 0, len(hits))
+	for _, hit := range hits {
+		refs = append(refs, hit.Ref)
+	}
+	return refs
+}
+
+func loadOutlineContextRows(ctx context.Context, snapshot *stindex.Snapshot, refs, kinds []string) (map[string][]OutlineContextOutlineRow, error) {
+	grouped := make(map[string][]OutlineContextOutlineRow, len(refs))
+	if len(refs) == 0 {
+		return grouped, nil
+	}
+	rows, err := snapshot.Outline(ctx, stindex.OutlineQuery{
+		Refs:  refs,
+		Kinds: kinds,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read candidate outlines: %w", err)
+	}
+	for _, row := range rows {
+		grouped[row.Ref] = append(grouped[row.Ref], outlineRowFromStroma(row))
+	}
+	return grouped, nil
+}
+
+func buildOutlineContextRecord(ctx context.Context, snapshot *stindex.Snapshot, query OutlineContextQuery, hit stindex.RecordSearchHit, outline []OutlineContextOutlineRow) (OutlineContextRecord, []string, error) {
+	record := OutlineContextRecord{
+		OutlineContextRecordSummary: OutlineContextRecordSummary{
+			Ref:       hit.Ref,
+			Kind:      hit.Kind,
+			Title:     hit.Title,
+			SourceRef: hit.SourceRef,
+		},
+		Score:         hit.Score,
+		Outline:       trimOutlineRows(outline, query.MaxOutlineRowsPerRecord),
+		Contributions: contributionsFromRecordHit(hit),
+		Selections:    []OutlineContextSelection{},
+	}
+	record.OutlineTruncated = len(record.Outline) < len(outline)
+
+	selectionPlan := planOutlineContextSelection(ctx, query, record, outline)
+	var warnings []string
+	if selectionPlan.warning != "" {
+		warnings = append(warnings, selectionPlan.warning)
+	}
+
+	outlineByChunkID := outlineRowsByChunkID(outline)
+	contributionsByChunkID := contributionsByChunkID(record.Contributions)
+	for _, chunkID := range selectionPlan.chunkIDs {
+		expanded, err := snapshot.ExpandContext(ctx, chunkID, stindex.ContextOptions{
+			IncludeParent:  query.IncludeParent,
+			NeighborWindow: query.NeighborWindow,
+		})
+		if err != nil {
+			return OutlineContextRecord{}, nil, fmt.Errorf("expand context for chunk %d: %w", chunkID, err)
+		}
+		record.Selections = append(record.Selections, buildOutlineContextSelection(
+			chunkID,
+			selectionPlan.source,
+			outlineByChunkID,
+			contributionsByChunkID,
+			expanded,
+			query.MaxSectionBytes,
+		))
+	}
+	return record, warnings, nil
+}
+
+func trimOutlineRows(rows []OutlineContextOutlineRow, limit int) []OutlineContextOutlineRow {
+	if len(rows) <= limit {
+		return rows
+	}
+	return rows[:limit]
+}
+
+func planOutlineContextSelection(ctx context.Context, query OutlineContextQuery, record OutlineContextRecord, outline []OutlineContextOutlineRow) outlineContextSelectionPlan {
+	if query.Selector != nil {
+		input := OutlineContextSelectionInput{
+			Query:         query.Query,
+			Record:        record.OutlineContextRecordSummary,
+			Outline:       trimOutlineRows(outline, query.MaxOutlineRowsPerRecord),
+			Contributions: record.Contributions,
+			Limit:         query.MaxSelectionsPerRecord,
+		}
+		chunkIDs, err := query.Selector(ctx, input)
+		selected := normalizeSelectedChunkIDs(chunkIDs, outline, query.MaxSelectionsPerRecord)
+		if err == nil && len(selected) > 0 {
+			return outlineContextSelectionPlan{chunkIDs: selected, source: "selector"}
+		}
+		warning := fmt.Sprintf("selector returned no usable chunks for %s; deterministic selection used", record.Ref)
+		if err != nil {
+			warning = fmt.Sprintf("selector failed for %s: %v; deterministic selection used", record.Ref, err)
+		} else if len(chunkIDs) > 0 {
+			warning = fmt.Sprintf("selector returned chunks outside the outline for %s; deterministic selection used", record.Ref)
+		}
+		return outlineContextSelectionPlan{
+			chunkIDs: deterministicOutlineChunkIDs(record.Contributions, outline, query.MaxSelectionsPerRecord),
+			source:   "deterministic_fallback",
+			warning:  warning,
+		}
+	}
+	return outlineContextSelectionPlan{
+		chunkIDs: deterministicOutlineChunkIDs(record.Contributions, outline, query.MaxSelectionsPerRecord),
+		source:   "deterministic",
+	}
+}
+
+func deterministicOutlineChunkIDs(contributions []OutlineContextContribution, outline []OutlineContextOutlineRow, limit int) []int64 {
+	allowed := outlineChunkIDSet(outline)
+	selected := make([]int64, 0, limit)
+	seen := make(map[int64]struct{}, limit)
+	for _, contribution := range sortedContributions(contributions) {
+		if _, ok := allowed[contribution.ChunkID]; !ok {
+			continue
+		}
+		if appendSelectedChunkID(&selected, seen, contribution.ChunkID, limit) {
+			return selected
+		}
+	}
+	for _, row := range outline {
+		if appendSelectedChunkID(&selected, seen, row.ChunkID, limit) {
+			return selected
+		}
+	}
+	return selected
+}
+
+func normalizeSelectedChunkIDs(chunkIDs []int64, outline []OutlineContextOutlineRow, limit int) []int64 {
+	allowed := outlineChunkIDSet(outline)
+	selected := make([]int64, 0, limit)
+	seen := make(map[int64]struct{}, limit)
+	for _, chunkID := range chunkIDs {
+		if _, ok := allowed[chunkID]; !ok {
+			continue
+		}
+		if appendSelectedChunkID(&selected, seen, chunkID, limit) {
+			return selected
+		}
+	}
+	return selected
+}
+
+func appendSelectedChunkID(selected *[]int64, seen map[int64]struct{}, chunkID int64, limit int) bool {
+	if chunkID == 0 {
+		return false
+	}
+	if _, ok := seen[chunkID]; ok {
+		return false
+	}
+	seen[chunkID] = struct{}{}
+	*selected = append(*selected, chunkID)
+	return len(*selected) >= limit
+}
+
+func sortedContributions(contributions []OutlineContextContribution) []OutlineContextContribution {
+	sorted := append([]OutlineContextContribution(nil), contributions...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Score != sorted[j].Score {
+			return sorted[i].Score > sorted[j].Score
+		}
+		return sorted[i].ChunkID < sorted[j].ChunkID
+	})
+	return sorted
+}
+
+func outlineChunkIDSet(outline []OutlineContextOutlineRow) map[int64]struct{} {
+	set := make(map[int64]struct{}, len(outline))
+	for _, row := range outline {
+		set[row.ChunkID] = struct{}{}
+	}
+	return set
+}
+
+func outlineRowsByChunkID(outline []OutlineContextOutlineRow) map[int64]OutlineContextOutlineRow {
+	byID := make(map[int64]OutlineContextOutlineRow, len(outline))
+	for _, row := range outline {
+		byID[row.ChunkID] = row
+	}
+	return byID
+}
+
+func contributionsByChunkID(contributions []OutlineContextContribution) map[int64]OutlineContextContribution {
+	byID := make(map[int64]OutlineContextContribution, len(contributions))
+	for _, contribution := range contributions {
+		if _, ok := byID[contribution.ChunkID]; ok {
+			continue
+		}
+		byID[contribution.ChunkID] = contribution
+	}
+	return byID
+}
+
+func buildOutlineContextSelection(chunkID int64, source string, outline map[int64]OutlineContextOutlineRow, contributions map[int64]OutlineContextContribution, expanded []stindex.Section, maxBytes int) OutlineContextSelection {
+	row := outline[chunkID]
+	contribution := contributions[chunkID]
+	heading := defaultString(row.Heading, contribution.Heading)
+	selection := OutlineContextSelection{
+		ChunkID:         chunkID,
+		Heading:         heading,
+		Score:           contribution.Score,
+		SelectionSource: source,
+		SourceSpan:      firstSourceSpan(row.SourceSpan, contribution.SourceSpan),
+		Expanded:        make([]OutlineContextSection, 0, len(expanded)),
+	}
+	for _, section := range expanded {
+		selection.Expanded = append(selection.Expanded, sectionFromStroma(section, outline, row, chunkID, maxBytes))
+	}
+	return selection
+}
+
+func firstSourceSpan(spans ...*OutlineContextSourceSpan) *OutlineContextSourceSpan {
+	for _, span := range spans {
+		if span != nil {
+			return span
+		}
+	}
+	return nil
+}
+
+func sectionFromStroma(section stindex.Section, outline map[int64]OutlineContextOutlineRow, selectedRow OutlineContextOutlineRow, selectedID int64, maxBytes int) OutlineContextSection {
+	content, truncated := truncateOutlineContent(section.Content, maxBytes)
+	var depth *int
+	if row, ok := outline[section.ChunkID]; ok {
+		depth = &row.Depth
+	}
+	return OutlineContextSection{
+		ChunkID:          section.ChunkID,
+		Ref:              section.Ref,
+		Kind:             section.Kind,
+		Title:            section.Title,
+		SourceRef:        section.SourceRef,
+		Heading:          section.Heading,
+		Role:             outlineContextSectionRole(section.ChunkID, selectedRow, selectedID),
+		Depth:            depth,
+		Content:          content,
+		ContentTruncated: truncated,
+		ContextPrefix:    section.ContextPrefix,
+		SourceSpan:       sourceSpanFromStroma(section.SourceSpan),
+	}
+}
+
+func outlineContextSectionRole(chunkID int64, selectedRow OutlineContextOutlineRow, selectedID int64) string {
+	if chunkID == selectedID {
+		return "selected"
+	}
+	if selectedRow.ParentChunkID != nil && chunkID == *selectedRow.ParentChunkID {
+		return "parent"
+	}
+	return "neighbor"
+}
+
+func truncateOutlineContent(content string, maxBytes int) (string, bool) {
+	content = strings.TrimSpace(content)
+	if len(content) <= maxBytes {
+		return content, false
+	}
+	cut := utf8SafeCut(content, maxBytes)
+	return strings.TrimSpace(content[:cut]) + "...", true
+}
+
+func utf8SafeCut(content string, maxBytes int) int {
+	if maxBytes <= 0 {
+		return 0
+	}
+	for index, r := range content {
+		next := index + utf8.RuneLen(r)
+		if next > maxBytes {
+			if index == 0 {
+				return 0
+			}
+			return index
+		}
+	}
+	return len(content)
+}
+
+func outlineRowFromStroma(row stindex.OutlineRow) OutlineContextOutlineRow {
+	return OutlineContextOutlineRow{
+		ChunkID:       row.ChunkID,
+		Heading:       row.Heading,
+		ParentChunkID: row.ParentChunkID,
+		Depth:         row.Depth,
+		ContextPrefix: row.ContextPrefix,
+		SourceSpan:    sourceSpanFromStroma(row.SourceSpan),
+	}
+}
+
+func contributionsFromRecordHit(hit stindex.RecordSearchHit) []OutlineContextContribution {
+	if len(hit.Contributions) == 0 {
+		return nil
+	}
+	contributions := make([]OutlineContextContribution, 0, len(hit.Contributions))
+	for _, contribution := range hit.Contributions {
+		contributions = append(contributions, OutlineContextContribution{
+			ChunkID:    contribution.ChunkID,
+			Heading:    contribution.Heading,
+			Score:      contribution.Score,
+			SourceSpan: sourceSpanFromStroma(contribution.SourceSpan),
+		})
+	}
+	return contributions
+}
+
+func sourceSpanFromStroma(span *stchunk.SourceSpan) *OutlineContextSourceSpan {
+	if span == nil {
+		return nil
+	}
+	return &OutlineContextSourceSpan{
+		Unit:     span.Unit,
+		Start:    span.Start,
+		End:      span.End,
+		Metadata: cloneStringMap(span.Metadata),
+	}
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	if len(source) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}

--- a/internal/index/outline_context_test.go
+++ b/internal/index/outline_context_test.go
@@ -1,0 +1,155 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/dusk-network/pituitary/internal/model"
+	"github.com/dusk-network/pituitary/internal/source"
+	stindex "github.com/dusk-network/stroma/v3/index"
+)
+
+func TestRetrieveOutlineContextReturnsOutlineAndExpandedContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	result, err := RetrieveOutlineContext(cfg, OutlineContextQuery{
+		Query:          "tenant-specific API rate-limit configuration",
+		Refs:           []string{"doc://guides/api-rate-limits"},
+		Kinds:          []string{model.ArtifactKindDoc},
+		Limit:          1,
+		IncludeParent:  true,
+		NeighborWindow: 1,
+	})
+	if err != nil {
+		t.Fatalf("RetrieveOutlineContext() error = %v", err)
+	}
+	if result.SnapshotFingerprint == "" {
+		t.Fatal("SnapshotFingerprint is empty")
+	}
+	if len(result.Records) != 1 {
+		t.Fatalf("records = %+v, want one record", result.Records)
+	}
+	record := result.Records[0]
+	if record.Ref != "doc://guides/api-rate-limits" || record.Kind != model.ArtifactKindDoc {
+		t.Fatalf("record = %+v, want API guide doc", record)
+	}
+	if len(record.Outline) == 0 {
+		t.Fatalf("record.Outline is empty")
+	}
+	if len(record.Selections) != 1 {
+		t.Fatalf("selections = %+v, want one selection", record.Selections)
+	}
+	selection := record.Selections[0]
+	if selection.ChunkID == 0 || selection.Heading == "" || selection.SelectionSource != "deterministic" {
+		t.Fatalf("selection = %+v, want deterministic selected chunk", selection)
+	}
+	if len(selection.Expanded) == 0 {
+		t.Fatalf("selection.Expanded is empty")
+	}
+	var foundSelected bool
+	for _, section := range selection.Expanded {
+		if section.Role == "selected" && section.ChunkID == selection.ChunkID && section.Content != "" {
+			foundSelected = true
+		}
+	}
+	if !foundSelected {
+		t.Fatalf("expanded = %+v, want selected section with content", selection.Expanded)
+	}
+}
+
+func TestRetrieveOutlineContextFallsBackWhenSelectorFails(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	result, err := RetrieveOutlineContext(cfg, OutlineContextQuery{
+		Query: "rate limiting",
+		Refs:  []string{"SPEC-042"},
+		Kinds: []string{model.ArtifactKindSpec},
+		Limit: 1,
+		Selector: func(context.Context, OutlineContextSelectionInput) ([]int64, error) {
+			return nil, errors.New("selector unavailable")
+		},
+	})
+	if err != nil {
+		t.Fatalf("RetrieveOutlineContext() error = %v", err)
+	}
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "deterministic selection used") {
+		t.Fatalf("warnings = %v, want deterministic fallback warning", result.Warnings)
+	}
+	if len(result.Records) != 1 || len(result.Records[0].Selections) != 1 {
+		t.Fatalf("records = %+v, want one fallback selection", result.Records)
+	}
+	if got, want := result.Records[0].Selections[0].SelectionSource, "deterministic_fallback"; got != want {
+		t.Fatalf("SelectionSource = %q, want %q", got, want)
+	}
+}
+
+func TestRetrieveOutlineContextRejectsUnboundedInputs(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	_, err := RetrieveOutlineContext(cfg, OutlineContextQuery{
+		Query: "rate limiting",
+		Limit: maxOutlineContextLimit + 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "limit must be less than or equal") {
+		t.Fatalf("RetrieveOutlineContext() error = %v, want limit guard", err)
+	}
+}
+
+func TestTruncateOutlineContentPreservesUTF8(t *testing.T) {
+	t.Parallel()
+
+	content, truncated := truncateOutlineContent("alpha café 東京 omega", 11)
+	if !truncated {
+		t.Fatal("truncateOutlineContent() truncated = false, want true")
+	}
+	if !utf8.ValidString(content) {
+		t.Fatalf("truncateOutlineContent() returned invalid UTF-8: %q", content)
+	}
+	if strings.ContainsRune(content, utf8.RuneError) {
+		t.Fatalf("truncateOutlineContent() content = %q, want no replacement rune", content)
+	}
+
+	content, truncated = truncateOutlineContent("🙂 wide", 1)
+	if !truncated || content != "..." || !utf8.ValidString(content) {
+		t.Fatalf("truncateOutlineContent() = (%q, %v), want UTF-8 ellipsis-only truncation", content, truncated)
+	}
+}
+
+func TestSectionFromStromaOmitsUnknownDepth(t *testing.T) {
+	t.Parallel()
+
+	section := sectionFromStroma(stindex.Section{ChunkID: 42, Heading: "Leaf", Content: "body"}, nil, OutlineContextOutlineRow{}, 42, 100)
+	if section.Depth != nil {
+		t.Fatalf("Depth = %v, want nil for section missing from outline", *section.Depth)
+	}
+
+	depth := 2
+	section = sectionFromStroma(stindex.Section{ChunkID: 42, Heading: "Leaf", Content: "body"}, map[int64]OutlineContextOutlineRow{
+		42: {ChunkID: 42, Depth: depth},
+	}, OutlineContextOutlineRow{}, 42, 100)
+	if section.Depth == nil || *section.Depth != depth {
+		t.Fatalf("Depth = %v, want %d", section.Depth, depth)
+	}
+}

--- a/internal/index/parent_chain.go
+++ b/internal/index/parent_chain.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	stchunk "github.com/dusk-network/stroma/v2/chunk"
+	stchunk "github.com/dusk-network/stroma/v3/chunk"
 
 	"github.com/dusk-network/pituitary/sdk"
 )

--- a/internal/index/parent_chain_test.go
+++ b/internal/index/parent_chain_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	stchunk "github.com/dusk-network/stroma/v2/chunk"
+	stchunk "github.com/dusk-network/stroma/v3/chunk"
 
 	pchunk "github.com/dusk-network/pituitary/internal/chunk"
 	"github.com/dusk-network/pituitary/internal/config"

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -19,8 +19,8 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
-	stcorpus "github.com/dusk-network/stroma/v2/corpus"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stcorpus "github.com/dusk-network/stroma/v3/corpus"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 const schemaVersion = 10
@@ -41,6 +41,7 @@ type RebuildResult struct {
 	ReusedArtifactCount   int                        `json:"reused_artifact_count,omitempty"`
 	ReusedChunkCount      int                        `json:"reused_chunk_count,omitempty"`
 	EmbeddedChunkCount    int                        `json:"embedded_chunk_count,omitempty"`
+	ReuseDisabledReason   string                     `json:"reuse_disabled_reason,omitempty"`
 	AddedCount            int                        `json:"added_count,omitempty"`
 	UpdatedCount          int                        `json:"updated_count,omitempty"`
 	RemovedCount          int                        `json:"removed_count,omitempty"`
@@ -114,7 +115,10 @@ func PrepareRebuildContextWithOptions(ctx context.Context, cfg *config.Config, r
 		return nil, err
 	}
 
-	result := summarizeRebuild(records, dimension, reuseState, options)
+	result, err := summarizeRebuild(records, dimension, reuseState, options)
+	if err != nil {
+		return nil, err
+	}
 	result.IndexPath = cfg.Workspace.ResolvedIndexPath
 	result.DryRun = true
 	result.InferAppliesToEnabled = effectiveInferAppliesTo(cfg, records.Specs)
@@ -234,7 +238,10 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 		}
 	}
 
-	result := summarizeRebuild(records, dimension, reuseState, options)
+	result, err := summarizeRebuild(records, dimension, reuseState, options)
+	if err != nil {
+		return nil, err
+	}
 	result.ContentFingerprint = contentFP
 	result.IndexPath = indexPath
 

--- a/internal/index/retrieval_chunk_precision_bench_test.go
+++ b/internal/index/retrieval_chunk_precision_bench_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 // ResolveStatus values for resolveChunkRelevance. Centralized as unexported

--- a/internal/index/retrieval_precision_bench_test.go
+++ b/internal/index/retrieval_precision_bench_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"

--- a/internal/index/reuse.go
+++ b/internal/index/reuse.go
@@ -10,11 +10,12 @@ import (
 	"github.com/dusk-network/pituitary/internal/chunk"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 type reuseState struct {
-	artifacts map[string]storedArtifact
+	artifacts      map[string]storedArtifact
+	disabledReason string
 }
 
 type storedArtifact struct {
@@ -38,28 +39,35 @@ func loadReuseStateContext(ctx context.Context, snapshotPath, embedderFingerprin
 	info, err := os.Stat(snapshotPath)
 	switch {
 	case os.IsNotExist(err):
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
+		return emptyReuseState("no existing stroma snapshot"), nil
 	case err != nil:
 		return nil, fmt.Errorf("stat existing snapshot %s: %w", snapshotPath, err)
 	case info.IsDir():
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
+		return emptyReuseState(fmt.Sprintf("existing stroma snapshot %s is a directory", snapshotPath)), nil
 	}
 
 	snapshot, err := stindex.OpenSnapshot(ctx, snapshotPath)
 	if err != nil {
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
+		return emptyReuseState(fmt.Sprintf("open existing stroma snapshot: %v", err)), nil
 	}
 	defer snapshot.Close()
 
 	stats, err := snapshot.Stats(ctx)
 	if err != nil {
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
+		return emptyReuseState(fmt.Sprintf("read existing stroma snapshot stats: %v", err)), nil
 	}
 	if stats.EmbedderFingerprint != embedderFingerprint || stats.EmbedderDimension != embedderDimension {
-		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
+		return emptyReuseState("existing stroma snapshot embedder does not match current runtime"), nil
 	}
 
 	return loadStoredArtifactsContext(ctx, snapshot)
+}
+
+func emptyReuseState(reason string) *reuseState {
+	return &reuseState{
+		artifacts:      map[string]storedArtifact{},
+		disabledReason: reason,
+	}
 }
 
 func loadStoredArtifactsContext(ctx context.Context, snapshot *stindex.Snapshot) (*reuseState, error) {
@@ -127,29 +135,39 @@ func storedArtifactForRecord(state *reuseState, ref string) storedArtifact {
 	return state.artifacts[ref]
 }
 
-func updateRebuildReuseCountsForSpecs(result *RebuildResult, records []model.SpecRecord, state *reuseState) {
+func updateRebuildReuseCountsForSpecs(result *RebuildResult, records []model.SpecRecord, state *reuseState) error {
 	for _, spec := range records {
-		plan := planArtifactReuse(spec.Title, spec.ContentHash, spec.BodyText, storedArtifactForRecord(state, spec.Ref))
+		record, err := corpusRecordFromSpec(spec)
+		if err != nil {
+			return fmt.Errorf("normalize spec %s for reuse accounting: %w", spec.Ref, err)
+		}
+		plan := planArtifactReuse(spec.Title, record.ContentHash, spec.BodyText, storedArtifactForRecord(state, spec.Ref))
 		if plan.artifactUnchanged {
 			result.ReusedArtifactCount++
 		}
 		result.ReusedChunkCount += plan.reusedChunkCount
 		result.EmbeddedChunkCount += plan.embeddedChunkCount
 	}
+	return nil
 }
 
-func updateRebuildReuseCountsForDocs(result *RebuildResult, records []model.DocRecord, state *reuseState) {
+func updateRebuildReuseCountsForDocs(result *RebuildResult, records []model.DocRecord, state *reuseState) error {
 	for _, doc := range records {
-		plan := planArtifactReuse(doc.Title, doc.ContentHash, doc.BodyText, storedArtifactForRecord(state, doc.Ref))
+		record, err := corpusRecordFromDoc(doc)
+		if err != nil {
+			return fmt.Errorf("normalize doc %s for reuse accounting: %w", doc.Ref, err)
+		}
+		plan := planArtifactReuse(doc.Title, record.ContentHash, doc.BodyText, storedArtifactForRecord(state, doc.Ref))
 		if plan.artifactUnchanged {
 			result.ReusedArtifactCount++
 		}
 		result.ReusedChunkCount += plan.reusedChunkCount
 		result.EmbeddedChunkCount += plan.embeddedChunkCount
 	}
+	return nil
 }
 
-func summarizeRebuild(records *source.LoadResult, dimension int, state *reuseState, options RebuildOptions) *RebuildResult {
+func summarizeRebuild(records *source.LoadResult, dimension int, state *reuseState, options RebuildOptions) (*RebuildResult, error) {
 	result := &RebuildResult{
 		ArtifactCount:     len(records.Specs) + len(records.Docs),
 		SpecCount:         len(records.Specs),
@@ -159,6 +177,9 @@ func summarizeRebuild(records *source.LoadResult, dimension int, state *reuseSta
 		Repos:             repoCoverageFromRecords(records),
 		Sources:           append([]source.LoadSourceSummary(nil), records.Sources...),
 	}
+	if state != nil {
+		result.ReuseDisabledReason = state.disabledReason
+	}
 
 	for _, spec := range records.Specs {
 		result.ChunkCount += len(chunk.Markdown(spec.Title, spec.BodyText))
@@ -167,8 +188,12 @@ func summarizeRebuild(records *source.LoadResult, dimension int, state *reuseSta
 	for _, doc := range records.Docs {
 		result.ChunkCount += len(chunk.Markdown(doc.Title, doc.BodyText))
 	}
-	updateRebuildReuseCountsForSpecs(result, records.Specs, state)
-	updateRebuildReuseCountsForDocs(result, records.Docs, state)
+	if err := updateRebuildReuseCountsForSpecs(result, records.Specs, state); err != nil {
+		return nil, err
+	}
+	if err := updateRebuildReuseCountsForDocs(result, records.Docs, state); err != nil {
+		return nil, err
+	}
 	result.ContentFingerprint = contentFingerprint(records)
-	return result
+	return result, nil
 }

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/ranking"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 const (

--- a/internal/index/search_test.go
+++ b/internal/index/search_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
-	stindex "github.com/dusk-network/stroma/v2/index"
+	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
 func TestSearchSpecsReturnsRankedSections(t *testing.T) {

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 
-	ststore "github.com/dusk-network/stroma/v2/store"
+	ststore "github.com/dusk-network/stroma/v3/store"
 )
 
 func openReadWriteContext(ctx context.Context, path string) (*sql.DB, error) {

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -13,8 +13,8 @@ import (
 	pchunk "github.com/dusk-network/pituitary/internal/chunk"
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
-	stindex "github.com/dusk-network/stroma/v2/index"
-	ststore "github.com/dusk-network/stroma/v2/store"
+	stindex "github.com/dusk-network/stroma/v3/index"
+	ststore "github.com/dusk-network/stroma/v3/store"
 )
 
 // UpdatePreconditionError reports that the existing index is structurally
@@ -137,7 +137,10 @@ func updateContext(ctx context.Context, cfg *config.Config, records *source.Load
 	if err != nil {
 		return nil, err
 	}
-	result := summarizeRebuild(records, dimension, reuseState, RebuildOptions{})
+	result, err := summarizeRebuild(records, dimension, reuseState, RebuildOptions{})
+	if err != nil {
+		return nil, err
+	}
 	result.IndexPath = indexPath
 	result.Update = true
 	result.FullRebuild = false
@@ -553,9 +556,14 @@ func normalizeStromaUpdateError(snapshotPath string, err error) error {
 			Action: "run `pituitary index --rebuild`",
 		}
 	}
+	if errors.Is(err, stindex.ErrUnsupportedSchemaVersion) {
+		return &UpdatePreconditionError{
+			Reason: strings.TrimSpace(err.Error()),
+			Action: "run `pituitary index --rebuild`",
+		}
+	}
 	message := strings.TrimSpace(err.Error())
 	for _, marker := range []string{
-		"schema version mismatch",
 		"embedder fingerprint mismatch",
 		"embedder dimension mismatch",
 		"quantization mismatch",

--- a/internal/index/update_test.go
+++ b/internal/index/update_test.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/source"
-	ststore "github.com/dusk-network/stroma/v2/store"
+	stindex "github.com/dusk-network/stroma/v3/index"
+	ststore "github.com/dusk-network/stroma/v3/store"
 )
 
 func TestUpdateNoOp(t *testing.T) {
@@ -559,7 +560,6 @@ func TestNormalizeStromaUpdateErrorTreatsCompatibilityErrorsAsPreconditions(t *t
 	t.Parallel()
 
 	markers := []string{
-		"schema version mismatch",
 		"embedder fingerprint mismatch",
 		"embedder dimension mismatch",
 		"quantization mismatch",
@@ -581,6 +581,21 @@ func TestNormalizeStromaUpdateErrorTreatsCompatibilityErrorsAsPreconditions(t *t
 				t.Fatalf("normalized error = %q, want rebuild guidance", err)
 			}
 		})
+	}
+}
+
+func TestNormalizeStromaUpdateErrorTreatsUnsupportedSchemaAsPrecondition(t *testing.T) {
+	t.Parallel()
+
+	err := normalizeStromaUpdateError("snapshot.db", fmt.Errorf("%w: index=%q update=%q", stindex.ErrUnsupportedSchemaVersion, "1", "10"))
+	if !IsUpdatePrecondition(err) {
+		t.Fatalf("expected UpdatePreconditionError, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unsupported snapshot schema version") {
+		t.Fatalf("normalized error = %q, want unsupported schema marker", err)
+	}
+	if !strings.Contains(err.Error(), "pituitary index --rebuild") {
+		t.Fatalf("normalized error = %q, want rebuild guidance", err)
 	}
 }
 

--- a/internal/runtimeerr/errors.go
+++ b/internal/runtimeerr/errors.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dusk-network/stroma/v2/provider"
+	"github.com/dusk-network/stroma/v3/provider"
 )
 
 // Failure classes are mirrored from stroma's provider package so callers


### PR DESCRIPTION
## Summary

- upgrade Pituitary to Stroma v3.0.0 and record the 2026-05-07 complexity baseline
- add a reusable `internal/index` outline-context API over SearchRecords, Outline, and ExpandContext
- wire `review-spec --outline-context` to return bounded JSON context with refs, chunk ids, headings, snapshot fingerprint, spans, and expanded sections
- split review-spec orchestration into named phases so PageIndex retrieval does not add another branch-heavy analysis path

Closes #385.

## Complexity

- Ran `skills complexity-scan --path . --top 20` before commit.
- Baseline is recorded in `docs/development/complexity-baseline-2026-05-07.md`.
- Post-implementation scan still shows no new production function in the top branch-heavy list; existing hotspots remain `cmd/run_command.go`, config validation, renderers, rebuild/update.
- Total surface increases because this adds the reusable PageIndex/context API and tests, but complexity in the touched review-spec path is reduced by replacing the single long orchestration body with named phases.

## Reviews

- Ran Claude adversarial review twice before PR creation.
- Addressed findings: UTF-8-safe truncation, capped review refs/query, optional outline-context warning fallback, snapshot reuse instead of double-open, unsupported-schema sentinel handling, reuse-disabled reason reporting, explicit unknown depth handling, and selector fallback diagnostics.

## Validation

- `go test ./...`
- `git diff --minimal --check`
- `skills complexity-scan --path . --top 20`
