### PR TITLE
feat: lexical (FTS-only) fallback retrieval via stroma SearchLexical (#397)

### DIFF
--- a/cmd/search_specs.go
+++ b/cmd/search_specs.go
@@ -35,13 +35,14 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 		statuses searchSpecsFlagList
 		limit    int
 		familyID int
+		lexical  bool
 	)
 
 	return runCommand[index.SearchSpecRequest, index.SearchSpecResult](
 		ctx, args, stdout, stderr,
 		commandRun[index.SearchSpecRequest, index.SearchSpecResult]{
 			Name:  "search-specs",
-			Usage: "pituitary [--config PATH] search-specs (--query TEXT | --request-file PATH|-) [--domain VALUE] [--status VALUE]... [--limit N] [--format FORMAT]",
+			Usage: "pituitary [--config PATH] search-specs (--query TEXT | --request-file PATH|-) [--domain VALUE] [--status VALUE]... [--limit N] [--lexical] [--format FORMAT]",
 			Options: commandRunOptions{
 				RequestFile:   true,
 				ConfigForFile: true,
@@ -52,12 +53,17 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 				fs.Var(&statuses, "status", "filter by status; repeat to set multiple statuses")
 				fs.IntVar(&limit, "limit", 10, "maximum matches to return")
 				fs.IntVar(&familyID, "family", -1, "filter results to specs in the given family ID")
+				fs.BoolVar(&lexical, "lexical", false, "force FTS-only retrieval (skip the embedder)")
 			},
 			InlineFlagsSet: func(fs *flag.FlagSet) bool {
-				return strings.TrimSpace(query) != "" || strings.TrimSpace(domain) != "" || len(statuses) > 0 || flagWasSet(fs, "limit")
+				return strings.TrimSpace(query) != "" || strings.TrimSpace(domain) != "" || len(statuses) > 0 || flagWasSet(fs, "limit") || lexical
 			},
 			LoadRequestFile: autoLoadWorkspaceRequest[index.SearchSpecRequest],
 			BuildRequest: func(_ context.Context, _ *config.Config, _ string, _ []string) (index.SearchSpecRequest, error) {
+				mode := index.SearchSpecModeHybrid
+				if lexical {
+					mode = index.SearchSpecModeLexical
+				}
 				return index.SearchSpecRequest{
 					Query: strings.TrimSpace(query),
 					Filters: index.SearchSpecFilters{
@@ -65,6 +71,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 						Statuses: []string(statuses),
 					},
 					Limit: &limit,
+					Mode:  mode,
 				}, nil
 			},
 			Normalize: func(_ context.Context, req index.SearchSpecRequest, _ string) (index.SearchSpecRequest, error) {
@@ -75,6 +82,7 @@ func runSearchSpecsContext(ctx context.Context, args []string, stdout, stderr io
 				req.Filters.Statuses = queryArgs.Statuses
 				req.Query = queryArgs.Query
 				req.Filters.Domain = queryArgs.Domain
+				req.Mode = queryArgs.Mode
 				requestLimit := queryArgs.Limit
 				req.Limit = &requestLimit
 				if req.Query == "" {

--- a/cmd/search_specs_test.go
+++ b/cmd/search_specs_test.go
@@ -638,6 +638,64 @@ path = "rfcs"
 	return root
 }
 
+func TestRunSearchSpecsLexicalFlag(t *testing.T) {
+	repo := writeSearchWorkspace(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := withWorkingDir(t, repo, func() int {
+		if code := runIndex([]string{"--rebuild"}, ioDiscard{}, ioDiscard{}); code != 0 {
+			t.Fatalf("runIndex() exit code = %d, want 0", code)
+		}
+		return runSearchSpecs([]string{"--query", "rate limiting", "--lexical", "--format", "json"}, &stdout, &stderr)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runSearchSpecs(--lexical) exit code = %d, want 0", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("runSearchSpecs(--lexical) wrote unexpected stderr: %q", stderr.String())
+	}
+
+	var payload struct {
+		Request struct {
+			Mode string `json:"mode"`
+		} `json:"request"`
+		Result struct {
+			ScoreKind  string `json:"score_kind"`
+			Provenance struct {
+				Mode             string `json:"mode"`
+				EmbedderBypassed bool   `json:"embedder_bypassed"`
+				FallbackReason   string `json:"fallback_reason"`
+			} `json:"provenance"`
+			Matches []struct {
+				Ref string `json:"ref"`
+			} `json:"matches"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal lexical payload: %v", err)
+	}
+	if payload.Request.Mode != "lexical" {
+		t.Fatalf("request.mode = %q, want %q", payload.Request.Mode, "lexical")
+	}
+	if payload.Result.ScoreKind != "lexical_relevance" {
+		t.Fatalf("result.score_kind = %q, want lexical_relevance", payload.Result.ScoreKind)
+	}
+	if payload.Result.Provenance.Mode != "lexical" {
+		t.Fatalf("provenance.mode = %q, want lexical", payload.Result.Provenance.Mode)
+	}
+	if !payload.Result.Provenance.EmbedderBypassed {
+		t.Fatal("provenance.embedder_bypassed = false, want true for explicit lexical")
+	}
+	if payload.Result.Provenance.FallbackReason != "" {
+		t.Fatalf("provenance.fallback_reason = %q, want empty for explicit lexical", payload.Result.Provenance.FallbackReason)
+	}
+	if len(payload.Result.Matches) == 0 {
+		t.Fatal("matches = empty, want lexical hits")
+	}
+}
+
 func copyTree(t *testing.T, src, dst string) {
 	t.Helper()
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -102,6 +102,28 @@ For Nomic-compatible models, Pituitary automatically applies the required `searc
 
 The default `fixture` embedder is the deterministic baseline for tests, CI, and zero-credential evaluation. It is not the best retrieval runtime for real corpora. If you are evaluating search quality, overlap ranking, drift detection, or terminology audits on a real repo, switch to a real local embedding runtime first and then rebuild the index.
 
+### Hybrid vs Lexical Search
+
+`search-specs` answers queries in one of two retrieval modes:
+
+- **Hybrid** (default). Vector search is fused with the snapshot's FTS index and reranked. Requires the configured embedder to be reachable at query time. The `result.score_kind` is `hybrid_relevance`.
+- **Lexical** (FTS-only). The embedder is bypassed entirely; results come from the snapshot's FTS5 index. The `result.score_kind` is `lexical_relevance`.
+
+Lexical mode is selected in two ways:
+
+1. **Explicit opt-in.** Pass `--lexical` on the CLI or set `"mode": "lexical"` on the MCP `search_specs` request. Use this when you want a deterministic, embedder-free retrieval — for example, on CI without a configured runtime, in offline development, or when the embedder is rate-limited and you want to avoid the call.
+2. **Automatic fallback.** When hybrid retrieval is requested but the configured embedder runtime is unavailable (unloaded model, unreachable endpoint, transport failure), `search-specs` automatically retries the request as lexical instead of erroring. The result's `provenance` block records the downgrade:
+
+   ```json
+   "provenance": {
+     "mode": "lexical",
+     "embedder_bypassed": true,
+     "fallback_reason": "embedder_unavailable"
+   }
+   ```
+
+   Successful hybrid responses carry `provenance.mode = "hybrid"`. Explicit lexical requests leave `fallback_reason` empty. Inspect `provenance` before treating lexical results as equivalent to hybrid: lexical recall is bounded by surface-form overlap with the query and will miss conceptual matches that hybrid retrieval would surface.
+
 ## Indexing Pipeline
 
 When you run `pituitary index --rebuild`:

--- a/internal/app/operations.go
+++ b/internal/app/operations.go
@@ -153,6 +153,7 @@ func SearchSpecs(ctx context.Context, configPath string, request index.SearchSpe
 	request.Query = query.Query
 	request.Filters.Domain = query.Domain
 	request.Filters.Statuses = query.Statuses
+	request.Mode = query.Mode
 	limit := query.Limit
 	request.Limit = &limit
 

--- a/internal/app/operations_test.go
+++ b/internal/app/operations_test.go
@@ -470,7 +470,63 @@ func TestCheckDocDriftClassifiesAnalysisProviderDependencyFailures(t *testing.T)
 	}
 }
 
-func TestSearchSpecsReportsActionableUnloadedModelErrorForOpenAICompatibleEmbedder(t *testing.T) {
+func TestSearchSpecsDoesNotFallBackOnAuthFailure(t *testing.T) {
+	// Auth failures indicate operator misconfiguration (missing API
+	// key); silently degrading to lexical would let CI/operators
+	// trust degraded results that never used the configured embedder.
+	// The original dependency_unavailable diagnostic must surface.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		response := map[string]any{"data": []map[string]any{}}
+		for i := range request.Input {
+			response["data"] = append(response["data"].([]map[string]any), map[string]any{
+				"index":     i,
+				"embedding": []float64{float64(i + 1), float64(i + 2), float64(i + 3)},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("PITUITARY_TEST_EMBED_KEY", "test-key")
+	configPath := writeOperationWorkspaceWithRuntime(t, fmt.Sprintf(`
+[runtime.embedder]
+provider = "openai_compatible"
+model = "pituitary-embed"
+endpoint = %q
+api_key_env = "PITUITARY_TEST_EMBED_KEY"
+timeout_ms = 1000
+max_retries = 0
+`, server.URL+"/v1"), "")
+
+	// Unset the API key after the index is built so that the
+	// embedder constructor at search time returns an auth-class
+	// dependency-unavailable error.
+	t.Setenv("PITUITARY_TEST_EMBED_KEY", "")
+
+	operation := SearchSpecs(context.Background(), configPath, index.SearchSpecRequest{
+		Query: "rate limiting",
+	})
+	if operation.Issue == nil {
+		t.Fatal("SearchSpecs() issue = nil, want auth dependency error (no fallback)")
+	}
+	if operation.Issue.Code != CodeDependencyUnavailable {
+		t.Fatalf("SearchSpecs() issue.code = %q, want %q (auth must not fall back)", operation.Issue.Code, CodeDependencyUnavailable)
+	}
+	if got := operation.Issue.Details["failure_class"]; got != runtimeerr.FailureClassAuth {
+		t.Fatalf("issue.details.failure_class = %#v, want %q", got, runtimeerr.FailureClassAuth)
+	}
+}
+
+func TestSearchSpecsFallsBackToLexicalWhenOpenAICompatibleEmbedderFails(t *testing.T) {
 	t.Parallel()
 
 	var failSearch atomic.Bool
@@ -522,27 +578,30 @@ max_retries = 0
 	operation := SearchSpecs(context.Background(), configPath, index.SearchSpecRequest{
 		Query: "rate limiting",
 	})
-	if operation.Issue == nil {
-		t.Fatal("SearchSpecs() issue = nil, want dependency error")
+	if operation.Issue != nil {
+		t.Fatalf("SearchSpecs() issue = %+v, want fallback success", operation.Issue)
 	}
-	if operation.Issue.Code != CodeDependencyUnavailable {
-		t.Fatalf("SearchSpecs() issue.code = %q, want %q", operation.Issue.Code, CodeDependencyUnavailable)
+	if operation.Result == nil {
+		t.Fatal("SearchSpecs() result = nil, want lexical fallback result")
 	}
-	if operation.Issue.ExitCode != 3 {
-		t.Fatalf("SearchSpecs() issue.exitCode = %d, want 3", operation.Issue.ExitCode)
+	if got, want := operation.Result.ScoreKind, index.SearchSpecScoreKindLexicalRelevance; got != want {
+		t.Fatalf("result.ScoreKind = %q, want %q", got, want)
 	}
-	wantDescriptor := fmt.Sprintf(`runtime.embedder (provider "openai_compatible", model "pituitary-embed", endpoint %q) is unavailable because the configured model appears to be unloaded`, server.URL+"/v1")
-	if !strings.Contains(operation.Issue.Message, wantDescriptor) {
-		t.Fatalf("SearchSpecs() issue.message = %q, want runtime descriptor and unloaded-model guidance", operation.Issue.Message)
+	prov := operation.Result.Provenance
+	if prov == nil {
+		t.Fatal("result.Provenance = nil, want lexical fallback provenance")
 	}
-	if !strings.Contains(operation.Issue.Message, "load or pin model") {
-		t.Fatalf("SearchSpecs() issue.message = %q, want model loading guidance", operation.Issue.Message)
+	if got, want := prov.Mode, "lexical"; got != want {
+		t.Fatalf("provenance.Mode = %q, want %q", got, want)
 	}
-	if !strings.Contains(operation.Issue.Message, "LM Studio") {
-		t.Fatalf("SearchSpecs() issue.message = %q, want LM Studio hint", operation.Issue.Message)
+	if !prov.EmbedderBypassed {
+		t.Fatal("provenance.EmbedderBypassed = false, want true after fallback")
 	}
-	if !strings.Contains(operation.Issue.Message, "Raw provider error:") || !strings.Contains(operation.Issue.Message, "Model unloaded..") {
-		t.Fatalf("SearchSpecs() issue.message = %q, want raw provider detail", operation.Issue.Message)
+	if got, want := prov.FallbackReason, index.SearchSpecFallbackReasonEmbedderUnavailable; got != want {
+		t.Fatalf("provenance.FallbackReason = %q, want %q", got, want)
+	}
+	if len(operation.Result.Matches) == 0 {
+		t.Fatal("result.Matches = empty, want lexical hits for 'rate limiting'")
 	}
 }
 

--- a/internal/index/embedder.go
+++ b/internal/index/embedder.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/runtimeerr"
 	stembed "github.com/dusk-network/stroma/v3/embed"
 )
 
@@ -55,6 +56,38 @@ func DependencyUnavailableRuntime(err error) string {
 		return ""
 	}
 	return strings.TrimSpace(target.RuntimeName())
+}
+
+// DependencyUnavailableFailureClass returns the failure class recorded
+// on a dependency-unavailable error, or empty string if none.
+func DependencyUnavailableFailureClass(err error) string {
+	details := DependencyUnavailableDetails(err)
+	if details == nil {
+		return ""
+	}
+	if class, ok := details["failure_class"].(string); ok {
+		return strings.TrimSpace(class)
+	}
+	return ""
+}
+
+// IsRecoverableEmbedderFailure reports whether a dependency-unavailable
+// embedder error is the kind that should permit automatic fallback to a
+// degraded retrieval path. Auth and schema-mismatch failures indicate
+// operator misconfiguration that masking with degraded results would
+// hide; transient classes (timeout, transport, server, rate-limit, and
+// the generic dependency_unavailable that covers unloaded-model
+// returns) are recoverable by definition.
+func IsRecoverableEmbedderFailure(err error) bool {
+	if !IsDependencyUnavailable(err) {
+		return false
+	}
+	switch DependencyUnavailableFailureClass(err) {
+	case runtimeerr.FailureClassAuth, runtimeerr.FailureClassSchemaMismatch:
+		return false
+	default:
+		return true
+	}
 }
 
 // DependencyUnavailableDetails reports structured diagnostic fields associated

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -29,7 +29,26 @@ const (
 	// SearchSpecScoreKindSemanticSimilarity indicates scores from vector-only
 	// retrieval where the score remains cosine-similarity-like.
 	SearchSpecScoreKindSemanticSimilarity = "semantic_similarity"
+
+	// SearchSpecScoreKindLexicalRelevance indicates scores from FTS-only
+	// retrieval that bypassed the embedder.
+	SearchSpecScoreKindLexicalRelevance = "lexical_relevance"
 )
+
+const (
+	// SearchSpecModeHybrid is the default retrieval mode (vector + FTS fusion).
+	SearchSpecModeHybrid = ""
+
+	// SearchSpecModeLexical selects FTS-only retrieval that does not call
+	// the embedder. Useful as an explicit fallback when the embedder is
+	// unavailable or undesired.
+	SearchSpecModeLexical = "lexical"
+)
+
+// SearchSpecFallbackReasonEmbedderUnavailable is recorded on the result
+// provenance when the requested hybrid retrieval automatically degraded
+// to lexical because the embedder runtime was unavailable.
+const SearchSpecFallbackReasonEmbedderUnavailable = "embedder_unavailable"
 
 // SearchSpecFilters captures the optional search filters exposed by transports.
 type SearchSpecFilters struct {
@@ -42,6 +61,9 @@ type SearchSpecRequest struct {
 	Query   string            `json:"query"`
 	Filters SearchSpecFilters `json:"filters"`
 	Limit   *int              `json:"limit,omitempty"`
+	// Mode selects the retrieval mode. Empty means hybrid (default).
+	// "lexical" forces FTS-only retrieval that bypasses the embedder.
+	Mode string `json:"mode,omitempty"`
 }
 
 // SearchSpecQuery is the normalized search request for the spec index.
@@ -51,6 +73,7 @@ type SearchSpecQuery struct {
 	Domain   string   `json:"domain,omitempty"`
 	Statuses []string `json:"statuses"`
 	Limit    int      `json:"limit,omitempty"`
+	Mode     string   `json:"mode,omitempty"`
 }
 
 // SearchSpecMatch is one ranked section match.
@@ -74,6 +97,22 @@ type SearchSpecResult struct {
 	ScoreKind        string                   `json:"score_kind,omitempty"`
 	ScoreDescription string                   `json:"score_description,omitempty"`
 	ContentTrust     *resultmeta.ContentTrust `json:"content_trust,omitempty"`
+	Provenance       *SearchSpecProvenance    `json:"provenance,omitempty"`
+}
+
+// SearchSpecProvenance reports how a search request was actually
+// executed. It distinguishes the requested mode from the executed mode
+// so callers can detect when hybrid retrieval automatically fell back
+// to lexical because the embedder was unavailable.
+type SearchSpecProvenance struct {
+	// Mode is the retrieval mode actually used: "hybrid" or "lexical".
+	Mode string `json:"mode"`
+	// EmbedderBypassed is true when the request was answered without
+	// calling the embedder (explicit lexical or fallback).
+	EmbedderBypassed bool `json:"embedder_bypassed"`
+	// FallbackReason names why hybrid was downgraded to lexical, when
+	// applicable. Empty for explicit lexical or successful hybrid.
+	FallbackReason string `json:"fallback_reason,omitempty"`
 }
 
 type chunkCandidate struct {
@@ -242,13 +281,31 @@ func (r SearchSpecRequest) ToQuery() (SearchSpecQuery, error) {
 	if err != nil {
 		return SearchSpecQuery{}, err
 	}
+	mode, err := normalizeSearchMode(r.Mode)
+	if err != nil {
+		return SearchSpecQuery{}, err
+	}
 	return SearchSpecQuery{
 		Query:    strings.TrimSpace(r.Query),
 		Kind:     model.ArtifactKindSpec,
 		Domain:   strings.TrimSpace(r.Filters.Domain),
 		Statuses: statuses,
 		Limit:    limit,
+		Mode:     mode,
 	}, nil
+}
+
+// normalizeSearchMode validates the requested retrieval mode. Unknown
+// values reject; the empty string and SearchSpecModeLexical are the
+// only accepted inputs today.
+func normalizeSearchMode(mode string) (string, error) {
+	mode = strings.TrimSpace(strings.ToLower(mode))
+	switch mode {
+	case SearchSpecModeHybrid, SearchSpecModeLexical:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("unsupported search mode %q", mode)
+	}
 }
 
 // NormalizeSearchStatuses applies the canonical status filter defaults and validation.
@@ -279,10 +336,46 @@ func SearchSpecs(cfg *config.Config, query SearchSpecQuery) (*SearchSpecResult, 
 }
 
 // SearchSpecsContext executes semantic retrieval over the indexed spec corpus.
+//
+// When query.Mode is SearchSpecModeLexical the embedder is bypassed and
+// the request is answered from the snapshot's FTS index. When Mode is
+// the default hybrid mode, retrieval automatically falls back to lexical
+// if the embedder runtime is unavailable; the result's Provenance
+// records whether the fallback occurred.
 func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpecQuery) (*SearchSpecResult, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
+
+	query, err := normalizeSearchSpecQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(query.Query) == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+
+	if query.Mode == SearchSpecModeLexical {
+		return searchSpecsLexical(ctx, cfg, query, "")
+	}
+
+	result, err := searchSpecsHybrid(ctx, cfg, query)
+	if err == nil {
+		return result, nil
+	}
+	// Only fall back for transient/recoverable embedder failures.
+	// Auth and schema-mismatch failures indicate operator
+	// misconfiguration; masking them with degraded lexical results
+	// would let callers (CI, operators) trust output that never used
+	// the configured embedder, so the original diagnostic surfaces
+	// instead.
+	if !IsRecoverableEmbedderFailure(err) {
+		return nil, err
+	}
+	return searchSpecsLexical(ctx, cfg, query, SearchSpecFallbackReasonEmbedderUnavailable)
+}
+
+func searchSpecsHybrid(ctx context.Context, cfg *config.Config, query SearchSpecQuery) (*SearchSpecResult, error) {
 	strategy, err := fusion.Resolve(fusionConfigFromRuntime(cfg.Runtime.Search))
 	if err != nil {
 		return nil, fmt.Errorf("resolve search fusion: %w", err)
@@ -290,7 +383,12 @@ func SearchSpecsContext(ctx context.Context, cfg *config.Config, query SearchSpe
 	loader := func(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, embedder Embedder, query SearchSpecQuery) ([]chunkCandidate, error) {
 		return loadRankedCandidatesContextWithFusion(ctx, db, snapshot, embedder, query, strategy, cfg.Runtime.Search.Reranker)
 	}
-	return searchSpecsContextWithScoreKind(ctx, cfg, query, SearchSpecScoreKindHybridRelevance, loader)
+	result, err := searchSpecsContextWithScoreKind(ctx, cfg, query, SearchSpecScoreKindHybridRelevance, loader)
+	if err != nil {
+		return nil, err
+	}
+	result.Provenance = &SearchSpecProvenance{Mode: "hybrid"}
+	return result, nil
 }
 
 func fusionConfigFromRuntime(cfg config.SearchConfig) fusion.Config {
@@ -312,6 +410,8 @@ func SearchSpecScoreColumnLabel(kind string) string {
 	switch kind {
 	case SearchSpecScoreKindSemanticSimilarity:
 		return "SIMILARITY"
+	case SearchSpecScoreKindLexicalRelevance:
+		return "LEXICAL"
 	default:
 		return "RELEVANCE"
 	}
@@ -323,6 +423,8 @@ func SearchSpecScoreDescription(kind string) string {
 	switch kind {
 	case SearchSpecScoreKindSemanticSimilarity:
 		return "cosine-style semantic similarity from vector-only retrieval"
+	case SearchSpecScoreKindLexicalRelevance:
+		return "lexical relevance from FTS-only retrieval; embedder was bypassed"
 	default:
 		return "hybrid relevance from fused vector and lexical retrieval; not a cosine similarity percentage"
 	}
@@ -371,11 +473,16 @@ func normalizeSearchSpecQuery(query SearchSpecQuery) (SearchSpecQuery, error) {
 	if err != nil {
 		return SearchSpecQuery{}, err
 	}
+	mode, err := normalizeSearchMode(query.Mode)
+	if err != nil {
+		return SearchSpecQuery{}, err
+	}
 	query.Query = strings.TrimSpace(query.Query)
 	query.Kind = defaultString(query.Kind, model.ArtifactKindSpec)
 	query.Domain = strings.TrimSpace(query.Domain)
 	query.Statuses = statuses
 	query.Limit = limit
+	query.Mode = mode
 	return query, nil
 }
 

--- a/internal/index/search_lexical.go
+++ b/internal/index/search_lexical.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/ranking"
 	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
@@ -45,6 +46,8 @@ func searchSpecsLexical(ctx context.Context, cfg *config.Config, query SearchSpe
 }
 
 func loadLexicalCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, query SearchSpecQuery) ([]chunkCandidate, error) {
+	preferHistorical := ranking.SearchPrefersHistoricalContext(query.Query)
+
 	hits, err := snapshot.SearchLexical(ctx, stindex.SnapshotLexicalSearchQuery{
 		LexicalSearchParams: stindex.LexicalSearchParams{
 			Text:  query.Query,
@@ -59,6 +62,7 @@ func loadLexicalCandidatesContext(ctx context.Context, db *sql.DB, snapshot *sti
 	// the historical-section ordering applies as it would in the
 	// non-arm-aware default. Pass scorePreAdjusted=false so
 	// buildRankedCandidatesContext computes the historical adjustment
-	// once on the raw FTS score.
-	return buildRankedCandidatesContext(ctx, db, hits, query, false, false)
+	// once on the raw FTS score, using the same query-aware
+	// preferHistorical signal as the hybrid and vector paths.
+	return buildRankedCandidatesContext(ctx, db, hits, query, preferHistorical, false)
 }

--- a/internal/index/search_lexical.go
+++ b/internal/index/search_lexical.go
@@ -1,0 +1,64 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	stindex "github.com/dusk-network/stroma/v3/index"
+)
+
+// searchSpecsLexical executes FTS-only retrieval over the indexed spec
+// corpus. It does not call the embedder and does not validate the
+// stored embedder dimension or fingerprint, so it remains usable when
+// the configured embedder runtime is unavailable.
+//
+// fallbackReason, when non-empty, is recorded on the result provenance
+// so callers can tell hybrid retrieval was downgraded to lexical (vs.
+// the caller asking for lexical explicitly).
+func searchSpecsLexical(ctx context.Context, cfg *config.Config, query SearchSpecQuery, fallbackReason string) (*SearchSpecResult, error) {
+	db, err := OpenReadOnlyContext(ctx, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		return nil, fmt.Errorf("open index %s: %w", cfg.Workspace.ResolvedIndexPath, err)
+	}
+	defer db.Close()
+
+	snapshot, err := OpenStromaSnapshotContext(ctx, db, cfg.Workspace.ResolvedIndexPath)
+	if err != nil {
+		return nil, err
+	}
+	defer snapshot.Close()
+
+	candidates, err := loadLexicalCandidatesContext(ctx, db, snapshot, query)
+	if err != nil {
+		return nil, err
+	}
+
+	result := buildSearchSpecResult(candidates, SearchSpecScoreKindLexicalRelevance)
+	result.Provenance = &SearchSpecProvenance{
+		Mode:             "lexical",
+		EmbedderBypassed: true,
+		FallbackReason:   fallbackReason,
+	}
+	return result, nil
+}
+
+func loadLexicalCandidatesContext(ctx context.Context, db *sql.DB, snapshot *stindex.Snapshot, query SearchSpecQuery) ([]chunkCandidate, error) {
+	hits, err := snapshot.SearchLexical(ctx, stindex.SnapshotLexicalSearchQuery{
+		LexicalSearchParams: stindex.LexicalSearchParams{
+			Text:  query.Query,
+			Limit: searchCandidateLimit(query.Limit),
+			Kinds: []string{query.Kind},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query lexical candidates: %w", err)
+	}
+	// Lexical retrieval has no fusion provenance and no vector arm, so
+	// the historical-section ordering applies as it would in the
+	// non-arm-aware default. Pass scorePreAdjusted=false so
+	// buildRankedCandidatesContext computes the historical adjustment
+	// once on the raw FTS score.
+	return buildRankedCandidatesContext(ctx, db, hits, query, false, false)
+}

--- a/internal/index/search_lexical_test.go
+++ b/internal/index/search_lexical_test.go
@@ -1,0 +1,104 @@
+package index
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+func TestSearchSpecsLexicalModeBypassesEmbedder(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	result, err := SearchSpecsContext(context.Background(), cfg, SearchSpecQuery{
+		Query: "rate limiting",
+		Mode:  SearchSpecModeLexical,
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("SearchSpecsContext() error = %v", err)
+	}
+	if got, want := result.ScoreKind, SearchSpecScoreKindLexicalRelevance; got != want {
+		t.Fatalf("result.ScoreKind = %q, want %q", got, want)
+	}
+	if !strings.Contains(result.ScoreDescription, "FTS-only") {
+		t.Fatalf("result.ScoreDescription = %q, want FTS-only guidance", result.ScoreDescription)
+	}
+	if result.Provenance == nil {
+		t.Fatal("result.Provenance = nil, want explicit lexical provenance")
+	}
+	if got, want := result.Provenance.Mode, "lexical"; got != want {
+		t.Fatalf("provenance.Mode = %q, want %q", got, want)
+	}
+	if !result.Provenance.EmbedderBypassed {
+		t.Fatal("provenance.EmbedderBypassed = false, want true for lexical mode")
+	}
+	if got := result.Provenance.FallbackReason; got != "" {
+		t.Fatalf("provenance.FallbackReason = %q, want empty for explicit lexical", got)
+	}
+	if len(result.Matches) == 0 {
+		t.Fatal("result.Matches = empty, want lexical hits for 'rate limiting'")
+	}
+}
+
+func TestSearchSpecsLexicalModeOrdersDeterministically(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfig(t)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	first, err := SearchSpecsContext(context.Background(), cfg, SearchSpecQuery{
+		Query: "rate limiting",
+		Mode:  SearchSpecModeLexical,
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("SearchSpecsContext() #1 error = %v", err)
+	}
+	second, err := SearchSpecsContext(context.Background(), cfg, SearchSpecQuery{
+		Query: "rate limiting",
+		Mode:  SearchSpecModeLexical,
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("SearchSpecsContext() #2 error = %v", err)
+	}
+	if len(first.Matches) != len(second.Matches) {
+		t.Fatalf("match counts differ: %d vs %d", len(first.Matches), len(second.Matches))
+	}
+	for i := range first.Matches {
+		if first.Matches[i].Ref != second.Matches[i].Ref ||
+			first.Matches[i].SectionHeading != second.Matches[i].SectionHeading ||
+			first.Matches[i].Score != second.Matches[i].Score {
+			t.Fatalf("match[%d] differs: %+v vs %+v", i, first.Matches[i], second.Matches[i])
+		}
+	}
+}
+
+func TestSearchSpecsRequestRejectsUnknownMode(t *testing.T) {
+	t.Parallel()
+
+	_, err := (SearchSpecRequest{Query: "anything", Mode: "vector_only"}).ToQuery()
+	if err == nil {
+		t.Fatal("ToQuery() error = nil, want unsupported-mode error")
+	}
+	if !strings.Contains(err.Error(), "unsupported search mode") {
+		t.Fatalf("ToQuery() error = %q, want unsupported-mode message", err)
+	}
+}


### PR DESCRIPTION
Closes #397.

## Summary

- Adds explicit lexical retrieval (`--lexical` CLI flag, `"mode": "lexical"` MCP arg) that bypasses the embedder and answers from the snapshot's FTS index via `stroma.SnapshotSearchLexical`.
- Adds automatic fallback: hybrid retrieval downgrades to lexical when the embedder reports a recoverable failure (transport / timeout / server / rate-limit / generic `dependency_unavailable`, which covers unloaded-model returns). Auth and schema-mismatch failures still surface the original `dependency_unavailable` so misconfiguration is not masked.
- Result envelope gains `provenance { mode, embedder_bypassed, fallback_reason }` so callers can distinguish hybrid from lexical and detect downgrades.
- Documents the new contract in `docs/runtime.md`.

## Test plan

- [x] `go test ./...`
- [x] `make ci`
- New unit tests cover: explicit lexical CLI flag, deterministic lexical ordering, request rejection of unknown modes, auto-fallback on recoverable embedder failure (preserves operation success + sets `fallback_reason=embedder_unavailable`), refusal to fall back on auth failures (preserves `failure_class=auth` dependency error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)