### PR TITLE
feat: short-circuit explain-file on excluded markdown contracts (#379)

### DIFF
--- a/internal/source/explain.go
+++ b/internal/source/explain.go
@@ -259,8 +259,16 @@ func explainMarkdownContractSource(workspaceRoot string, explanation SourceFileE
 		return explanation, nil
 	}
 
-	// #nosec G304 -- absolutePath is derived from the selected workspace source and explanation target.
-	body, err := os.ReadFile(absolutePath)
+	// Short-circuit before reading: an excluded markdown_contract file does
+	// not need its content read or inferred just to report why it was
+	// excluded. This keeps `explain-file` fast on large excluded files and
+	// avoids buffering arbitrary-sized markdown into memory for diagnostics.
+	if !selection.Selected {
+		explanation.Reason = selection.Reason
+		return explanation, nil
+	}
+
+	body, err := readBoundedFile(absolutePath, maxMarkdownBodyBytes)
 	if err != nil {
 		return SourceFileExplanation{}, fmt.Errorf(
 			"source %q contract %q: read markdown: %w",
@@ -288,11 +296,6 @@ func explainMarkdownContractSource(workspaceRoot string, explanation SourceFileE
 		RelatesTo:  relationRefs(record.Relations, model.RelationRelatesTo),
 		AppliesTo:  append([]string(nil), record.AppliesTo...),
 		Inference:  record.Inference,
-	}
-
-	if !selection.Selected {
-		explanation.Reason = selection.Reason
-		return explanation, nil
 	}
 
 	explanation.Selected = true

--- a/internal/source/explain_shortcircuit_test.go
+++ b/internal/source/explain_shortcircuit_test.go
@@ -1,0 +1,118 @@
+package source
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+)
+
+// TestExplainFileExcludedMarkdownContractIsNotRead proves the explain-file
+// short-circuit: when the selector excludes a markdown_contract path, the
+// diagnostic must not buffer the file content into memory for inference.
+//
+// We exercise this by writing a file whose body would exceed the
+// markdown body bound. If explainMarkdownContractSource still tried to read
+// it, readBoundedFile would fail and ExplainFile would return an error.
+// With the short-circuit in place, the read never happens and the call
+// succeeds with an exclusion reason.
+func TestExplainFileExcludedMarkdownContractIsNotRead(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "pituitary.toml"), `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "contracts"
+adapter = "filesystem"
+kind = "markdown_contract"
+path = "contracts"
+files = ["platform/tenant-rate-limits.md"]
+`)
+	mustWriteFile(t, filepath.Join(repo, "contracts", "platform", "tenant-rate-limits.md"), `
+# Tenant Rate Limits
+Status: draft
+`)
+
+	excluded := filepath.Join(repo, "contracts", "auth", "huge-policy.md")
+	if err := os.MkdirAll(filepath.Dir(excluded), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	oversized := bytes.Repeat([]byte("a"), maxMarkdownBodyBytes+1)
+	if err := os.WriteFile(excluded, oversized, 0o644); err != nil {
+		t.Fatalf("write oversized: %v", err)
+	}
+
+	cfg, err := config.Load(filepath.Join(repo, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	result, err := ExplainFile(cfg, excluded)
+	if err != nil {
+		t.Fatalf("ExplainFile() error = %v (excluded contract should not be read)", err)
+	}
+	if got, want := result.Summary.Status, "excluded"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	if len(result.Sources) == 0 {
+		t.Fatalf("result.Sources is empty")
+	}
+	if got, want := result.Sources[0].Reason, explainReasonNotListedInFiles; got != want {
+		t.Fatalf("contract source reason = %q, want %q", got, want)
+	}
+	if result.Sources[0].InferredSpec != nil {
+		t.Fatalf("InferredSpec = %+v, want nil for excluded contract (no inference performed)", result.Sources[0].InferredSpec)
+	}
+}
+
+// TestExplainFileSelectedMarkdownContractStillInfers verifies the happy path
+// is unchanged: a selected contract still reports inferred metadata.
+func TestExplainFileSelectedMarkdownContractStillInfers(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "pituitary.toml"), `
+[workspace]
+root = "."
+index_path = ".pituitary/pituitary.db"
+
+[[sources]]
+name = "contracts"
+adapter = "filesystem"
+kind = "markdown_contract"
+path = "contracts"
+`)
+	mustWriteFile(t, filepath.Join(repo, "contracts", "auth", "session-policy.md"), `
+Ref: RFC-AUTH-001
+Status: accepted
+Domain: identity
+
+# Session Policy
+
+All interactive sessions must use tenant-scoped policy evaluation.
+`)
+
+	cfg, err := config.Load(filepath.Join(repo, "pituitary.toml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	result, err := ExplainFile(cfg, filepath.Join(repo, "contracts", "auth", "session-policy.md"))
+	if err != nil {
+		t.Fatalf("ExplainFile error = %v", err)
+	}
+	if got, want := result.Summary.Status, "indexed"; got != want {
+		t.Fatalf("summary status = %q, want %q", got, want)
+	}
+	if result.Sources[0].InferredSpec == nil {
+		t.Fatalf("InferredSpec = nil, want inferred metadata for selected contract")
+	}
+	if got, want := result.Sources[0].InferredSpec.Ref, "RFC-AUTH-001"; got != want {
+		t.Fatalf("InferredSpec.Ref = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- `explainMarkdownContractSource` returns the selector exclusion reason before reading or inferring the markdown body. `explain-file` on a 10 MiB excluded contract is now O(selector match) instead of O(file size).
- The selected path uses `readBoundedFile(maxMarkdownBodyBytes)` instead of `os.ReadFile`, matching the indexed loader's safety guard and closing the adjacent unbounded-read gap surfaced when reviewing #375.

Closes #379.

## Intentional contract change
`inferred_spec` is no longer populated in the explain-file output for **excluded** markdown_contract entries. This is the acceptance criterion of #379 ("return selector exclusion reasons before reading or inferring file content") — inference now scopes to selected contracts only. Output for selected contracts is unchanged.

## Out-of-scope follow-up (raised by adversarial review)
- `explainSpecBundleSource` still calls `discoverSpecBundleDirs` (full source-tree walk) before evaluating the selector for the target bundle. Same shape of "diagnostic pays the full discovery cost even when excluded," but in spec_bundle metadata traversal rather than markdown reads. Worth a separate issue rather than folding into #379's narrower scope.

## Test plan
- [x] `go test ./internal/source/ -run "TestExplainFileExcludedMarkdownContractIsNotRead|TestExplainFileSelectedMarkdownContractStillInfers"` (excluded contract is not read; selected contract still infers metadata)
- [x] `make ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)