### PR TITLE
fix: bound and screen check-compliance --path file reads (#378)

### DIFF
--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dusk-network/pituitary/internal/index"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/resultmeta"
+	"github.com/dusk-network/pituitary/internal/source"
 	"github.com/dusk-network/pituitary/internal/temporal"
 	"golang.org/x/sync/errgroup"
 )
@@ -609,11 +610,13 @@ func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, p
 			return nil, fmt.Errorf("path %q appears to be a binary file; --path expects text content", rawPath)
 		}
 
-		content := string(data)
+		// Compute the digest from the raw bytes to avoid a redundant
+		// string→[]byte copy on near-limit files; the string conversion
+		// for Content remains a single allocation.
 		targets = append(targets, complianceTarget{
 			Path:         relPath,
-			Content:      content,
-			DuplicateKey: complianceContentDigest(content),
+			Content:      string(data),
+			DuplicateKey: complianceContentDigestBytes(data),
 		})
 	}
 	return targets, nil
@@ -831,7 +834,7 @@ func complianceDuplicateKey(workspaceRoot, relPath, fallbackContent string) stri
 		_, absPath, err := resolveWorkspaceFilePath(workspaceRoot, relPath)
 		if err == nil {
 			if data, readErr := readBoundedCompliancePath(absPath, maxCompliancePathBytes); readErr == nil && !looksLikeBinary(data) {
-				return complianceContentDigest(string(data))
+				return complianceContentDigestBytes(data)
 			}
 		}
 	}
@@ -846,6 +849,17 @@ func complianceContentDigest(content string) string {
 		return ""
 	}
 	sum := sha256.Sum256([]byte(content))
+	return fmt.Sprintf("%x", sum[:])
+}
+
+// complianceContentDigestBytes mirrors complianceContentDigest but accepts the
+// raw byte slice already in hand, avoiding a transient string allocation when
+// the caller has just read the file into memory.
+func complianceContentDigestBytes(content []byte) string {
+	if len(content) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(content)
 	return fmt.Sprintf("%x", sum[:])
 }
 
@@ -893,6 +907,26 @@ func resolveWorkspaceFilePath(rootPath, rawPath string) (string, string, error) 
 	}
 	if relPath == ".." || stringsHasPrefix(relPath, ".."+string(filepath.Separator)) {
 		return "", "", fmt.Errorf("path %q is outside workspace root %s", rawPath, rootPath)
+	}
+
+	// Lexical containment alone is not enough: a parent component may be a
+	// symlink that resolves outside the workspace. Re-check containment with
+	// symlink resolution so `--path workspace_link/passwd` cannot read
+	// /etc/passwd via a workspace-resident symlink.
+	realRoot, err := source.EvalSymlinksBestEffort(rootPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve workspace root %q: %w", rootPath, err)
+	}
+	realPath, err := source.EvalSymlinksBestEffort(absPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve path %q: %w", rawPath, err)
+	}
+	realRel, err := filepath.Rel(realRoot, realPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve path %q relative to workspace: %w", rawPath, err)
+	}
+	if realRel == ".." || stringsHasPrefix(realRel, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("path %q resolves outside workspace root %s via symlinks", rawPath, rootPath)
 	}
 
 	return normalizeCompliancePath(relPath), absPath, nil

--- a/internal/analysis/compliance.go
+++ b/internal/analysis/compliance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	pathpkg "path"
 	"path/filepath"
@@ -570,6 +571,16 @@ func loadComplianceTargetsContext(ctx context.Context, cfg *config.Config, reque
 	return loadDiffComplianceTargetsContext(ctx, cfg, request.DiffText)
 }
 
+// maxCompliancePathBytes caps the size of a single --path target so a crafted
+// or accidentally large file in the workspace cannot trigger an unbounded
+// allocation during compliance analysis. Mirrors the markdown body limit used
+// by the indexed source loader.
+const maxCompliancePathBytes = 10 * 1024 * 1024 // 10 MiB
+
+// binarySniffWindow is the number of leading bytes inspected for NUL bytes
+// when screening compliance targets for binary content.
+const binarySniffWindow = 8000
+
 func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, paths []string) ([]complianceTarget, error) {
 	targets := make([]complianceTarget, 0, len(paths))
 
@@ -579,27 +590,70 @@ func loadPathComplianceTargetsContext(ctx context.Context, cfg *config.Config, p
 			return nil, err
 		}
 
-		info, err := os.Stat(absPath)
+		info, err := os.Lstat(absPath)
 		if err != nil {
 			return nil, fmt.Errorf("read path %q: %w", rawPath, err)
 		}
 		if info.IsDir() {
 			return nil, fmt.Errorf("path %q is a directory; --path expects a file", rawPath)
 		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("path %q is not a regular file; --path expects a workspace-resident text file", rawPath)
+		}
 
-		// #nosec G304 -- absPath is resolved under the workspace root by resolveWorkspaceFilePath.
-		data, err := os.ReadFile(absPath)
+		data, err := readBoundedCompliancePath(absPath, maxCompliancePathBytes)
 		if err != nil {
 			return nil, fmt.Errorf("read path %q: %w", rawPath, err)
 		}
+		if looksLikeBinary(data) {
+			return nil, fmt.Errorf("path %q appears to be a binary file; --path expects text content", rawPath)
+		}
 
+		content := string(data)
 		targets = append(targets, complianceTarget{
 			Path:         relPath,
-			Content:      string(data),
-			DuplicateKey: complianceContentDigest(string(data)),
+			Content:      content,
+			DuplicateKey: complianceContentDigest(content),
 		})
 	}
 	return targets, nil
+}
+
+// readBoundedCompliancePath reads at most maxBytes from path, rejecting larger
+// inputs with an explicit error. The read is wrapped in io.LimitReader so a
+// file that grows between Stat and Read still cannot exceed the bound.
+func readBoundedCompliancePath(path string, maxBytes int64) ([]byte, error) {
+	// #nosec G304 -- callers resolve path containment via resolveWorkspaceFilePath; LimitReader enforces the allocation bound.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%s exceeds %d-byte size limit", filepath.ToSlash(path), maxBytes)
+	}
+	return data, nil
+}
+
+// looksLikeBinary returns true when the leading binarySniffWindow bytes of
+// data contain a NUL byte. This is the same heuristic git uses for its
+// "binary files differ" detection and is sufficient to keep obvious binaries
+// out of compliance analysis prompts.
+func looksLikeBinary(data []byte) bool {
+	n := len(data)
+	if n > binarySniffWindow {
+		n = binarySniffWindow
+	}
+	for i := 0; i < n; i++ {
+		if data[i] == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func loadDiffComplianceTargetsContext(ctx context.Context, cfg *config.Config, diffText string) ([]complianceTarget, error) {
@@ -776,7 +830,7 @@ func complianceDuplicateKey(workspaceRoot, relPath, fallbackContent string) stri
 	if workspaceRoot != "" && relPath != "" {
 		_, absPath, err := resolveWorkspaceFilePath(workspaceRoot, relPath)
 		if err == nil {
-			if data, readErr := os.ReadFile(absPath); readErr == nil {
+			if data, readErr := readBoundedCompliancePath(absPath, maxCompliancePathBytes); readErr == nil && !looksLikeBinary(data) {
 				return complianceContentDigest(string(data))
 			}
 		}

--- a/internal/analysis/compliance_path_read_test.go
+++ b/internal/analysis/compliance_path_read_test.go
@@ -1,0 +1,173 @@
+package analysis
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+func TestLoadPathComplianceTargetsContext_RejectsOversizedFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg := &config.Config{Workspace: config.Workspace{RootPath: root}}
+
+	rel := "src/big.go"
+	abs := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Write 1 byte over the limit; LimitReader stops at maxCompliancePathBytes+1.
+	oversized := bytes.Repeat([]byte("a"), maxCompliancePathBytes+1)
+	if err := os.WriteFile(abs, oversized, 0o644); err != nil {
+		t.Fatalf("write oversized: %v", err)
+	}
+
+	_, err := loadPathComplianceTargetsContext(t.Context(), cfg, []string{rel})
+	if err == nil {
+		t.Fatalf("loadPathComplianceTargetsContext: want size-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("loadPathComplianceTargetsContext error = %v, want size-limit error", err)
+	}
+}
+
+func TestLoadPathComplianceTargetsContext_RejectsBinaryFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg := &config.Config{Workspace: config.Workspace{RootPath: root}}
+
+	rel := "bin/blob.dat"
+	abs := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// NUL byte inside the sniff window triggers the binary screen.
+	if err := os.WriteFile(abs, []byte("text\x00more text"), 0o644); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	_, err := loadPathComplianceTargetsContext(t.Context(), cfg, []string{rel})
+	if err == nil {
+		t.Fatalf("loadPathComplianceTargetsContext: want binary-rejection error, got nil")
+	}
+	if !strings.Contains(err.Error(), "binary file") {
+		t.Fatalf("loadPathComplianceTargetsContext error = %v, want binary-file error", err)
+	}
+}
+
+func TestLoadPathComplianceTargetsContext_AcceptsSmallTextFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg := &config.Config{Workspace: config.Workspace{RootPath: root}}
+
+	rel := "src/handler.go"
+	abs := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "package main\n\nfunc main() {}\n"
+	if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	targets, err := loadPathComplianceTargetsContext(t.Context(), cfg, []string{rel})
+	if err != nil {
+		t.Fatalf("loadPathComplianceTargetsContext error = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("len(targets) = %d, want 1", len(targets))
+	}
+	if got, want := targets[0].Path, rel; got != want {
+		t.Fatalf("targets[0].Path = %q, want %q", got, want)
+	}
+	if got, want := targets[0].Content, body; got != want {
+		t.Fatalf("targets[0].Content = %q, want %q", got, want)
+	}
+	if targets[0].DuplicateKey == "" {
+		t.Fatalf("targets[0].DuplicateKey is empty; want sha256 digest")
+	}
+}
+
+func TestLoadPathComplianceTargetsContext_RejectsSymlink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg := &config.Config{Workspace: config.Workspace{RootPath: root}}
+
+	target := filepath.Join(root, "real.go")
+	if err := os.WriteFile(target, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(root, "link.go")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+
+	_, err := loadPathComplianceTargetsContext(t.Context(), cfg, []string{"link.go"})
+	if err == nil {
+		t.Fatalf("loadPathComplianceTargetsContext on symlink: want non-regular-file error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("loadPathComplianceTargetsContext error = %v, want non-regular-file error", err)
+	}
+}
+
+func TestReadBoundedCompliancePath_ReturnsExactSizeAtLimit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "limit.txt")
+
+	const limit int64 = 32
+	atLimit := bytes.Repeat([]byte("x"), int(limit))
+	if err := os.WriteFile(path, atLimit, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readBoundedCompliancePath(path, limit)
+	if err != nil {
+		t.Fatalf("readBoundedCompliancePath at limit: err = %v", err)
+	}
+	if !bytes.Equal(got, atLimit) {
+		t.Fatalf("readBoundedCompliancePath returned %d bytes, want %d", len(got), len(atLimit))
+	}
+
+	overLimit := bytes.Repeat([]byte("x"), int(limit)+1)
+	if err := os.WriteFile(path, overLimit, 0o644); err != nil {
+		t.Fatalf("write over: %v", err)
+	}
+	if _, err := readBoundedCompliancePath(path, limit); err == nil {
+		t.Fatalf("readBoundedCompliancePath over limit: err = nil, want size-limit error")
+	}
+}
+
+func TestLooksLikeBinary(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"empty", nil, false},
+		{"plain text", []byte("hello world\n"), false},
+		{"utf8 bom", []byte("\xEF\xBB\xBFhello"), false},
+		{"nul byte at start", []byte("\x00abc"), true},
+		{"nul byte in window", append([]byte(strings.Repeat("a", 100)), 0x00, 'x'), true},
+		{"nul byte beyond window", append(bytes.Repeat([]byte("a"), binarySniffWindow), 0x00), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := looksLikeBinary(tc.data); got != tc.want {
+				t.Fatalf("looksLikeBinary(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/analysis/compliance_path_read_test.go
+++ b/internal/analysis/compliance_path_read_test.go
@@ -119,6 +119,34 @@ func TestLoadPathComplianceTargetsContext_RejectsSymlink(t *testing.T) {
 	}
 }
 
+func TestLoadPathComplianceTargetsContext_RejectsSymlinkedParentEscape(t *testing.T) {
+	t.Parallel()
+
+	// Outside-workspace target -- must never be read by --path, even via a
+	// symlinked parent directory inside the workspace. Final-component Lstat
+	// alone misses this; the symlink-safe containment check in
+	// resolveWorkspaceFilePath catches it.
+	outside := t.TempDir()
+	outsideFile := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("SECRET"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	root := t.TempDir()
+	cfg := &config.Config{Workspace: config.Workspace{RootPath: root}}
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := loadPathComplianceTargetsContext(t.Context(), cfg, []string{"escape/secret.txt"})
+	if err == nil {
+		t.Fatalf("loadPathComplianceTargetsContext: want symlink-escape error, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside workspace") {
+		t.Fatalf("loadPathComplianceTargetsContext error = %v, want outside-workspace error", err)
+	}
+}
+
 func TestReadBoundedCompliancePath_ReturnsExactSizeAtLimit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `loadPathComplianceTargetsContext` now applies a 10 MiB bounded read (matching the indexed source loader's `maxMarkdownBodyBytes`), a NUL-byte binary screen, and a regular-file guard before handing content to compliance analysis.
- `complianceDuplicateKey` uses the same bounded reader so the duplicate-collapse path cannot itself trigger an unbounded allocation.
- File contents are converted to a string once at the call site, removing the duplicate `string(data)` conversion the issue called out.

Closes #378.

## Out-of-scope follow-ups (raised by adversarial review)
- Aggregate input budget across many `--path` targets and downstream embedding-payload limits — separate sizing question, not part of "match indexed source safety limits."
- Stronger text-content validation than NUL-byte sniffing (e.g. UTF-8 decode, UTF-16 acceptance) — current heuristic mirrors git's "binary files differ" detection; tightening it changes UX semantics and deserves its own issue.

## Test plan
- [x] `go test ./internal/analysis/ -run "TestLoadPathComplianceTargetsContext|TestReadBoundedCompliancePath|TestLooksLikeBinary"` (oversized, binary, symlink, regular-file, exact-limit, NUL-byte heuristic)
- [x] `make ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)