### PR TITLE
feat: stream rebuild and incremental update via stroma RecordSource (#396)

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -138,6 +138,8 @@ When you run `pituitary index --rebuild`:
 
 Use `--full` to skip reuse and force a complete re-embed.
 
+The chunking and embedding stages run as a streaming pipeline against stroma: records are yielded one at a time into `stindex.RebuildFromSource`, which chunks, embeds, and flushes to the staging snapshot in bounded internal batches. Peak memory inside stroma's pipeline therefore scales with its batch size rather than with corpus size, so large workspaces no longer accumulate the full chunks-and-vectors plan before commit. The source loader still materializes a `LoadResult` of all spec and doc records up front today; reducing that resident set requires a loader-side change that yields records lazily from disk, which is tracked separately. Incremental updates use the same streaming entry point: `pituitary update` consumes the union of configured sources via `stindex.SyncFromSource`, which preserves today's "configure source change → next update reflects removals" behavior without paying full-rebuild cost. Stroma retains changed records and their planned chunks/vectors until commit, so a single update that touches a very large fraction of the corpus is still bounded by available memory; for that case `pituitary index --rebuild` remains the safer path.
+
 Query commands validate index freshness before executing. A stale index fails fast with a rebuild hint.
 
 ## JSON Timings

--- a/internal/index/benchmark_test.go
+++ b/internal/index/benchmark_test.go
@@ -1,8 +1,14 @@
 package index
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
 )
@@ -24,6 +30,114 @@ func BenchmarkRebuildFixture(b *testing.B) {
 			b.Fatalf("Rebuild() error = %v", err)
 		}
 	}
+}
+
+// BenchmarkRebuildLargeCorpus exercises the streaming rebuild pipeline
+// against a synthetic corpus large enough to make resident-set memory
+// visible in -benchmem output. The corpus is constructed in memory so
+// the measurement isolates the rebuild pipeline itself: the streaming
+// switch (#396) lets stroma chunk and embed in bounded internal
+// batches rather than holding the full chunks-and-vectors plan
+// resident before commit, which the B/op delta against pre-#396
+// should reflect.
+func BenchmarkRebuildLargeCorpus(b *testing.B) {
+	const docCount = 200
+	const bodyKB = 4
+
+	indexDir := b.TempDir()
+	cfg := minimalRebuildConfig(b, filepath.Join(indexDir, "pituitary.db"))
+	records := syntheticLargeCorpus(docCount, bodyKB)
+	if _, err := Rebuild(cfg, records); err != nil {
+		b.Fatalf("warm Rebuild() error = %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Rebuild(cfg, records); err != nil {
+			b.Fatalf("Rebuild() error = %v", err)
+		}
+	}
+}
+
+// syntheticLargeCorpus produces a deterministic in-memory LoadResult
+// of N markdown docs, each carrying ~bodyKB KB of body text. Bodies
+// vary per record so chunk-reuse from the previous iteration's
+// snapshot stays bounded — the benchmark stresses the embed-and-flush
+// path, not the reuse cache.
+func syntheticLargeCorpus(n, bodyKB int) *source.LoadResult {
+	docs := make([]model.DocRecord, 0, n)
+	for i := 0; i < n; i++ {
+		ref := fmt.Sprintf("doc://bench/%04d", i)
+		title := fmt.Sprintf("Synthetic Doc %04d", i)
+		var body strings.Builder
+		body.WriteString("# ")
+		body.WriteString(title)
+		body.WriteString("\n\nBenchmark fixture body. Doc ordinal: ")
+		body.WriteString(fmt.Sprintf("%d.\n\n", i))
+		for body.Len() < bodyKB*1024 {
+			body.WriteString(fmt.Sprintf("## Section %d-%d\n\n", i, body.Len()))
+			body.WriteString("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ")
+			body.WriteString(fmt.Sprintf("Doc %04d filler line %d.\n\n", i, body.Len()))
+		}
+		text := body.String()
+		hash := sha256.Sum256([]byte(text))
+		docs = append(docs, model.DocRecord{
+			Ref:         ref,
+			Kind:        model.ArtifactKindDoc,
+			Title:       title,
+			SourceRef:   fmt.Sprintf("docs/bench/%04d.md", i),
+			BodyFormat:  "markdown",
+			BodyText:    text,
+			ContentHash: hex.EncodeToString(hash[:]),
+			Metadata:    map[string]string{"path": fmt.Sprintf("docs/bench/%04d.md", i)},
+		})
+	}
+	return &source.LoadResult{
+		Docs: docs,
+		Sources: []source.LoadSourceSummary{{
+			Name:      "bench",
+			Adapter:   "filesystem",
+			Kind:      "markdown_docs",
+			Path:      "docs/bench",
+			ItemCount: n,
+			DocCount:  n,
+		}},
+	}
+}
+
+// minimalRebuildConfig builds a workspace config rooted at a temp dir
+// without writing fixture files. The streaming benchmark constructs
+// its corpus directly in memory; the config only needs the embedder
+// runtime and a workspace root the rebuild pipeline can stage into.
+func minimalRebuildConfig(tb testing.TB, indexPath string) *config.Config {
+	tb.Helper()
+	repo := tb.TempDir()
+	configPath := filepath.Join(repo, "pituitary.toml")
+	mustWriteFile(tb, configPath, `
+[workspace]
+root = "`+filepath.ToSlash(repo)+`"
+index_path = "`+filepath.ToSlash(indexPath)+`"
+infer_applies_to = false
+
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "synthetic"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "."
+include = ["unused-no-files-on-disk.md"]
+`)
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
 }
 
 func BenchmarkSearchSpecs(b *testing.B) {

--- a/internal/index/benchmark_test.go
+++ b/internal/index/benchmark_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -47,14 +48,19 @@ func BenchmarkRebuildLargeCorpus(b *testing.B) {
 	indexDir := b.TempDir()
 	cfg := minimalRebuildConfig(b, filepath.Join(indexDir, "pituitary.db"))
 	records := syntheticLargeCorpus(docCount, bodyKB)
-	if _, err := Rebuild(cfg, records); err != nil {
+	if _, err := RebuildContextWithOptions(context.Background(), cfg, records, RebuildOptions{Full: true}); err != nil {
 		b.Fatalf("warm Rebuild() error = %v", err)
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := Rebuild(cfg, records); err != nil {
+		// RebuildOptions{Full: true} disables chunk reuse so each
+		// iteration actually exercises the embed-and-flush path the
+		// streaming switch targets. Without Full=true the second
+		// call onward would reuse the prior snapshot and the bench
+		// would measure reuse cache lookups, not streaming rebuild.
+		if _, err := RebuildContextWithOptions(context.Background(), cfg, records, RebuildOptions{Full: true}); err != nil {
 			b.Fatalf("Rebuild() error = %v", err)
 		}
 	}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -19,7 +19,6 @@ import (
 	"github.com/dusk-network/pituitary/internal/config"
 	"github.com/dusk-network/pituitary/internal/model"
 	"github.com/dusk-network/pituitary/internal/source"
-	stcorpus "github.com/dusk-network/stroma/v3/corpus"
 	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
@@ -199,10 +198,6 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 		return nil, err
 	}
 
-	corpusRecords, err := corpusRecordsFromLoadResult(records)
-	if err != nil {
-		return nil, err
-	}
 	emitPlannedRebuildProgress(records, reuseState, reporter)
 
 	chunkPolicy, err := pchunk.Resolve(chunkConfigFromRuntime(cfg.Runtime.Chunking))
@@ -225,7 +220,14 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 		// snapshot remains safe even when the content-addressed path is unchanged.
 		stromaOptions.ReuseFromPath = currentSnapshotPath
 	}
-	if _, err := stindex.Rebuild(ctx, corpusRecords, stromaOptions); err != nil {
+	// RebuildFromSource lets stroma chunk and embed records one at a
+	// time in bounded internal batches. Compared to the materialized
+	// Rebuild call it replaced, stroma no longer keeps the full set of
+	// chunks-and-vectors resident before commit. The LoadResult passed
+	// in here is still fully materialized — the caller-side resident
+	// reduction (yielding records lazily from disk inside the source
+	// loader) is a separate change tracked in the issue thread.
+	if _, err := stindex.RebuildFromSource(ctx, source.NewLoadResultRecordSource(records), stromaOptions); err != nil {
 		return nil, fmt.Errorf("build stroma snapshot: %w", err)
 	}
 
@@ -284,29 +286,6 @@ func refreshRebuildChunkCountFromSnapshotContext(ctx context.Context, snapshotPa
 	return nil
 }
 
-func corpusRecordsFromLoadResult(records *source.LoadResult) ([]stcorpus.Record, error) {
-	if records == nil {
-		return nil, fmt.Errorf("records are required")
-	}
-
-	corpusRecords := make([]stcorpus.Record, 0, len(records.Specs)+len(records.Docs))
-	for _, spec := range records.Specs {
-		record, err := corpusRecordFromSpec(spec)
-		if err != nil {
-			return nil, err
-		}
-		corpusRecords = append(corpusRecords, record)
-	}
-	for _, doc := range records.Docs {
-		record, err := corpusRecordFromDoc(doc)
-		if err != nil {
-			return nil, err
-		}
-		corpusRecords = append(corpusRecords, record)
-	}
-	return corpusRecords, nil
-}
-
 // chunkConfigFromRuntime adapts the config-layer chunking shape to the
 // chunk package's Config. It is a pure data translation: config holds
 // raw TOML-validated values, chunk.Resolve turns them into a
@@ -337,34 +316,6 @@ func chunkContextualizerFromRuntime(cfg config.ChunkingConfig) pchunk.Contextual
 	return pchunk.ContextualizerConfig{
 		Format: pchunk.PrefixFormat(cfg.Contextualizer.Format),
 	}
-}
-
-func corpusRecordFromSpec(spec model.SpecRecord) (stcorpus.Record, error) {
-	metadata := cloneMetadata(spec.Metadata)
-
-	return stcorpus.Record{
-		Ref:         spec.Ref,
-		Kind:        spec.Kind,
-		Title:       spec.Title,
-		SourceRef:   spec.SourceRef,
-		BodyFormat:  spec.BodyFormat,
-		BodyText:    spec.BodyText,
-		ContentHash: spec.ContentHash,
-		Metadata:    metadata,
-	}.Normalize()
-}
-
-func corpusRecordFromDoc(doc model.DocRecord) (stcorpus.Record, error) {
-	return stcorpus.Record{
-		Ref:         doc.Ref,
-		Kind:        doc.Kind,
-		Title:       doc.Title,
-		SourceRef:   doc.SourceRef,
-		BodyFormat:  doc.BodyFormat,
-		BodyText:    doc.BodyText,
-		ContentHash: doc.ContentHash,
-		Metadata:    cloneMetadata(doc.Metadata),
-	}.Normalize()
 }
 
 func publishBusinessIndexContext(ctx context.Context, cfg *config.Config, records *source.LoadResult, result *RebuildResult, snapshotPath string) error {

--- a/internal/index/reuse.go
+++ b/internal/index/reuse.go
@@ -137,7 +137,7 @@ func storedArtifactForRecord(state *reuseState, ref string) storedArtifact {
 
 func updateRebuildReuseCountsForSpecs(result *RebuildResult, records []model.SpecRecord, state *reuseState) error {
 	for _, spec := range records {
-		record, err := corpusRecordFromSpec(spec)
+		record, err := source.CorpusRecordFromSpec(spec)
 		if err != nil {
 			return fmt.Errorf("normalize spec %s for reuse accounting: %w", spec.Ref, err)
 		}
@@ -153,7 +153,7 @@ func updateRebuildReuseCountsForSpecs(result *RebuildResult, records []model.Spe
 
 func updateRebuildReuseCountsForDocs(result *RebuildResult, records []model.DocRecord, state *reuseState) error {
 	for _, doc := range records {
-		record, err := corpusRecordFromDoc(doc)
+		record, err := source.CorpusRecordFromDoc(doc)
 		if err != nil {
 			return fmt.Errorf("normalize doc %s for reuse accounting: %w", doc.Ref, err)
 		}

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -421,13 +421,6 @@ func updateStromaSnapshotContext(
 
 	selected := selectedLoadResultForRefs(records, append(append([]string{}, diff.added...), diff.updated...))
 	emitPlannedRebuildProgress(selected, reuseState, reporter)
-	selectedRecords, err := corpusRecordsFromLoadResult(selected)
-	if err != nil {
-		if cleanupSnapshot != nil {
-			cleanupSnapshot()
-		}
-		return "", nil, err
-	}
 	// Thread the same chunking config through stroma's Update path
 	// that rebuild.go threads through stroma's Rebuild path. Without
 	// this, a repo configured with per-kind chunking or an opt-in
@@ -448,7 +441,24 @@ func updateStromaSnapshotContext(
 		}
 		return "", nil, fmt.Errorf("resolve chunk contextualizer: %w", err)
 	}
-	if _, err := stindex.Update(ctx, selectedRecords, diff.removed, stindex.UpdateOptions{
+	// SyncFromSource streams the full desired corpus into stroma. It
+	// computes the (ref, content_hash) diff against the existing
+	// snapshot itself — unchanged records are reused without loading
+	// their bodies, and stored records absent from the stream are
+	// removed. Pituitary's per-source loader produces the union of all
+	// configured sources, so SyncFromSource's auto-removal preserves
+	// today's "configure source change → next update reflects
+	// removals" contract without paying full-rebuild cost. Callers
+	// that want partial-feed semantics (do not delete records absent
+	// from the stream) should switch to UpdateFromSource explicitly.
+	//
+	// MaxPlannedRecords is intentionally not set here, so a single
+	// update that touches a very large fraction of the corpus retains
+	// the changed-record plan in memory until commit (today's behavior
+	// before the streaming switch). For mass edits prefer
+	// `pituitary index --rebuild`; an opt-in cap with a fall-back-to-
+	// rebuild branch is tracked separately.
+	if _, err := stindex.SyncFromSource(ctx, source.NewLoadResultRecordSource(records), stindex.UpdateOptions{
 		Path:           targetSnapshotPath,
 		Embedder:       embedder,
 		ChunkPolicy:    chunkPolicy,

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -443,8 +443,11 @@ func updateStromaSnapshotContext(
 	}
 	// SyncFromSource streams the full desired corpus into stroma. It
 	// computes the (ref, content_hash) diff against the existing
-	// snapshot itself — unchanged records are reused without loading
-	// their bodies, and stored records absent from the stream are
+	// snapshot itself — unchanged records are reused without
+	// re-chunking or re-embedding their bodies (the bodies are still
+	// resident here because the loader handed us a fully materialized
+	// LoadResult; loader-side body reduction is the deferred follow-up
+	// noted above), and stored records absent from the stream are
 	// removed. Pituitary's per-source loader produces the union of all
 	// configured sources, so SyncFromSource's auto-removal preserves
 	// today's "configure source change → next update reflects

--- a/internal/source/stream.go
+++ b/internal/source/stream.go
@@ -56,10 +56,15 @@ func NewLoadResultRecordSource(records *LoadResult) RecordSource {
 
 	specIdx := 0
 	docIdx := 0
+	var terminalErr error
 	exhausted := false
 	return RecordSourceFunc(func(_ context.Context) (stcorpus.Record, bool, error) {
 		if exhausted {
-			return stcorpus.Record{}, false, nil
+			// Sticky terminal state: a normalization failure on a
+			// prior Next must keep surfacing the same error so
+			// callers (and stroma's RebuildFromSource) cannot
+			// silently treat the stream as cleanly exhausted.
+			return stcorpus.Record{}, false, terminalErr
 		}
 		if specIdx < len(records.Specs) {
 			spec := records.Specs[specIdx]
@@ -67,6 +72,7 @@ func NewLoadResultRecordSource(records *LoadResult) RecordSource {
 			record, err := corpusRecordFromSpec(spec)
 			if err != nil {
 				exhausted = true
+				terminalErr = err
 				return stcorpus.Record{}, false, err
 			}
 			return record, true, nil
@@ -77,6 +83,7 @@ func NewLoadResultRecordSource(records *LoadResult) RecordSource {
 			record, err := corpusRecordFromDoc(doc)
 			if err != nil {
 				exhausted = true
+				terminalErr = err
 				return stcorpus.Record{}, false, err
 			}
 			return record, true, nil

--- a/internal/source/stream.go
+++ b/internal/source/stream.go
@@ -1,0 +1,147 @@
+package source
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dusk-network/pituitary/internal/model"
+	stcorpus "github.com/dusk-network/stroma/v3/corpus"
+)
+
+// RecordSource streams normalized stroma corpus records one at a time.
+//
+// It mirrors stroma's index.RecordSource shape so loaders can yield
+// records lazily into stindex.RebuildFromSource / UpdateFromSource /
+// SyncFromSource without materializing the full corpus first. The
+// stroma pipeline consumes records serially, chunks and embeds in
+// bounded internal batches, and never holds the full BodyText of every
+// record resident at once.
+//
+// Implementations must:
+//   - return (record, true, nil) while input remains;
+//   - return (zero, false, nil) once the stream is exhausted;
+//   - return (zero, false, err) on a loading or normalization failure.
+//
+// Calling Next after exhaustion or an error must keep returning the
+// same exhausted/error state.
+type RecordSource interface {
+	Next(ctx context.Context) (stcorpus.Record, bool, error)
+}
+
+// RecordSourceFunc adapts a function value to RecordSource. Mirrors
+// stroma's index.RecordSourceFunc contract.
+type RecordSourceFunc func(ctx context.Context) (stcorpus.Record, bool, error)
+
+// Next implements RecordSource by delegating to the underlying function.
+func (f RecordSourceFunc) Next(ctx context.Context) (stcorpus.Record, bool, error) {
+	return f(ctx)
+}
+
+// NewLoadResultRecordSource yields stroma corpus records from an
+// already-materialized LoadResult, in spec-then-doc order. This is the
+// backward-compatible adapter for callers that produce a LoadResult
+// today: the bodies are still resident in the slices, but stroma's
+// pipeline becomes incremental on the index side, which removes the
+// previous "every chunk and embedding stays resident until commit"
+// peak from the rebuild pipeline.
+//
+// True end-to-end streaming (bodies decoded inside Next) is a separate
+// loader-side change that builds on this adapter contract.
+func NewLoadResultRecordSource(records *LoadResult) RecordSource {
+	if records == nil {
+		return RecordSourceFunc(func(context.Context) (stcorpus.Record, bool, error) {
+			return stcorpus.Record{}, false, nil
+		})
+	}
+
+	specIdx := 0
+	docIdx := 0
+	exhausted := false
+	return RecordSourceFunc(func(_ context.Context) (stcorpus.Record, bool, error) {
+		if exhausted {
+			return stcorpus.Record{}, false, nil
+		}
+		if specIdx < len(records.Specs) {
+			spec := records.Specs[specIdx]
+			specIdx++
+			record, err := corpusRecordFromSpec(spec)
+			if err != nil {
+				exhausted = true
+				return stcorpus.Record{}, false, err
+			}
+			return record, true, nil
+		}
+		if docIdx < len(records.Docs) {
+			doc := records.Docs[docIdx]
+			docIdx++
+			record, err := corpusRecordFromDoc(doc)
+			if err != nil {
+				exhausted = true
+				return stcorpus.Record{}, false, err
+			}
+			return record, true, nil
+		}
+		exhausted = true
+		return stcorpus.Record{}, false, nil
+	})
+}
+
+// CorpusRecordFromSpec converts a normalized spec record into a stroma
+// corpus record, preserving the metadata and content-hash provenance
+// the rebuild and update pipelines rely on.
+func CorpusRecordFromSpec(spec model.SpecRecord) (stcorpus.Record, error) {
+	return corpusRecordFromSpec(spec)
+}
+
+// CorpusRecordFromDoc converts a normalized doc record into a stroma
+// corpus record. See CorpusRecordFromSpec for the metadata contract.
+func CorpusRecordFromDoc(doc model.DocRecord) (stcorpus.Record, error) {
+	return corpusRecordFromDoc(doc)
+}
+
+func corpusRecordFromSpec(spec model.SpecRecord) (stcorpus.Record, error) {
+	record := stcorpus.Record{
+		Ref:         spec.Ref,
+		Kind:        spec.Kind,
+		Title:       spec.Title,
+		SourceRef:   spec.SourceRef,
+		BodyFormat:  spec.BodyFormat,
+		BodyText:    spec.BodyText,
+		ContentHash: spec.ContentHash,
+		Metadata:    cloneMetadata(spec.Metadata),
+	}
+	normalized, err := record.Normalize()
+	if err != nil {
+		return stcorpus.Record{}, fmt.Errorf("normalize spec %s: %w", spec.Ref, err)
+	}
+	return normalized, nil
+}
+
+func corpusRecordFromDoc(doc model.DocRecord) (stcorpus.Record, error) {
+	record := stcorpus.Record{
+		Ref:         doc.Ref,
+		Kind:        doc.Kind,
+		Title:       doc.Title,
+		SourceRef:   doc.SourceRef,
+		BodyFormat:  doc.BodyFormat,
+		BodyText:    doc.BodyText,
+		ContentHash: doc.ContentHash,
+		Metadata:    cloneMetadata(doc.Metadata),
+	}
+	normalized, err := record.Normalize()
+	if err != nil {
+		return stcorpus.Record{}, fmt.Errorf("normalize doc %s: %w", doc.Ref, err)
+	}
+	return normalized, nil
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/source/stream_test.go
+++ b/internal/source/stream_test.go
@@ -1,0 +1,73 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/model"
+	stcorpus "github.com/dusk-network/stroma/v3/corpus"
+)
+
+func TestLoadResultRecordSourceYieldsSpecsThenDocs(t *testing.T) {
+	t.Parallel()
+
+	result := &LoadResult{
+		Specs: []model.SpecRecord{
+			{Ref: "SPEC-1", Kind: model.ArtifactKindSpec, Title: "One", BodyText: "spec one body", BodyFormat: "markdown", ContentHash: "h1", SourceRef: "specs/one"},
+			{Ref: "SPEC-2", Kind: model.ArtifactKindSpec, Title: "Two", BodyText: "spec two body", BodyFormat: "markdown", ContentHash: "h2", SourceRef: "specs/two"},
+		},
+		Docs: []model.DocRecord{
+			{Ref: "DOC-1", Kind: model.ArtifactKindDoc, Title: "Doc", BodyText: "doc body", BodyFormat: "markdown", ContentHash: "h3", SourceRef: "docs/one"},
+		},
+	}
+
+	src := NewLoadResultRecordSource(result)
+	ctx := context.Background()
+	var refs []string
+	for {
+		record, ok, err := src.Next(ctx)
+		if err != nil {
+			t.Fatalf("Next() error = %v", err)
+		}
+		if !ok {
+			break
+		}
+		refs = append(refs, record.Ref)
+	}
+	want := []string{"SPEC-1", "SPEC-2", "DOC-1"}
+	if len(refs) != len(want) {
+		t.Fatalf("yielded refs = %v, want %v", refs, want)
+	}
+	for i, ref := range want {
+		if refs[i] != ref {
+			t.Fatalf("yielded refs[%d] = %q, want %q", i, refs[i], ref)
+		}
+	}
+
+	// After exhaustion the iterator must keep returning false.
+	if _, ok, err := src.Next(ctx); ok || err != nil {
+		t.Fatalf("Next() after exhaustion = (_, %v, %v), want (zero, false, nil)", ok, err)
+	}
+}
+
+func TestLoadResultRecordSourceHandlesNilLoadResult(t *testing.T) {
+	t.Parallel()
+
+	src := NewLoadResultRecordSource(nil)
+	if _, ok, err := src.Next(context.Background()); ok || err != nil {
+		t.Fatalf("Next() on nil source = (_, %v, %v), want (zero, false, nil)", ok, err)
+	}
+}
+
+func TestRecordSourceFuncImplementsRecordSource(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("loader exploded")
+	src := RecordSourceFunc(func(context.Context) (stcorpus.Record, bool, error) {
+		return stcorpus.Record{}, false, wantErr
+	})
+	if _, _, err := src.Next(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("Next() error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/source/stream_test.go
+++ b/internal/source/stream_test.go
@@ -60,6 +60,36 @@ func TestLoadResultRecordSourceHandlesNilLoadResult(t *testing.T) {
 	}
 }
 
+func TestLoadResultRecordSourceStickyErrorAfterNormalizationFailure(t *testing.T) {
+	t.Parallel()
+
+	// A spec record with no Ref fails stcorpus.Record.Normalize. The
+	// adapter must surface that error on the failing Next and on every
+	// subsequent Next, not silently flip to (zero, false, nil) — that
+	// would let stroma's RebuildFromSource treat the stream as cleanly
+	// exhausted and commit a partial snapshot.
+	bad := model.SpecRecord{Kind: model.ArtifactKindSpec, Title: "no ref", BodyText: "x", BodyFormat: "markdown", ContentHash: "h"}
+	src := NewLoadResultRecordSource(&LoadResult{Specs: []model.SpecRecord{bad}})
+	ctx := context.Background()
+
+	_, ok, firstErr := src.Next(ctx)
+	if firstErr == nil {
+		t.Fatal("Next() error = nil, want normalization failure on bad spec")
+	}
+	if ok {
+		t.Fatal("Next() ok = true, want false on the failing record")
+	}
+	for i := 0; i < 3; i++ {
+		_, ok, err := src.Next(ctx)
+		if ok {
+			t.Fatalf("Next() #%d ok = true, want sticky terminal state", i)
+		}
+		if !errors.Is(err, firstErr) {
+			t.Fatalf("Next() #%d error = %v, want sticky %v", i, err, firstErr)
+		}
+	}
+}
+
 func TestRecordSourceFuncImplementsRecordSource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #396.

## Summary

- Switches `pituitary index --rebuild` to `stindex.RebuildFromSource` and `pituitary update` to `stindex.SyncFromSource`. Records are yielded one at a time into stroma, which chunks and embeds in bounded internal batches and flushes without keeping the full chunks-and-vectors plan resident before commit.
- New `internal/source/stream.go` exposes a `RecordSource` interface (matching stroma's shape) and a `LoadResultRecordSource` adapter.
- Update path keeps today's behavior: `SyncFromSource` removes stored records absent from the configured source set, matching the existing "configure source change → next update reflects removals" contract.
- Adds `BenchmarkRebuildLargeCorpus` (200 docs × 4KB) under \`-benchmem\` so future memory work has a stable baseline.
- Documents the scope in \`docs/runtime.md\`: the index-side pipeline is now bounded, but the source loader still materializes a full \`LoadResult\`. Loader-side lazy yielding is a separate change tracked in the issue thread.

## Codex review feedback addressed

The pre-commit codex adversarial-review correctly flagged that the original docs/comments overstated the scope (the LoadResult is still fully resident, and \`MaxPlannedRecords\` is unset on the update path so a mass-edit can still build an unbounded changed-record plan). Fixed by tightening the wording in \`docs/runtime.md\`, \`internal/index/rebuild.go\`, and \`internal/index/update.go\` to describe what this PR actually delivers — the stroma-side bounding — and to point at the deferred follow-ups for true caller-side streaming and an opt-in \`MaxPlannedRecords\` cap with a fall-back-to-rebuild branch.

## Test plan

- [x] \`go test ./...\`
- [x] \`go vet ./...\`
- [x] New benchmark runs: \`go test ./internal/index/ -bench BenchmarkRebuildLargeCorpus -benchtime=1x -run '^\$'\`
- [x] Pre-existing rebuild and update integration tests still pass with the streaming switch (semantic-similarity, hybrid retrieval, doc drift, compliance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)