### PR TITLE
fix: bound discovery file reads to match indexed source safety limits (#375)

### DIFF
--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -187,6 +187,28 @@ func WriteDiscoveredConfig(path, content string) error {
 	return writeDiscoveredConfig(path, content)
 }
 
+// dirEntryIsRegular reports whether d describes a regular file. It first
+// trusts d.Type(), which on Linux/macOS is populated from the readdir d_type
+// entry (with a kernel-side lstat fallback for DT_UNKNOWN). On filesystems
+// that report unset type bits via a non-zero non-regular type mask, it
+// reaches for d.Info() as a defensive double-check, so an Info() error or a
+// non-regular resolved mode rejects the entry rather than letting an
+// ambiguous type slip through.
+func dirEntryIsRegular(d os.DirEntry) bool {
+	typ := d.Type()
+	if typ == 0 {
+		// Type bits unset: could be a regular file, or could be a
+		// filesystem that did not populate d_type. Resolve via Info to
+		// disambiguate so we never read a non-regular target.
+		info, err := d.Info()
+		if err != nil {
+			return false
+		}
+		return info.Mode().IsRegular()
+	}
+	return typ.IsRegular()
+}
+
 func discoverSpecBundleCandidates(workspaceRoot string, logger *diag.Logger) ([]discoveredCandidate, map[string]struct{}, int, error) {
 	var candidates []discoveredCandidate
 	bundleDirs := make(map[string]struct{})
@@ -206,7 +228,7 @@ func discoverSpecBundleCandidates(workspaceRoot string, logger *diag.Logger) ([]
 		if d.Name() != "spec.toml" {
 			return nil
 		}
-		if !d.Type().IsRegular() {
+		if !dirEntryIsRegular(d) {
 			rejected++
 			logger.Debugf("discover", "rejected spec bundle %s: spec.toml is not a regular file", workspaceRelative(workspaceRoot, path))
 			return nil
@@ -325,7 +347,7 @@ func discoverMarkdownCandidates(workspaceRoot string, specBundleDirs map[string]
 		if filepath.Ext(path) != ".md" {
 			return nil
 		}
-		if !d.Type().IsRegular() {
+		if !dirEntryIsRegular(d) {
 			logger.Debugf("discover", "skipping markdown %s: not a regular file", workspaceRelative(workspaceRoot, path))
 			return nil
 		}

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -206,6 +206,11 @@ func discoverSpecBundleCandidates(workspaceRoot string, logger *diag.Logger) ([]
 		if d.Name() != "spec.toml" {
 			return nil
 		}
+		if !d.Type().IsRegular() {
+			rejected++
+			logger.Debugf("discover", "rejected spec bundle %s: spec.toml is not a regular file", workspaceRelative(workspaceRoot, path))
+			return nil
+		}
 
 		bundleDir := filepath.Dir(path)
 		ok, rationale, rejectionReason := assessDiscoveredSpecBundle(workspaceRoot, bundleDir)
@@ -246,8 +251,7 @@ func discoverSpecBundleCandidates(workspaceRoot string, logger *diag.Logger) ([]
 
 func discoverSpecBundleIdentity(bundleDir string) (string, string, error) {
 	specPath := filepath.Join(bundleDir, "spec.toml")
-	// #nosec G304 -- specPath is the fixed bundle manifest inside a discovered workspace directory.
-	specBytes, err := os.ReadFile(specPath)
+	specBytes, err := readBoundedFile(specPath, maxSpecTOMLBytes)
 	if err != nil {
 		return "", "", fmt.Errorf("read discovered spec bundle %q: %w", filepath.ToSlash(bundleDir), err)
 	}
@@ -259,8 +263,7 @@ func discoverSpecBundleIdentity(bundleDir string) (string, string, error) {
 	if !pathWithinRoot(bundleDir, bodyPath) {
 		return "", "", fmt.Errorf("read discovered spec body %q: path escapes bundle", filepath.ToSlash(bodyPath))
 	}
-	// #nosec G304 -- bodyPath is validated to remain inside the discovered bundle directory.
-	bodyBytes, err := os.ReadFile(bodyPath)
+	bodyBytes, err := readBoundedFile(bodyPath, maxMarkdownBodyBytes)
 	if err != nil {
 		return "", "", fmt.Errorf("read discovered spec body %q: %w", filepath.ToSlash(bodyPath), err)
 	}
@@ -269,8 +272,7 @@ func discoverSpecBundleIdentity(bundleDir string) (string, string, error) {
 
 func assessDiscoveredSpecBundle(workspaceRoot, bundleDir string) (bool, []string, string) {
 	specPath := filepath.Join(bundleDir, "spec.toml")
-	// #nosec G304 -- specPath is the fixed bundle manifest inside a discovered workspace directory.
-	specBytes, err := os.ReadFile(specPath)
+	specBytes, err := readBoundedFile(specPath, maxSpecTOMLBytes)
 	if err != nil {
 		return false, nil, fmt.Sprintf("read spec.toml: %v", err)
 	}
@@ -286,12 +288,16 @@ func assessDiscoveredSpecBundle(workspaceRoot, bundleDir string) (bool, []string
 	if !pathWithinRoot(bundleDir, bodyPath) {
 		return false, nil, fmt.Sprintf("body path %q escapes the bundle directory", raw.Body)
 	}
-	info, err := os.Stat(bodyPath)
+	info, err := os.Lstat(bodyPath)
 	switch {
 	case err != nil:
 		return false, nil, fmt.Sprintf("body file %s does not exist", workspaceRelative(workspaceRoot, bodyPath))
 	case info.IsDir():
 		return false, nil, fmt.Sprintf("body path %s is a directory", workspaceRelative(workspaceRoot, bodyPath))
+	case !info.Mode().IsRegular():
+		return false, nil, fmt.Sprintf("body file %s is not a regular file", workspaceRelative(workspaceRoot, bodyPath))
+	case info.Size() > maxMarkdownBodyBytes:
+		return false, nil, fmt.Sprintf("body file %s exceeds %d-byte size limit", workspaceRelative(workspaceRoot, bodyPath), maxMarkdownBodyBytes)
 	}
 
 	return true, []string{
@@ -317,6 +323,10 @@ func discoverMarkdownCandidates(workspaceRoot string, specBundleDirs map[string]
 			return nil
 		}
 		if filepath.Ext(path) != ".md" {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			logger.Debugf("discover", "skipping markdown %s: not a regular file", workspaceRelative(workspaceRoot, path))
 			return nil
 		}
 		if withinAnyDiscoveryRoot(path, specBundleDirs) {
@@ -353,8 +363,7 @@ func discoverMarkdownCandidates(workspaceRoot string, specBundleDirs map[string]
 
 func classifyMarkdownCandidate(workspaceRoot, path string) (markdownCandidateAssessment, error) {
 	relPath := workspaceRelative(workspaceRoot, path)
-	// #nosec G304 -- path comes from filepath.WalkDir rooted at the workspace.
-	body, err := os.ReadFile(path)
+	body, err := readBoundedFile(path, maxMarkdownBodyBytes)
 	if err != nil {
 		return markdownCandidateAssessment{
 			RelativePath: relPath,

--- a/internal/source/discover_bounded_test.go
+++ b/internal/source/discover_bounded_test.go
@@ -180,29 +180,30 @@ Landing page.
 func TestDiscoverSpecBundles_SkipsSymlinkedSpecTOML(t *testing.T) {
 	t.Parallel()
 
-	repo := t.TempDir()
-	// Real bundle outside any spec dir to act as the symlink target.
-	realDir := filepath.Join(repo, "external")
-	if err := os.MkdirAll(realDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	mustWriteFile(t, filepath.Join(realDir, "spec.toml"), `
+	// Place the real bundle OUTSIDE the workspace so discovery cannot find
+	// it as a normal candidate. The only way SPEC-EXTERNAL can land in the
+	// generated config is if discovery follows the in-workspace symlink --
+	// which the regular-file guard must prevent.
+	external := t.TempDir()
+	mustWriteFile(t, filepath.Join(external, "spec.toml"), `
 id = "SPEC-EXTERNAL"
 title = "External"
 status = "draft"
 domain = "api"
 body = "body.md"
 `)
-	mustWriteFile(t, filepath.Join(realDir, "body.md"), `
+	mustWriteFile(t, filepath.Join(external, "body.md"), `
 # External
 
 Body.
 `)
+
+	repo := t.TempDir()
 	bundleDir := filepath.Join(repo, "specs", "via-symlink")
 	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := os.Symlink(filepath.Join(realDir, "spec.toml"), filepath.Join(bundleDir, "spec.toml")); err != nil {
+	if err := os.Symlink(filepath.Join(external, "spec.toml"), filepath.Join(bundleDir, "spec.toml")); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
 

--- a/internal/source/discover_bounded_test.go
+++ b/internal/source/discover_bounded_test.go
@@ -1,0 +1,238 @@
+package source
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAssessDiscoveredSpecBundle_RejectsOversizedSpecTOML(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	bundleDir := filepath.Join(repo, "specs", "huge")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// One byte over the spec.toml bound is enough to trip readBoundedFile.
+	oversized := bytes.Repeat([]byte("a"), maxSpecTOMLBytes+1)
+	if err := os.WriteFile(filepath.Join(bundleDir, "spec.toml"), oversized, 0o644); err != nil {
+		t.Fatalf("write spec.toml: %v", err)
+	}
+
+	ok, _, reason := assessDiscoveredSpecBundle(repo, bundleDir)
+	if ok {
+		t.Fatalf("assessDiscoveredSpecBundle: ok = true, want false for oversized spec.toml")
+	}
+	if !strings.Contains(reason, "size limit") {
+		t.Fatalf("assessDiscoveredSpecBundle reason = %q, want size-limit rejection", reason)
+	}
+}
+
+func TestDiscoverSpecBundleIdentity_RejectsOversizedSpecTOML(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	bundleDir := filepath.Join(repo, "specs", "huge")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	oversized := bytes.Repeat([]byte("a"), maxSpecTOMLBytes+1)
+	if err := os.WriteFile(filepath.Join(bundleDir, "spec.toml"), oversized, 0o644); err != nil {
+		t.Fatalf("write spec.toml: %v", err)
+	}
+
+	if _, _, err := discoverSpecBundleIdentity(bundleDir); err == nil {
+		t.Fatalf("discoverSpecBundleIdentity: err = nil, want size-limit error")
+	} else if !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("discoverSpecBundleIdentity error = %v, want size-limit error", err)
+	}
+}
+
+func TestDiscoverSpecBundleIdentity_RejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	bundleDir := filepath.Join(repo, "specs", "huge-body")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(bundleDir, "spec.toml"), `
+id = "SPEC-HUGE"
+title = "Huge Body"
+status = "draft"
+domain = "api"
+body = "body.md"
+`)
+	oversized := bytes.Repeat([]byte("a"), maxMarkdownBodyBytes+1)
+	if err := os.WriteFile(filepath.Join(bundleDir, "body.md"), oversized, 0o644); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+
+	if _, _, err := discoverSpecBundleIdentity(bundleDir); err == nil {
+		t.Fatalf("discoverSpecBundleIdentity: err = nil, want size-limit error for body")
+	} else if !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("discoverSpecBundleIdentity error = %v, want size-limit error", err)
+	}
+}
+
+func TestAssessDiscoveredSpecBundle_RejectsOversizedBodyByStat(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	bundleDir := filepath.Join(repo, "specs", "huge-body")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(bundleDir, "spec.toml"), `
+id = "SPEC-HUGE"
+title = "Huge Body"
+status = "draft"
+domain = "api"
+body = "body.md"
+`)
+	oversized := bytes.Repeat([]byte("a"), maxMarkdownBodyBytes+1)
+	if err := os.WriteFile(filepath.Join(bundleDir, "body.md"), oversized, 0o644); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+
+	ok, _, reason := assessDiscoveredSpecBundle(repo, bundleDir)
+	if ok {
+		t.Fatalf("assessDiscoveredSpecBundle: ok = true, want false for oversized body")
+	}
+	if !strings.Contains(reason, "size limit") {
+		t.Fatalf("assessDiscoveredSpecBundle reason = %q, want size-limit rejection", reason)
+	}
+}
+
+func TestDiscoverWorkspace_OversizedBodyDoesNotFailDiscovery(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	// One bundle has an oversized body; another bundle is healthy. Discovery
+	// must reject the bad bundle without aborting the entire scan.
+	badBundle := filepath.Join(repo, "specs", "huge")
+	if err := os.MkdirAll(badBundle, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(badBundle, "spec.toml"), `
+id = "SPEC-HUGE"
+title = "Huge Body"
+status = "draft"
+domain = "api"
+body = "body.md"
+`)
+	oversized := bytes.Repeat([]byte("a"), maxMarkdownBodyBytes+1)
+	if err := os.WriteFile(filepath.Join(badBundle, "body.md"), oversized, 0o644); err != nil {
+		t.Fatalf("write oversized body: %v", err)
+	}
+
+	goodBundle := filepath.Join(repo, "specs", "ok")
+	mustWriteFile(t, filepath.Join(goodBundle, "spec.toml"), `
+id = "SPEC-OK"
+title = "Healthy"
+status = "draft"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(t, filepath.Join(goodBundle, "body.md"), `
+# Healthy
+
+Body content.
+`)
+
+	result, err := DiscoverWorkspace(DiscoverOptions{RootPath: repo})
+	if err != nil {
+		t.Fatalf("DiscoverWorkspace error = %v", err)
+	}
+	if !strings.Contains(result.Config, "SPEC-OK") && !strings.Contains(result.Config, goodBundle) && !strings.Contains(result.Config, "specs/ok") {
+		t.Fatalf("generated config %q does not include healthy bundle path", result.Config)
+	}
+}
+
+func TestDiscoverMarkdownCandidates_SkipsSymlinks(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "README.md"), `
+# Project
+
+Landing page.
+`)
+	target := filepath.Join(repo, "README.md")
+	link := filepath.Join(repo, "MIRROR.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	result, err := DiscoverWorkspace(DiscoverOptions{RootPath: repo})
+	if err != nil {
+		t.Fatalf("DiscoverWorkspace error = %v", err)
+	}
+	// The symlinked candidate must not appear in the generated config.
+	if strings.Contains(result.Config, "MIRROR.md") {
+		t.Fatalf("generated config %q unexpectedly includes symlinked markdown", result.Config)
+	}
+}
+
+func TestDiscoverSpecBundles_SkipsSymlinkedSpecTOML(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	// Real bundle outside any spec dir to act as the symlink target.
+	realDir := filepath.Join(repo, "external")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(realDir, "spec.toml"), `
+id = "SPEC-EXTERNAL"
+title = "External"
+status = "draft"
+domain = "api"
+body = "body.md"
+`)
+	mustWriteFile(t, filepath.Join(realDir, "body.md"), `
+# External
+
+Body.
+`)
+	bundleDir := filepath.Join(repo, "specs", "via-symlink")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(realDir, "spec.toml"), filepath.Join(bundleDir, "spec.toml")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	result, err := DiscoverWorkspace(DiscoverOptions{RootPath: repo})
+	if err != nil && !strings.Contains(err.Error(), "no likely sources") {
+		t.Fatalf("DiscoverWorkspace error = %v", err)
+	}
+	if err == nil && strings.Contains(result.Config, "SPEC-EXTERNAL") {
+		t.Fatalf("generated config %q unexpectedly indexes symlinked spec.toml", result.Config)
+	}
+}
+
+func TestClassifyMarkdownCandidate_RejectsOversizedMarkdown(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mdPath := filepath.Join(repo, "huge.md")
+	oversized := bytes.Repeat([]byte("a"), maxMarkdownBodyBytes+1)
+	if err := os.WriteFile(mdPath, oversized, 0o644); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+
+	assessment, err := classifyMarkdownCandidate(repo, mdPath)
+	if err != nil {
+		t.Fatalf("classifyMarkdownCandidate: err = %v, want nil (read errors surface as Reason)", err)
+	}
+	if assessment.Selected {
+		t.Fatalf("assessment.Selected = true, want false for oversized markdown")
+	}
+	if !strings.Contains(assessment.Reason, "size limit") {
+		t.Fatalf("assessment.Reason = %q, want size-limit rejection", assessment.Reason)
+	}
+}


### PR DESCRIPTION
## Summary
- `discoverSpecBundleIdentity`, `assessDiscoveredSpecBundle`, and `classifyMarkdownCandidate` switch from `os.ReadFile` to the existing `readBoundedFile` helper with `maxSpecTOMLBytes` / `maxMarkdownBodyBytes`. The first-run path (`pituitary init` / `pituitary discover`) can no longer be made to allocate unbounded memory by a crafted spec.toml or markdown file.
- `assessDiscoveredSpecBundle` now stat-screens the body's size and regular-file mode, so an oversized body becomes a graceful per-bundle rejection instead of a fatal walker error that aborts the entire scan.
- Both the spec-bundle and markdown-candidate walkers skip non-regular entries (notably symlinks) up front, so a workspace-rooted symlink can no longer divert the bounded read to a target outside the workspace.

Closes #375.

## Out-of-scope follow-up
- `internal/source/explain.go::explainMarkdownContractSource` still does an unbounded `os.ReadFile` before checking selector exclusion. That is exactly what issue #379 is for; not folded in here to keep the PRs reviewable.

## Test plan
- [x] `go test ./internal/source/ -run "TestAssess|TestDiscoverSpecBundleIdentity|TestClassifyMarkdownCandidate|TestDiscoverWorkspace_Oversized|TestDiscoverMarkdownCandidates_SkipsSymlinks|TestDiscoverSpecBundles_SkipsSymlinkedSpecTOML"`
- [x] `make ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)