### PR TITLE
feat: propagate cancellation through source loading and adapters (#377)

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -62,7 +62,7 @@ func runDiscoverContext(ctx context.Context, args []string, stdout, stderr io.Wr
 		ConfigPath: strings.TrimSpace(configPath),
 		Write:      write,
 	}
-	result, err := source.DiscoverWorkspace(source.DiscoverOptions{
+	result, err := source.DiscoverWorkspaceContext(ctx, source.DiscoverOptions{
 		RootPath:   path,
 		ConfigPath: request.ConfigPath,
 		Write:      write,

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -121,7 +121,7 @@ func runIndexContext(ctx context.Context, args []string, stdout, stderr io.Write
 		return writeCLIError(stdout, stderr, format, "index", request, configLoadIssue("invalid config:\n"+err.Error(), resolution), 2)
 	}
 	emitMultirepoShadowWarning(resolution)
-	records, err := source.LoadFromConfigWithOptions(cfg, source.LoadOptions{Logger: cliLoggerFromContext(ctx)})
+	records, err := source.LoadFromConfigWithOptionsContext(ctx, cfg, source.LoadOptions{Logger: cliLoggerFromContext(ctx)})
 	if err != nil {
 		return writeCLIError(stdout, stderr, format, "index", request, cliIssue{
 			Code:    "source_error",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -76,7 +76,7 @@ func runInitContext(ctx context.Context, args []string, stdout, stderr io.Writer
 		DryRun:     dryRun,
 	}
 	logger := cliLoggerFromContext(ctx)
-	discovered, err := source.DiscoverWorkspace(source.DiscoverOptions{
+	discovered, err := source.DiscoverWorkspaceContext(ctx, source.DiscoverOptions{
 		RootPath:   path,
 		ConfigPath: request.ConfigPath,
 		Write:      false,
@@ -115,7 +115,7 @@ func runInitContext(ctx context.Context, args []string, stdout, stderr io.Writer
 			Message: "generated config is invalid:\n" + err.Error(),
 		}, 2)
 	}
-	records, err := source.LoadFromConfigWithOptions(cfg, source.LoadOptions{Logger: logger})
+	records, err := source.LoadFromConfigWithOptionsContext(ctx, cfg, source.LoadOptions{Logger: logger})
 	if err != nil {
 		return writeCLIError(stdout, stderr, format, "init", request, cliIssue{
 			Code:    "source_error",

--- a/cmd/preview_sources.go
+++ b/cmd/preview_sources.go
@@ -67,7 +67,7 @@ func runPreviewSourcesContext(ctx context.Context, args []string, stdout, stderr
 	}
 	emitMultirepoShadowWarning(resolution)
 
-	result, err := source.PreviewFromConfigWithOptions(cfg, source.PreviewOptions{
+	result, err := source.PreviewFromConfigWithOptionsContext(ctx, cfg, source.PreviewOptions{
 		Logger:  cliLoggerFromContext(ctx),
 		Verbose: verbose,
 	})

--- a/extensions/github/adapter.go
+++ b/extensions/github/adapter.go
@@ -38,6 +38,12 @@ type adapter struct {
 }
 
 func (a *adapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sdk.AdapterResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(cfg.Kind) != kindIssue {
 		return nil, fmt.Errorf("unsupported kind %q", cfg.Kind)
 	}
@@ -70,6 +76,13 @@ func (a *adapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sdk.AdapterR
 		Docs:  make([]sdk.DocRecord, 0, len(issues)),
 	}
 	for _, issue := range issues {
+		// Re-check between records so a non-cooperating issue client
+		// (one that ignores ctx and returns the full set anyway)
+		// cannot trick the adapter into building all records after
+		// cancellation.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if issue.IsPullRequest {
 			continue
 		}

--- a/extensions/github/cancellation_test.go
+++ b/extensions/github/cancellation_test.go
@@ -1,0 +1,135 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dusk-network/pituitary/sdk"
+)
+
+// uncooperativeIssueClient mimics a client that ignores ctx and
+// returns the full issue list regardless of cancellation. This lets us
+// prove the adapter itself enforces ctx, not just the client.
+type uncooperativeIssueClient struct {
+	issues []githubIssue
+}
+
+func (u uncooperativeIssueClient) ListIssues(_ context.Context, _ string, _ string, _ issueListOptions) ([]githubIssue, error) {
+	return append([]githubIssue(nil), u.issues...), nil
+}
+
+// TestAdapterLoadHonorsCanceledContextAtEntry verifies the adapter
+// rejects an already-canceled ctx before it ever reaches the client.
+func TestAdapterLoadHonorsCanceledContextAtEntry(t *testing.T) {
+	t.Parallel()
+
+	a := &adapter{clientFactory: func(_ sourceOptions) (issueClient, error) {
+		return uncooperativeIssueClient{issues: nil}, nil
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := a.Load(ctx, sdk.SourceConfig{
+		Name:    "issues",
+		Adapter: adapterName,
+		Kind:    kindIssue,
+		Options: map[string]any{"repo": "owner/repo"},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Load(canceled) error = %v, want context.Canceled", err)
+	}
+}
+
+// TestAdapterLoadHonorsCancelDuringRecordLoop proves the adapter's
+// per-record ctx.Err() guard catches cancellation even when the client
+// ignores ctx and returns all records. Without that guard the adapter
+// would happily build every spec/doc after the caller had gone away.
+func TestAdapterLoadHonorsCancelDuringRecordLoop(t *testing.T) {
+	t.Parallel()
+
+	issues := make([]githubIssue, 0, 32)
+	for i := 0; i < 32; i++ {
+		issues = append(issues, githubIssue{
+			Number:  i + 1,
+			Title:   "issue",
+			Body:    "body",
+			State:   "open",
+			HTMLURL: "https://example.invalid/owner/repo/issues/x",
+			Labels:  []string{"bug"},
+		})
+	}
+
+	a := &adapter{clientFactory: func(_ sourceOptions) (issueClient, error) {
+		return uncooperativeIssueClient{issues: issues}, nil
+	}}
+
+	// Budget exactly covers the entry guard. Inside the per-record
+	// loop the very next ctx.Err() returns Canceled.
+	ctx := newDeferredCancelContext(1)
+
+	_, err := a.Load(ctx, sdk.SourceConfig{
+		Name:    "issues",
+		Adapter: adapterName,
+		Kind:    kindIssue,
+		Options: map[string]any{"repo": "owner/repo"},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Load(deferred cancel) error = %v, want context.Canceled", err)
+	}
+	if !ctx.canceledOnce {
+		t.Fatalf("deferred-cancel context never reached the canceled phase")
+	}
+}
+
+// TestAdapterLoadNilContextDoesNotPanic guards the nil-ctx defensive
+// shim added in the cancellation propagation work.
+func TestAdapterLoadNilContextDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	a := &adapter{clientFactory: func(_ sourceOptions) (issueClient, error) {
+		return uncooperativeIssueClient{issues: nil}, nil
+	}}
+
+	//nolint:staticcheck // exercising the nil-context guard
+	if _, err := a.Load(nil, sdk.SourceConfig{
+		Name:    "issues",
+		Adapter: adapterName,
+		Kind:    kindIssue,
+		Options: map[string]any{"repo": "owner/repo"},
+	}); err != nil {
+		t.Fatalf("Load(nil ctx) error = %v, want nil", err)
+	}
+}
+
+type deferredCancelContext struct {
+	context.Context
+	freeRemain   int
+	canceledOnce bool
+	doneCh       chan struct{}
+}
+
+func newDeferredCancelContext(nFreeChecks int) *deferredCancelContext {
+	return &deferredCancelContext{
+		Context:    context.Background(),
+		freeRemain: nFreeChecks,
+		doneCh:     make(chan struct{}),
+	}
+}
+
+func (c *deferredCancelContext) Err() error {
+	if c.freeRemain > 0 {
+		c.freeRemain--
+		return nil
+	}
+	if !c.canceledOnce {
+		c.canceledOnce = true
+		close(c.doneCh)
+	}
+	return context.Canceled
+}
+
+func (c *deferredCancelContext) Done() <-chan struct{} {
+	return c.doneCh
+}

--- a/extensions/json/adapter.go
+++ b/extensions/json/adapter.go
@@ -33,7 +33,13 @@ func init() {
 type adapter struct{}
 
 func (a *adapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sdk.AdapterResult, error) {
-	files, kind, err := enumerateSelectedJSONFiles(cfg)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	files, kind, err := enumerateSelectedJSONFiles(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -44,6 +50,9 @@ func (a *adapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sdk.AdapterR
 
 	result := &sdk.AdapterResult{}
 	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		record, err := loadJSONArtifact(ctx, cfg, options, kind, file)
 		if err != nil {
 			return nil, err
@@ -61,9 +70,14 @@ func (a *adapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sdk.AdapterR
 }
 
 func (a *adapter) Preview(ctx context.Context, cfg sdk.SourceConfig) ([]sdk.PreviewItem, error) {
-	_ = ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
-	files, kind, err := enumerateSelectedJSONFiles(cfg)
+	files, kind, err := enumerateSelectedJSONFiles(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +179,7 @@ type selectedJSONFile struct {
 	RelativePath string
 }
 
-func enumerateSelectedJSONFiles(cfg sdk.SourceConfig) ([]selectedJSONFile, string, error) {
+func enumerateSelectedJSONFiles(ctx context.Context, cfg sdk.SourceConfig) ([]selectedJSONFile, string, error) {
 	kind := normalizeKind(cfg.Kind)
 	if kind == "" {
 		return nil, "", fmt.Errorf("unsupported kind %q", cfg.Kind)
@@ -181,6 +195,9 @@ func enumerateSelectedJSONFiles(cfg sdk.SourceConfig) ([]selectedJSONFile, strin
 
 	matches := make([]selectedJSONFile, 0)
 	err = filepath.WalkDir(resolvedPath, func(path string, d os.DirEntry, walkErr error) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -343,7 +360,9 @@ type loadedArtifact struct {
 }
 
 func loadJSONArtifact(ctx context.Context, cfg sdk.SourceConfig, options sourceOptions, kind string, file selectedJSONFile) (loadedArtifact, error) {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return loadedArtifact{}, err
+	}
 
 	raw, err := os.ReadFile(file.AbsolutePath)
 	if err != nil {

--- a/extensions/json/cancellation_test.go
+++ b/extensions/json/cancellation_test.go
@@ -1,0 +1,163 @@
+package jsonadapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/dusk-network/pituitary/sdk"
+)
+
+// deferredCancelContext is a context whose Err() returns nil for the
+// first nFreeChecks calls and context.Canceled afterwards. Used to
+// prove cancellation guards inside the adapter walk callback (not just
+// the entry guard) actually fire.
+type deferredCancelContext struct {
+	context.Context
+	mu           sync.Mutex
+	freeRemain   int
+	canceledOnce bool
+	doneCh       chan struct{}
+}
+
+func newDeferredCancelContext(nFreeChecks int) *deferredCancelContext {
+	return &deferredCancelContext{
+		Context:    context.Background(),
+		freeRemain: nFreeChecks,
+		doneCh:     make(chan struct{}),
+	}
+}
+
+func (c *deferredCancelContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.freeRemain > 0 {
+		c.freeRemain--
+		return nil
+	}
+	if !c.canceledOnce {
+		c.canceledOnce = true
+		close(c.doneCh)
+	}
+	return context.Canceled
+}
+
+func (c *deferredCancelContext) Done() <-chan struct{} {
+	return c.doneCh
+}
+
+// TestAdapterLoadHonorsCanceledContext checks the adapter rejects an
+// already-canceled context before starting any I/O.
+func TestAdapterLoadHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "specs", "a.json"), `{"ref":"X-1","title":"X","status":"draft","domain":"x","body":"b"}`)
+
+	a := &adapter{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := a.Load(ctx, sdk.SourceConfig{
+		Name:          "specs",
+		Adapter:       adapterName,
+		Kind:          kindSpec,
+		Path:          "specs",
+		WorkspaceRoot: root,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Load(canceled) error = %v, want context.Canceled", err)
+	}
+}
+
+// TestAdapterPreviewHonorsCanceledContext mirrors the above for
+// Preview, the path Pituitary's PreviewFromConfigContext uses.
+func TestAdapterPreviewHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "specs", "a.json"), `{"ref":"X-1","title":"X","status":"draft","domain":"x","body":"b"}`)
+
+	a := &adapter{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := a.Preview(ctx, sdk.SourceConfig{
+		Name:          "specs",
+		Adapter:       adapterName,
+		Kind:          kindSpec,
+		Path:          "specs",
+		WorkspaceRoot: root,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Preview(canceled) error = %v, want context.Canceled", err)
+	}
+}
+
+// TestAdapterLoadCancelDuringWalk proves cancellation observed inside
+// the WalkDir callback (and only there) surfaces context.Canceled.
+// Non-.json entries are walked but never selected, so removing the
+// per-walk-entry guard would let the walk complete cleanly with zero
+// matches and the Load would succeed.
+func TestAdapterLoadCancelDuringWalk(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	specsDir := filepath.Join(root, "specs")
+	if err := os.MkdirAll(specsDir, 0o755); err != nil {
+		t.Fatalf("mkdir specs: %v", err)
+	}
+	for i := 0; i < 64; i++ {
+		path := filepath.Join(specsDir, fmt.Sprintf("noise_%03d.txt", i))
+		if err := os.WriteFile(path, []byte("noise\n"), 0o644); err != nil {
+			t.Fatalf("write noise: %v", err)
+		}
+	}
+
+	a := &adapter{}
+	// Budget covers Adapter.Load entry only; the very next ctx.Err()
+	// (inside the WalkDir callback) returns Canceled.
+	ctx := newDeferredCancelContext(1)
+
+	_, err := a.Load(ctx, sdk.SourceConfig{
+		Name:          "specs",
+		Adapter:       adapterName,
+		Kind:          kindSpec,
+		Path:          "specs",
+		WorkspaceRoot: root,
+	})
+	if err == nil {
+		t.Fatalf("Load(deferred cancel) error = nil, want cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Load error = %v, want context.Canceled", err)
+	}
+	if !ctx.canceledOnce {
+		t.Fatalf("deferred-cancel context never reached the canceled phase; cancellation was observed earlier than expected")
+	}
+}
+
+// TestAdapterLoadNilContextDoesNotPanic guards the nil-ctx defensive
+// check we added on the same shape as the filesystem adapter.
+func TestAdapterLoadNilContextDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "specs", "a.json"), `{"ref":"X-1","title":"X","status":"draft","domain":"x","body":"b"}`)
+
+	a := &adapter{}
+	//nolint:staticcheck // exercising the nil-context guard
+	if _, err := a.Load(nil, sdk.SourceConfig{
+		Name:          "specs",
+		Adapter:       adapterName,
+		Kind:          kindSpec,
+		Path:          "specs",
+		WorkspaceRoot: root,
+	}); err != nil {
+		t.Fatalf("Load(nil ctx) error = %v, want nil", err)
+	}
+}

--- a/internal/app/fix.go
+++ b/internal/app/fix.go
@@ -103,7 +103,7 @@ func runFixDocDrift(ctx context.Context, cfg *config.Config, request FixRequest)
 		}, nil
 	}
 
-	records, err := source.LoadFromConfig(cfg)
+	records, err := source.LoadFromConfigContext(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func resolveFixTargets(ctx context.Context, cfg *config.Config, request FixReque
 	}
 
 	if hasPath {
-		records, err := source.LoadFromConfig(cfg)
+		records, err := source.LoadFromConfigContext(ctx, cfg)
 		if err != nil {
 			return "", nil, err
 		}

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -47,7 +47,7 @@ type RuntimeProviderStatus struct {
 // Status loads config, inspects the current index, and optionally probes runtime dependencies.
 func Status(ctx context.Context, configPath string, request StatusRequest) Response[StatusRequest, StatusResult] {
 	return executeWithConfig(ctx, configPath, request, func(cfg *config.Config) (*StatusResult, error) {
-		records, err := source.LoadFromConfig(cfg)
+		records, err := source.LoadFromConfigContext(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/index/freshness.go
+++ b/internal/index/freshness.go
@@ -210,7 +210,7 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 		return status, nil
 	}
 
-	records, err := source.LoadFromConfig(cfg)
+	records, err := source.LoadFromConfigContext(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("load current sources for freshness check: %w", err)
 	}

--- a/internal/source/cancellation_test.go
+++ b/internal/source/cancellation_test.go
@@ -289,6 +289,59 @@ func TestPreviewFromConfigContextHonorsCanceledContext(t *testing.T) {
 	}
 }
 
+// TestLoadFromConfigContextNilContextDoesNotPanic guards the nil-ctx
+// defense added on the public Context entrypoints.
+func TestLoadFromConfigContextNilContextDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	cfg := &config.Config{
+		ConfigPath: filepath.Join(workspaceRoot, "pituitary.toml"),
+		Workspace:  config.Workspace{RootPath: workspaceRoot},
+	}
+
+	//nolint:staticcheck // exercising the nil-context guard
+	if _, err := LoadFromConfigContext(nil, cfg); err != nil {
+		t.Fatalf("LoadFromConfigContext(nil ctx) error = %v, want nil", err)
+	}
+}
+
+// TestPreviewFromConfigContextNilContextDoesNotPanic mirrors the above
+// for the preview path.
+func TestPreviewFromConfigContextNilContextDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	cfg := &config.Config{
+		ConfigPath: filepath.Join(workspaceRoot, "pituitary.toml"),
+		Workspace:  config.Workspace{RootPath: workspaceRoot},
+	}
+
+	//nolint:staticcheck // exercising the nil-context guard
+	if _, err := PreviewFromConfigContext(nil, cfg); err != nil {
+		t.Fatalf("PreviewFromConfigContext(nil ctx) error = %v, want nil", err)
+	}
+}
+
+// TestDiscoverWorkspaceContextNilContextDoesNotPanic mirrors the above
+// for the discover path.
+func TestDiscoverWorkspaceContextNilContextDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "specs"), 0o755); err != nil {
+		t.Fatalf("mkdir specs: %v", err)
+	}
+
+	//nolint:staticcheck // exercising the nil-context guard
+	_, err := DiscoverWorkspaceContext(nil, DiscoverOptions{RootPath: workspaceRoot})
+	// DiscoverWorkspaceContext returns an error when no sources are
+	// discovered; we only care that it does not panic.
+	if err != nil && !strings.Contains(err.Error(), "no likely sources discovered") {
+		t.Fatalf("DiscoverWorkspaceContext(nil ctx) unexpected error = %v", err)
+	}
+}
+
 // TestFilesystemAdapterLoadHonorsNilContext defensively checks the
 // adapter does not panic if a caller passes a nil context.
 func TestFilesystemAdapterLoadHonorsNilContext(t *testing.T) {

--- a/internal/source/cancellation_test.go
+++ b/internal/source/cancellation_test.go
@@ -1,0 +1,317 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/sdk"
+)
+
+// TestLoadFromConfigContextHonorsCanceledContext verifies that an
+// already-canceled context short-circuits the source-loading loop
+// before any adapter is invoked.
+func TestLoadFromConfigContextHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	docsDir := filepath.Join(workspaceRoot, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "a.md"), []byte("# A\n"), 0o644); err != nil {
+		t.Fatalf("write a.md: %v", err)
+	}
+
+	cfg := &config.Config{
+		ConfigPath: filepath.Join(workspaceRoot, "pituitary.toml"),
+		Workspace:  config.Workspace{RootPath: workspaceRoot},
+		Sources: []config.Source{
+			{
+				Name:         "docs",
+				Adapter:      config.AdapterFilesystem,
+				Kind:         config.SourceKindMarkdownDocs,
+				Path:         "docs",
+				ResolvedPath: docsDir,
+				RepoRootPath: workspaceRoot,
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := LoadFromConfigContext(ctx, cfg); !errors.Is(err, context.Canceled) {
+		t.Fatalf("LoadFromConfigContext(canceled) error = %v, want context.Canceled", err)
+	}
+}
+
+// deferredCancelContext is a context whose Err() returns nil for the
+// first nFreeChecks calls and context.Canceled afterwards. It lets a
+// test exercise cancellation that is only observed inside a filesystem
+// walk callback, after the loader and adapter entry guards have
+// already passed.
+type deferredCancelContext struct {
+	context.Context
+	mu           sync.Mutex
+	freeRemain   int
+	canceledOnce bool
+	doneCh       chan struct{}
+}
+
+func newDeferredCancelContext(nFreeChecks int) *deferredCancelContext {
+	return &deferredCancelContext{
+		Context:    context.Background(),
+		freeRemain: nFreeChecks,
+		doneCh:     make(chan struct{}),
+	}
+}
+
+func (c *deferredCancelContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.freeRemain > 0 {
+		c.freeRemain--
+		return nil
+	}
+	if !c.canceledOnce {
+		c.canceledOnce = true
+		close(c.doneCh)
+	}
+	return context.Canceled
+}
+
+func (c *deferredCancelContext) Done() <-chan struct{} {
+	return c.doneCh
+}
+
+// TestLoadFromConfigContextCancelDuringWalk proves that cancellation
+// observed inside the WalkDir callback (and only there) surfaces
+// context.Canceled. The fixture uses zero selected .md files but many
+// non-matching entries, so:
+//   - the loader and adapter entry guards see no cancellation (budget=2),
+//   - enumerateSelectedMarkdownPaths returns no matches with the walk
+//     guard present (cancellation observed inside WalkDir),
+//   - if the walk-callback ctx.Err() guard were removed, the walk would
+//     complete cleanly (zero matches, no per-match loop iterations),
+//     loadMarkdownDocs would return nil, and the loader would succeed.
+//
+// In other words, this test fails closed against regression of the
+// per-walk-entry guard, not just the loop-entry short-circuit.
+func TestLoadFromConfigContextCancelDuringWalk(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	docsDir := filepath.Join(workspaceRoot, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	// Many non-.md entries: walked but never selected for the per-match
+	// loop. The only place ctx.Err() can return Canceled is the WalkDir
+	// callback's guard.
+	for i := 0; i < 64; i++ {
+		path := filepath.Join(docsDir, fmt.Sprintf("noise_%03d.txt", i))
+		if err := os.WriteFile(path, []byte("noise\n"), 0o644); err != nil {
+			t.Fatalf("write noise: %v", err)
+		}
+	}
+
+	cfg := &config.Config{
+		ConfigPath: filepath.Join(workspaceRoot, "pituitary.toml"),
+		Workspace:  config.Workspace{RootPath: workspaceRoot},
+		Sources: []config.Source{
+			{
+				Name:         "docs",
+				Adapter:      config.AdapterFilesystem,
+				Kind:         config.SourceKindMarkdownDocs,
+				Path:         "docs",
+				ResolvedPath: docsDir,
+				RepoRootPath: workspaceRoot,
+			},
+		},
+	}
+
+	// Free checks budget covers loader loop entry + filesystem adapter
+	// Load entry. Subsequent ctx.Err() invocations (the walk callback)
+	// return context.Canceled.
+	ctx := newDeferredCancelContext(2)
+
+	_, err := LoadFromConfigContext(ctx, cfg)
+	if err == nil {
+		t.Fatalf("LoadFromConfigContext(deferred cancel) error = nil, want cancellation")
+	}
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Fatalf("LoadFromConfigContext error = %v, want it to wrap context.Canceled", err)
+	}
+	if !ctx.canceledOnce {
+		t.Fatalf("deferred-cancel context never reached the canceled phase; cancellation was observed earlier than expected")
+	}
+}
+
+// TestFilesystemAdapterLoadHonorsCanceledContext verifies the adapter
+// itself observes ctx.Err() before walking, regardless of caller.
+func TestFilesystemAdapterLoadHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	docsDir := filepath.Join(workspaceRoot, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "a.md"), []byte("# A\n"), 0o644); err != nil {
+		t.Fatalf("write a.md: %v", err)
+	}
+
+	a := &filesystemAdapter{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := a.Load(ctx, sdk.SourceConfig{
+		Name:          "docs",
+		Adapter:       config.AdapterFilesystem,
+		Kind:          config.SourceKindMarkdownDocs,
+		Path:          "docs",
+		WorkspaceRoot: workspaceRoot,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("filesystemAdapter.Load(canceled) error = %v, want context.Canceled", err)
+	}
+}
+
+// TestDiscoverWorkspaceContextHonorsCanceledContext verifies that
+// DiscoverWorkspaceContext short-circuits before walking when ctx is
+// already canceled. This guards the same-shape gap that the load path
+// closes: discovery scans whole workspaces just like source loading.
+func TestDiscoverWorkspaceContextHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "specs"), 0o755); err != nil {
+		t.Fatalf("mkdir specs: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := DiscoverWorkspaceContext(ctx, DiscoverOptions{RootPath: workspaceRoot})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("DiscoverWorkspaceContext(canceled) error = %v, want context.Canceled", err)
+	}
+}
+
+// TestDiscoverWorkspaceContextWriteRefusesAfterCancel verifies that
+// DiscoverWorkspaceContext does not write a fresh config to disk when
+// cancellation fires before the write boundary, so a canceled
+// `init`/`discover` cannot leave behind a partial side effect.
+func TestDiscoverWorkspaceContextWriteRefusesAfterCancel(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	bundleDir := filepath.Join(workspaceRoot, "specs", "demo")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "spec.toml"), []byte(`id = "DEMO-1"
+title = "Demo"
+status = "draft"
+domain = "demo"
+body = "body.md"
+`), 0o644); err != nil {
+		t.Fatalf("write spec.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "body.md"), []byte("# Demo\n"), 0o644); err != nil {
+		t.Fatalf("write body.md: %v", err)
+	}
+
+	configPath := filepath.Join(workspaceRoot, "pituitary.toml")
+	// Pre-cancel: cancellation must surface before the write boundary
+	// regardless of whether the scan, preview, render, or the
+	// pre-write guard catches it. The invariant under test is that a
+	// canceled DiscoverWorkspaceContext with Write=true never persists
+	// a partial side effect.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := DiscoverWorkspaceContext(ctx, DiscoverOptions{
+		RootPath:   workspaceRoot,
+		ConfigPath: configPath,
+		Write:      true,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("DiscoverWorkspaceContext(write,canceled) error = %v, want context.Canceled", err)
+	}
+	if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
+		t.Fatalf("config file should not have been written; stat err = %v", statErr)
+	}
+}
+
+// TestPreviewFromConfigContextHonorsCanceledContext verifies that the
+// preview path observes cancellation between sources.
+func TestPreviewFromConfigContextHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	docsDir := filepath.Join(workspaceRoot, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "a.md"), []byte("# A\n"), 0o644); err != nil {
+		t.Fatalf("write a.md: %v", err)
+	}
+
+	cfg := &config.Config{
+		ConfigPath: filepath.Join(workspaceRoot, "pituitary.toml"),
+		Workspace:  config.Workspace{RootPath: workspaceRoot},
+		Sources: []config.Source{
+			{
+				Name:         "docs",
+				Adapter:      config.AdapterFilesystem,
+				Kind:         config.SourceKindMarkdownDocs,
+				Path:         "docs",
+				ResolvedPath: docsDir,
+				RepoRootPath: workspaceRoot,
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := PreviewFromConfigContext(ctx, cfg)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("PreviewFromConfigContext(canceled) error = %v, want context.Canceled", err)
+	}
+}
+
+// TestFilesystemAdapterLoadHonorsNilContext defensively checks the
+// adapter does not panic if a caller passes a nil context.
+func TestFilesystemAdapterLoadHonorsNilContext(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	docsDir := filepath.Join(workspaceRoot, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "a.md"), []byte("# A\n"), 0o644); err != nil {
+		t.Fatalf("write a.md: %v", err)
+	}
+
+	a := &filesystemAdapter{}
+	//nolint:staticcheck // exercising the nil-context guard
+	if _, err := a.Load(nil, sdk.SourceConfig{
+		Name:          "docs",
+		Adapter:       config.AdapterFilesystem,
+		Kind:          config.SourceKindMarkdownDocs,
+		Path:          "docs",
+		WorkspaceRoot: workspaceRoot,
+	}); err != nil {
+		t.Fatalf("filesystemAdapter.Load(nil ctx) error = %v, want nil", err)
+	}
+}

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -101,6 +101,9 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 // filesystem walk callbacks that scan for spec bundles and markdown
 // candidates.
 func DiscoverWorkspaceContext(ctx context.Context, options DiscoverOptions) (*DiscoverResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	logger := options.Logger
 	rootPath := strings.TrimSpace(options.RootPath)
 	if rootPath == "" {

--- a/internal/source/discover.go
+++ b/internal/source/discover.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -88,7 +89,18 @@ type markdownCandidateAssessment struct {
 
 // DiscoverWorkspace scans one repo-like directory and proposes a starting
 // local config plus a preview of what that config would index.
+//
+// Convenience wrapper without cancellation. Prefer DiscoverWorkspaceContext
+// on request paths so canceled CLI/MCP calls stop discovery walks promptly.
 func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
+	return DiscoverWorkspaceContext(context.Background(), options)
+}
+
+// DiscoverWorkspaceContext is the cancellation-aware variant of
+// DiscoverWorkspace. ctx is checked between phases and inside the
+// filesystem walk callbacks that scan for spec bundles and markdown
+// candidates.
+func DiscoverWorkspaceContext(ctx context.Context, options DiscoverOptions) (*DiscoverResult, error) {
 	logger := options.Logger
 	rootPath := strings.TrimSpace(options.RootPath)
 	if rootPath == "" {
@@ -108,11 +120,11 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 	}
 	logger.Infof("discover", "scanning workspace %s", filepath.ToSlash(workspaceRoot))
 
-	specCandidates, specBundleDirs, rejectedSpecBundles, err := discoverSpecBundleCandidates(workspaceRoot, logger)
+	specCandidates, specBundleDirs, rejectedSpecBundles, err := discoverSpecBundleCandidates(ctx, workspaceRoot, logger)
 	if err != nil {
 		return nil, err
 	}
-	contractCandidates, docCandidates, rejectedMarkdown, err := discoverMarkdownCandidates(workspaceRoot, specBundleDirs, logger)
+	contractCandidates, docCandidates, rejectedMarkdown, err := discoverMarkdownCandidates(ctx, workspaceRoot, specBundleDirs, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +156,7 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	preview, err := PreviewFromConfigWithOptions(cfg, PreviewOptions{Logger: logger})
+	preview, err := PreviewFromConfigWithOptionsContext(ctx, cfg, PreviewOptions{Logger: logger})
 	if err != nil {
 		return nil, fmt.Errorf("preview discovered config: %w", err)
 	}
@@ -163,6 +175,12 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 	}
 
 	if options.Write {
+		// Guard the disk-mutating boundary: refuse to write a fresh
+		// config when the caller has already canceled, so a canceled
+		// `init`/`discover` cannot leave behind partial side effects.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if err := writeDiscoveredConfig(cfg.ConfigPath, configText); err != nil {
 			return nil, err
 		}
@@ -170,7 +188,7 @@ func DiscoverWorkspace(options DiscoverOptions) (*DiscoverResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reload written config: %w", err)
 		}
-		preview, err := PreviewFromConfigWithOptions(loaded, PreviewOptions{Logger: logger})
+		preview, err := PreviewFromConfigWithOptionsContext(ctx, loaded, PreviewOptions{Logger: logger})
 		if err != nil {
 			return nil, fmt.Errorf("preview written config: %w", err)
 		}
@@ -209,12 +227,15 @@ func dirEntryIsRegular(d os.DirEntry) bool {
 	return typ.IsRegular()
 }
 
-func discoverSpecBundleCandidates(workspaceRoot string, logger *diag.Logger) ([]discoveredCandidate, map[string]struct{}, int, error) {
+func discoverSpecBundleCandidates(ctx context.Context, workspaceRoot string, logger *diag.Logger) ([]discoveredCandidate, map[string]struct{}, int, error) {
 	var candidates []discoveredCandidate
 	bundleDirs := make(map[string]struct{})
 	rejected := 0
 
 	err := filepath.WalkDir(workspaceRoot, func(path string, d os.DirEntry, walkErr error) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -328,12 +349,15 @@ func assessDiscoveredSpecBundle(workspaceRoot, bundleDir string) (bool, []string
 	}, ""
 }
 
-func discoverMarkdownCandidates(workspaceRoot string, specBundleDirs map[string]struct{}, logger *diag.Logger) ([]discoveredCandidate, []discoveredCandidate, int, error) {
+func discoverMarkdownCandidates(ctx context.Context, workspaceRoot string, specBundleDirs map[string]struct{}, logger *diag.Logger) ([]discoveredCandidate, []discoveredCandidate, int, error) {
 	var contractCandidates []discoveredCandidate
 	var docCandidates []discoveredCandidate
 	rejected := 0
 
 	err := filepath.WalkDir(workspaceRoot, func(path string, d os.DirEntry, walkErr error) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
 		if walkErr != nil {
 			return walkErr
 		}

--- a/internal/source/explain.go
+++ b/internal/source/explain.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -305,7 +306,7 @@ func explainMarkdownContractSource(workspaceRoot string, explanation SourceFileE
 }
 
 func explainSpecBundleSource(workspaceRoot string, explanation SourceFileExplanation, source config.Source, absolutePath string) (SourceFileExplanation, error) {
-	candidateDirs, err := discoverSpecBundleDirs(source.ResolvedPath)
+	candidateDirs, err := discoverSpecBundleDirs(context.Background(), source.ResolvedPath)
 	if err != nil {
 		return SourceFileExplanation{}, err
 	}

--- a/internal/source/filesystem.go
+++ b/internal/source/filesystem.go
@@ -28,7 +28,12 @@ func init() {
 type filesystemAdapter struct{}
 
 func (a *filesystemAdapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sdk.AdapterResult, error) {
-	_ = ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	source := config.Source{
 		Name:         cfg.Name,
@@ -52,19 +57,19 @@ func (a *filesystemAdapter) Load(ctx context.Context, cfg sdk.SourceConfig) (*sd
 
 	switch source.Kind {
 	case config.SourceKindSpecBundle:
-		specs, err := loadSpecBundles(cfg.WorkspaceRoot, source)
+		specs, err := loadSpecBundles(ctx, cfg.WorkspaceRoot, source)
 		if err != nil {
 			return nil, err
 		}
 		return &sdk.AdapterResult{Specs: specs}, nil
 	case config.SourceKindMarkdownDocs:
-		docs, err := loadMarkdownDocs(cfg.WorkspaceRoot, source)
+		docs, err := loadMarkdownDocs(ctx, cfg.WorkspaceRoot, source)
 		if err != nil {
 			return nil, err
 		}
 		return &sdk.AdapterResult{Docs: docs}, nil
 	case config.SourceKindMarkdownContract:
-		specs, err := loadMarkdownContracts(cfg.WorkspaceRoot, source)
+		specs, err := loadMarkdownContracts(ctx, cfg.WorkspaceRoot, source)
 		if err != nil {
 			return nil, err
 		}
@@ -149,14 +154,17 @@ func describeOrigin(itemLabel string, origin artifactOrigin) string {
 	return fmt.Sprintf("source %q path %q %s %q", origin.sourceName, origin.sourcePath, itemLabel, origin.itemPath)
 }
 
-func loadSpecBundles(workspaceRoot string, source config.Source) ([]model.SpecRecord, error) {
-	bundleDirs, err := discoverSpecBundles(source)
+func loadSpecBundles(ctx context.Context, workspaceRoot string, source config.Source) ([]model.SpecRecord, error) {
+	bundleDirs, err := discoverSpecBundles(ctx, source)
 	if err != nil {
 		return nil, fmt.Errorf("source %q: %w", source.Name, err)
 	}
 
 	var records []model.SpecRecord
 	for _, bundleDir := range bundleDirs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		record, err := loadSpecBundle(workspaceRoot, source, bundleDir)
 		if err != nil {
 			return nil, err
@@ -166,8 +174,8 @@ func loadSpecBundles(workspaceRoot string, source config.Source) ([]model.SpecRe
 	return records, nil
 }
 
-func discoverSpecBundles(source config.Source) ([]string, error) {
-	bundleDirs, err := discoverSpecBundleDirs(source.ResolvedPath)
+func discoverSpecBundles(ctx context.Context, source config.Source) ([]string, error) {
+	bundleDirs, err := discoverSpecBundleDirs(ctx, source.ResolvedPath)
 	if err != nil {
 		return nil, err
 	}
@@ -196,9 +204,12 @@ func discoverSpecBundles(source config.Source) ([]string, error) {
 	return filtered, nil
 }
 
-func discoverSpecBundleDirs(root string) ([]string, error) {
+func discoverSpecBundleDirs(ctx context.Context, root string) ([]string, error) {
 	var bundleDirs []string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
 		if err != nil {
 			return err
 		}
@@ -344,13 +355,16 @@ func isValidSpecStatus(status string) bool {
 	}
 }
 
-func loadMarkdownDocs(workspaceRoot string, source config.Source) ([]model.DocRecord, error) {
+func loadMarkdownDocs(ctx context.Context, workspaceRoot string, source config.Source) ([]model.DocRecord, error) {
 	var records []model.DocRecord
-	matches, err := enumerateSelectedMarkdownPaths(workspaceRoot, source, "doc")
+	matches, err := enumerateSelectedMarkdownPaths(ctx, workspaceRoot, source, "doc")
 	if err != nil {
 		return nil, err
 	}
 	for _, match := range matches {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		bodyBytes, err := readBoundedFile(match.AbsolutePath, maxMarkdownBodyBytes)
 		if err != nil {
 			return nil, fmt.Errorf("source %q doc %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
@@ -376,13 +390,16 @@ func loadMarkdownDocs(workspaceRoot string, source config.Source) ([]model.DocRe
 	return records, nil
 }
 
-func loadMarkdownContracts(workspaceRoot string, source config.Source) ([]model.SpecRecord, error) {
+func loadMarkdownContracts(ctx context.Context, workspaceRoot string, source config.Source) ([]model.SpecRecord, error) {
 	var records []model.SpecRecord
-	matches, err := enumerateSelectedMarkdownPaths(workspaceRoot, source, "contract")
+	matches, err := enumerateSelectedMarkdownPaths(ctx, workspaceRoot, source, "contract")
 	if err != nil {
 		return nil, err
 	}
 	for _, match := range matches {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		bodyBytes, err := readBoundedFile(match.AbsolutePath, maxMarkdownBodyBytes)
 		if err != nil {
 			return nil, fmt.Errorf("source %q contract %q: read markdown: %w", source.Name, workspaceRelative(workspaceRoot, match.AbsolutePath), err)
@@ -402,9 +419,12 @@ type selectedMarkdownPath struct {
 	RelativePath string
 }
 
-func enumerateSelectedMarkdownPaths(workspaceRoot string, source config.Source, label string) ([]selectedMarkdownPath, error) {
+func enumerateSelectedMarkdownPaths(ctx context.Context, workspaceRoot string, source config.Source, label string) ([]selectedMarkdownPath, error) {
 	matches := make([]selectedMarkdownPath, 0)
 	err := filepath.WalkDir(source.ResolvedPath, func(path string, d os.DirEntry, err error) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -38,12 +38,33 @@ type LoadOptions struct {
 }
 
 // LoadFromConfig loads and normalizes all configured sources.
+//
+// This is a context-free convenience wrapper kept for callers that don't
+// thread cancellation. It delegates to LoadFromConfigContext with a
+// background context. Prefer LoadFromConfigContext on request paths so
+// canceled CLI/MCP calls stop walking large workspaces promptly.
 func LoadFromConfig(cfg *config.Config) (*LoadResult, error) {
-	return LoadFromConfigWithOptions(cfg, LoadOptions{})
+	return LoadFromConfigContext(context.Background(), cfg)
+}
+
+// LoadFromConfigContext loads and normalizes all configured sources,
+// passing ctx into adapter Load() so cancellation propagates into
+// filesystem walks and bounded file reads.
+func LoadFromConfigContext(ctx context.Context, cfg *config.Config) (*LoadResult, error) {
+	return LoadFromConfigWithOptionsContext(ctx, cfg, LoadOptions{})
 }
 
 // LoadFromConfigWithOptions loads and normalizes all configured sources.
+//
+// Convenience wrapper for callers without a context; see
+// LoadFromConfigWithOptionsContext for the cancellation-aware variant.
 func LoadFromConfigWithOptions(cfg *config.Config, options LoadOptions) (*LoadResult, error) {
+	return LoadFromConfigWithOptionsContext(context.Background(), cfg, options)
+}
+
+// LoadFromConfigWithOptionsContext loads and normalizes all configured
+// sources with the supplied options, passing ctx into adapter Load().
+func LoadFromConfigWithOptionsContext(ctx context.Context, cfg *config.Config, options LoadOptions) (*LoadResult, error) {
 	logger := options.Logger
 	result := &LoadResult{
 		Sources: make([]LoadSourceSummary, 0, len(cfg.Sources)),
@@ -53,6 +74,9 @@ func LoadFromConfigWithOptions(cfg *config.Config, options LoadOptions) (*LoadRe
 	logger.Infof("source", "loading %d configured source(s)", len(cfg.Sources))
 
 	for _, source := range cfg.Sources {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		resolvedRepo := strings.TrimSpace(source.ResolvedRepo)
 		if resolvedRepo == "" {
 			resolvedRepo = config.PrimaryRepoID(cfg)
@@ -78,7 +102,7 @@ func LoadFromConfigWithOptions(cfg *config.Config, options LoadOptions) (*LoadRe
 		if factory == nil {
 			return nil, unknownAdapterError(source.Name, source.Adapter)
 		}
-		adapterResult, err := factory().Load(context.Background(), sdk.SourceConfig{
+		adapterResult, err := factory().Load(ctx, sdk.SourceConfig{
 			Name:          source.Name,
 			Adapter:       source.Adapter,
 			Kind:          source.Kind,

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -65,6 +65,9 @@ func LoadFromConfigWithOptions(cfg *config.Config, options LoadOptions) (*LoadRe
 // LoadFromConfigWithOptionsContext loads and normalizes all configured
 // sources with the supplied options, passing ctx into adapter Load().
 func LoadFromConfigWithOptionsContext(ctx context.Context, cfg *config.Config, options LoadOptions) (*LoadResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	logger := options.Logger
 	result := &LoadResult{
 		Sources: make([]LoadSourceSummary, 0, len(cfg.Sources)),

--- a/internal/source/new.go
+++ b/internal/source/new.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -201,7 +202,7 @@ func inspectExistingSpecBundles(workspaceRoot, specRoot string) ([]string, map[s
 		return nil, nil, "", fmt.Errorf("spec root %q is not a directory", workspaceRelative(workspaceRoot, specRoot))
 	}
 
-	bundleDirs, err := discoverSpecBundleDirs(specRoot)
+	bundleDirs, err := discoverSpecBundleDirs(context.Background(), specRoot)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("scan spec root %q: %w", workspaceRelative(workspaceRoot, specRoot), err)
 	}

--- a/internal/source/preview.go
+++ b/internal/source/preview.go
@@ -56,19 +56,41 @@ type PreviewOptions struct {
 }
 
 // PreviewFromConfig enumerates source items without rebuilding the index.
+//
+// Convenience wrapper without cancellation. Prefer PreviewFromConfigContext
+// on request paths so canceled CLI/MCP calls stop preview walks promptly.
 func PreviewFromConfig(cfg *config.Config) (*PreviewResult, error) {
-	return PreviewFromConfigWithOptions(cfg, PreviewOptions{})
+	return PreviewFromConfigContext(context.Background(), cfg)
+}
+
+// PreviewFromConfigContext enumerates source items without rebuilding the
+// index, threading ctx into the underlying filesystem walks.
+func PreviewFromConfigContext(ctx context.Context, cfg *config.Config) (*PreviewResult, error) {
+	return PreviewFromConfigWithOptionsContext(ctx, cfg, PreviewOptions{})
 }
 
 // PreviewFromConfigWithOptions enumerates source items without rebuilding the index.
+//
+// Convenience wrapper without cancellation; see
+// PreviewFromConfigWithOptionsContext for the cancellation-aware variant.
 func PreviewFromConfigWithOptions(cfg *config.Config, options PreviewOptions) (*PreviewResult, error) {
+	return PreviewFromConfigWithOptionsContext(context.Background(), cfg, options)
+}
+
+// PreviewFromConfigWithOptionsContext enumerates source items without
+// rebuilding the index. The supplied ctx is checked between sources and
+// inside filesystem walk callbacks.
+func PreviewFromConfigWithOptionsContext(ctx context.Context, cfg *config.Config, options PreviewOptions) (*PreviewResult, error) {
 	logger := options.Logger
 	result := &PreviewResult{
 		Sources: make([]SourcePreview, 0, len(cfg.Sources)),
 	}
 
 	for _, source := range cfg.Sources {
-		preview, err := previewSource(cfg.Workspace.RootPath, source, options.Verbose)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		preview, err := previewSource(ctx, cfg.Workspace.RootPath, source, options.Verbose)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +105,7 @@ func PreviewFromConfigWithOptions(cfg *config.Config, options PreviewOptions) (*
 	return result, nil
 }
 
-func previewSource(workspaceRoot string, source config.Source, verbose bool) (SourcePreview, error) {
+func previewSource(ctx context.Context, workspaceRoot string, source config.Source, verbose bool) (SourcePreview, error) {
 	preview := SourcePreview{
 		Name:         source.Name,
 		Adapter:      source.Adapter,
@@ -96,12 +118,12 @@ func previewSource(workspaceRoot string, source config.Source, verbose bool) (So
 	}
 
 	if source.Adapter != config.AdapterFilesystem {
-		return previewViaAdapter(preview, source)
+		return previewViaAdapter(ctx, preview, source)
 	}
 
 	switch source.Kind {
 	case config.SourceKindSpecBundle:
-		bundleDirs, err := discoverSpecBundles(source)
+		bundleDirs, err := discoverSpecBundles(ctx, source)
 		if err != nil {
 			return SourcePreview{}, fmt.Errorf("source %q: %w", source.Name, err)
 		}
@@ -113,7 +135,7 @@ func previewSource(workspaceRoot string, source config.Source, verbose bool) (So
 			})
 		}
 	case config.SourceKindMarkdownDocs:
-		matches, candidateCount, rejected, err := previewMarkdownPaths(workspaceRoot, source, "doc", verbose)
+		matches, candidateCount, rejected, err := previewMarkdownPaths(ctx, workspaceRoot, source, "doc", verbose)
 		if err != nil {
 			return SourcePreview{}, err
 		}
@@ -128,7 +150,7 @@ func previewSource(workspaceRoot string, source config.Source, verbose bool) (So
 		}
 		preview.RejectedItems = rejected
 	case config.SourceKindMarkdownContract:
-		matches, candidateCount, rejected, err := previewMarkdownPaths(workspaceRoot, source, "contract", verbose)
+		matches, candidateCount, rejected, err := previewMarkdownPaths(ctx, workspaceRoot, source, "contract", verbose)
 		if err != nil {
 			return SourcePreview{}, err
 		}
@@ -155,11 +177,14 @@ type previewMarkdownPath struct {
 	Selection sourcePathSelection
 }
 
-func previewMarkdownPaths(workspaceRoot string, source config.Source, label string, verbose bool) ([]previewMarkdownPath, int, []PreviewRejectedItem, error) {
+func previewMarkdownPaths(ctx context.Context, workspaceRoot string, source config.Source, label string, verbose bool) ([]previewMarkdownPath, int, []PreviewRejectedItem, error) {
 	matches := make([]previewMarkdownPath, 0)
 	rejected := make([]PreviewRejectedItem, 0)
 	candidateCount := 0
 	err := filepath.WalkDir(source.ResolvedPath, func(path string, d os.DirEntry, err error) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
 		if err != nil {
 			return err
 		}
@@ -203,7 +228,7 @@ func previewMarkdownPaths(workspaceRoot string, source config.Source, label stri
 	return matches, candidateCount, rejected, nil
 }
 
-func previewViaAdapter(preview SourcePreview, source config.Source) (SourcePreview, error) {
+func previewViaAdapter(ctx context.Context, preview SourcePreview, source config.Source) (SourcePreview, error) {
 	factory := LookupAdapter(source.Adapter)
 	if factory == nil {
 		return SourcePreview{}, unknownAdapterError(source.Name, source.Adapter)
@@ -215,7 +240,7 @@ func previewViaAdapter(preview SourcePreview, source config.Source) (SourcePrevi
 		return SourcePreview{}, fmt.Errorf("source %q: adapter %q does not support preview", source.Name, source.Adapter)
 	}
 
-	items, err := previewer.Preview(context.Background(), sdk.SourceConfig{
+	items, err := previewer.Preview(ctx, sdk.SourceConfig{
 		Name:          source.Name,
 		Adapter:       source.Adapter,
 		Kind:          source.Kind,

--- a/internal/source/preview.go
+++ b/internal/source/preview.go
@@ -81,6 +81,9 @@ func PreviewFromConfigWithOptions(cfg *config.Config, options PreviewOptions) (*
 // rebuilding the index. The supplied ctx is checked between sources and
 // inside filesystem walk callbacks.
 func PreviewFromConfigWithOptionsContext(ctx context.Context, cfg *config.Config, options PreviewOptions) (*PreviewResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	logger := options.Logger
 	result := &PreviewResult{
 		Sources: make([]SourcePreview, 0, len(cfg.Sources)),


### PR DESCRIPTION
## Summary

Threads request context through the source-loading boundary so canceled CLI/MCP calls stop walking large workspaces promptly.

Closes #377.

### Public API additions
- `source.LoadFromConfigContext` / `LoadFromConfigWithOptionsContext`
- `source.PreviewFromConfigContext` / `PreviewFromConfigWithOptionsContext`
- `source.DiscoverWorkspaceContext`

Existing context-free entry points become `context.Background()` shims so non-request callers (dogfood/analysis tests, bench tool) keep working unchanged.

### Cancellation guards now fire at
- the loader's per-source loop entry,
- each filesystem/JSON/GitHub adapter `Load` entry (with nil-ctx defense),
- inside every source `filepath.WalkDir` callback (filesystem, JSON, discover for spec bundles and markdown candidates, preview),
- the per-record loops in `loadSpecBundles`, `loadMarkdownDocs`/`Contracts`, the JSON adapter, and the GitHub adapter — so an uncooperative client cannot trick the adapter into building all records,
- the disk-mutating boundary in `DiscoverWorkspaceContext` when `Write=true`, so a canceled `init`/`discover` never persists a partial side effect.

### Production callers updated to thread ctx
- `internal/app/status.go` (Status request)
- `internal/app/fix.go` (FixDocDrift + path-based target resolution)
- `internal/index/freshness.go` (`InspectFreshnessContext` content fingerprint reload — reached by `ensureFreshIndex` on the MCP hot path)
- `cmd/index.go`, `cmd/init.go`, `cmd/discover.go`, `cmd/preview_sources.go`

### Tests

- `internal/source/cancellation_test.go`, `extensions/json/cancellation_test.go`, `extensions/github/cancellation_test.go`
- Each package covers canceled-at-entry, deferred-cancel-during-walk, nil-context defense.
- The deferred-cancel walk tests use **non-matching extension files** so the walk-callback guard is the only place cancellation can be observed — they fail closed if a per-walk-entry guard is removed.
- `TestDiscoverWorkspaceContextWriteRefusesAfterCancel` proves the write-after-cancel invariant.

### Out of scope (follow-up needed)
`ast.WalkWorkspace` used by `extensions/astinfer` during rebuild has the same shape and is not threaded yet. That is a content-analysis surface (not source loading), and warrants its own issue.

## Review history

Three rounds of `/codex:adversarial-review`. Each round expanded the diff to close a real same-shape gap that the prior round missed (production callers → discover/preview → JSON/GitHub adapters + write-after-cancel).

## Test plan

- [x] `make fmt` clean
- [x] `make vet` clean
- [x] `make test` green
- [x] New cancellation tests pass and fail closed against guard regression
- [ ] CI: required status checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)