### PR TITLE
feat: plumb runtime.quantization through rebuild and update (#340)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/dusk-network/pituitary/internal/pathselector"
 	"github.com/dusk-network/pituitary/sdk"
+	ststore "github.com/dusk-network/stroma/v3/store"
 )
 
 const (
@@ -66,6 +67,13 @@ const (
 	// when query terminology matches the hit's section heading.
 	SearchRerankerHistorical         = "historical"
 	SearchRerankerArmAwareHistorical = "arm_aware_historical"
+
+	// Quantization* mirror stroma v3's store.Quantization* accept-listed
+	// values (#340). Empty resolves to QuantizationFloat32 to keep the
+	// pre-#340 storage format byte-for-byte.
+	QuantizationFloat32 = ststore.QuantizationFloat32
+	QuantizationInt8    = ststore.QuantizationInt8
+	QuantizationBinary  = ststore.QuantizationBinary
 )
 
 // Config is the validated workspace configuration resolved from pituitary.toml.
@@ -124,6 +132,13 @@ type Runtime struct {
 	Analysis RuntimeProvider
 	Chunking ChunkingConfig
 	Search   SearchConfig
+
+	// Quantization selects the vector storage format. Empty preserves
+	// the pre-#340 float32 default. Valid values: QuantizationFloat32,
+	// QuantizationInt8, QuantizationBinary. A change forces a rebuild
+	// (stroma's update path rejects cross-quantization reuse, surfaced
+	// via normalizeStromaUpdateError as an UpdatePreconditionError).
+	Quantization string
 }
 
 // SearchConfig groups search-time overrides for the retrieval pipeline.
@@ -306,11 +321,12 @@ type rawWorkspaceRepo struct {
 }
 
 type rawRuntime struct {
-	Profiles map[string]rawRuntimeProvider `toml:"profiles"`
-	Embedder rawRuntimeProvider            `toml:"embedder"`
-	Analysis rawRuntimeProvider            `toml:"analysis"`
-	Chunking rawChunking                   `toml:"chunking"`
-	Search   rawSearch                     `toml:"search"`
+	Profiles     map[string]rawRuntimeProvider `toml:"profiles"`
+	Embedder     rawRuntimeProvider            `toml:"embedder"`
+	Analysis     rawRuntimeProvider            `toml:"analysis"`
+	Chunking     rawChunking                   `toml:"chunking"`
+	Search       rawSearch                     `toml:"search"`
+	Quantization string                        `toml:"quantization"`
 }
 
 type rawSearch struct {
@@ -502,11 +518,12 @@ func buildFromRaw(configPath string, raw rawConfig, enforceSchemaVersion bool) (
 			Repos:             make([]WorkspaceRepo, 0, len(raw.Workspace.Repos)),
 		},
 		Runtime: Runtime{
-			Profiles: make(map[string]RuntimeProvider, len(raw.Runtime.Profiles)),
-			Embedder: buildRuntimeProvider(raw.Runtime.Embedder, RuntimeProviderFixture),
-			Analysis: buildRuntimeProvider(raw.Runtime.Analysis, RuntimeProviderDisabled),
-			Chunking: buildChunkingConfig(raw.Runtime.Chunking),
-			Search:   buildSearchConfig(raw.Runtime.Search),
+			Profiles:     make(map[string]RuntimeProvider, len(raw.Runtime.Profiles)),
+			Embedder:     buildRuntimeProvider(raw.Runtime.Embedder, RuntimeProviderFixture),
+			Analysis:     buildRuntimeProvider(raw.Runtime.Analysis, RuntimeProviderDisabled),
+			Chunking:     buildChunkingConfig(raw.Runtime.Chunking),
+			Search:       buildSearchConfig(raw.Runtime.Search),
+			Quantization: strings.ToLower(strings.TrimSpace(raw.Runtime.Quantization)),
 		},
 		Terminology: Terminology{
 			ExcludePaths:           uniqueStringList(raw.Terminology.ExcludePaths),
@@ -1310,7 +1327,31 @@ func validateRuntime(runtime *Runtime) error {
 	validateChunkingKind(&errs, "runtime.chunking.doc", runtime.Chunking.Doc)
 	validateChunkingContextualizer(&errs, "runtime.chunking.contextualizer", runtime.Chunking.Contextualizer)
 	validateSearchConfig(&errs, "runtime.search", runtime.Search)
+	validateRuntimeQuantization(&errs, "runtime.quantization", runtime.Quantization, runtime.Search)
 	return errs.err()
+}
+
+// validateRuntimeQuantization accept-lists the configured vector storage
+// format and rejects the int8/binary + matryoshka_prefilter_dimension
+// combination at config-load time. Stroma v3's snapshot search would
+// otherwise reject the same combination at search time with
+// "SearchDimension is only supported for float32 indexes".
+func validateRuntimeQuantization(errs *validationErrors, label string, quantization string, search SearchConfig) {
+	switch quantization {
+	case "", QuantizationFloat32, QuantizationInt8, QuantizationBinary:
+	default:
+		errs.add("%s: unsupported value %q (supported: %q, %q, %q)",
+			label, quantization,
+			QuantizationFloat32, QuantizationInt8, QuantizationBinary,
+		)
+		return
+	}
+	if search.PrefilterDimension > 0 && quantization != "" && quantization != QuantizationFloat32 {
+		errs.add(
+			"%s: matryoshka_prefilter_dimension is only supported with %q (got quantization %q); set runtime.quantization back to %q or clear runtime.search.matryoshka_prefilter_dimension",
+			label, QuantizationFloat32, quantization, QuantizationFloat32,
+		)
+	}
 }
 
 func buildChunkingConfig(raw rawChunking) ChunkingConfig {

--- a/internal/config/parse_toml.go
+++ b/internal/config/parse_toml.go
@@ -80,7 +80,7 @@ func undecodedKeyMessage(key toml.Key) string {
 	case "runtime":
 		switch len(key) {
 		case 2:
-			return unsupportedFieldMessage("runtime", key[1], []string{"profiles", "embedder", "analysis", "chunking", "search"})
+			return unsupportedFieldMessage("runtime", key[1], []string{"profiles", "embedder", "analysis", "chunking", "search", "quantization"})
 		default:
 			switch key[1] {
 			case "embedder", "analysis":

--- a/internal/config/quantization_test.go
+++ b/internal/config/quantization_test.go
@@ -1,0 +1,198 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadRuntimeQuantizationDefaultsToEmpty(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+`)
+
+	if cfg.Runtime.Quantization != "" {
+		t.Fatalf("runtime.quantization default = %q, want empty (preserves pre-#340 float32 default)", cfg.Runtime.Quantization)
+	}
+}
+
+func TestLoadRuntimeQuantizationParsesValidValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"float32", QuantizationFloat32},
+		{"int8", QuantizationInt8},
+		{"binary", QuantizationBinary},
+		{"INT8", QuantizationInt8},
+		{"  binary  ", QuantizationBinary},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime]
+quantization = "`+tc.raw+`"
+`)
+			if cfg.Runtime.Quantization != tc.want {
+				t.Fatalf("runtime.quantization = %q, want %q", cfg.Runtime.Quantization, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadRuntimeQuantizationRejectsUnknownValue(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime]
+quantization = "fp8"
+`)
+	if err == nil {
+		t.Fatal("expected error for unsupported quantization value")
+	}
+	if !strings.Contains(err.Error(), "runtime.quantization") {
+		t.Fatalf("error should mention runtime.quantization; got %v", err)
+	}
+	for _, want := range []string{QuantizationFloat32, QuantizationInt8, QuantizationBinary} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should list supported value %q; got %v", want, err)
+		}
+	}
+}
+
+func TestLoadRuntimeQuantizationRejectsMatryoshkaPrefilterCombo(t *testing.T) {
+	t.Parallel()
+
+	for _, q := range []string{QuantizationInt8, QuantizationBinary} {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := loadChunkingFixtureErr(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime]
+quantization = "`+q+`"
+
+[runtime.search]
+matryoshka_prefilter_dimension = 256
+`)
+			if err == nil {
+				t.Fatalf("expected error: matryoshka prefilter is incompatible with %q quantization", q)
+			}
+			if !strings.Contains(err.Error(), "matryoshka_prefilter_dimension") {
+				t.Fatalf("error should mention matryoshka_prefilter_dimension; got %v", err)
+			}
+			if !strings.Contains(err.Error(), QuantizationFloat32) {
+				t.Fatalf("error should steer users back to %q; got %v", QuantizationFloat32, err)
+			}
+		})
+	}
+}
+
+// TestRenderRoundTripPreservesQuantization is a regression test for the
+// migrate-config silent-drop hazard: Render must emit runtime.quantization
+// so a Load(Render(cfg)) cycle preserves the configured value. Without
+// this, `pituitary migrate-config --write` (or any other path that
+// normalizes a config through Render) would silently revert a user's
+// runtime.quantization = "int8" back to the implicit float32 default,
+// changing storage shape on the next index operation without an explicit
+// user decision.
+func TestRenderRoundTripPreservesQuantization(t *testing.T) {
+	t.Parallel()
+
+	for _, q := range []string{QuantizationInt8, QuantizationBinary} {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime]
+quantization = "`+q+`"
+`)
+
+			rendered, err := Render(cfg)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if !strings.Contains(rendered, "[runtime]") {
+				t.Fatalf("rendered output missing standalone [runtime] table:\n%s", rendered)
+			}
+			if !strings.Contains(rendered, `quantization = "`+q+`"`) {
+				t.Fatalf("rendered output missing quantization = %q:\n%s", q, rendered)
+			}
+
+			round := loadRenderedConfig(t, rendered)
+			if got := round.Runtime.Quantization; got != q {
+				t.Fatalf("round-tripped runtime.quantization = %q, want %q", got, q)
+			}
+		})
+	}
+}
+
+// TestRenderOmitsQuantizationWhenDefault keeps Render's output minimal
+// when the config preserves the float32 default. An empty value is the
+// pre-#340 contract; emitting [runtime] for a zero value would leak a
+// new section into every existing user's normalized config.
+func TestRenderOmitsQuantizationWhenDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+`)
+
+	rendered, err := Render(cfg)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(rendered, "quantization") {
+		t.Fatalf("rendered output should omit quantization when unset:\n%s", rendered)
+	}
+}
+
+func TestLoadRuntimeQuantizationFloat32WithMatryoshkaPrefilterIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadChunkingFixture(t, `
+[workspace]
+root = "workspace"
+index_path = ".pituitary/pituitary.db"
+
+[runtime]
+quantization = "float32"
+
+[runtime.search]
+matryoshka_prefilter_dimension = 256
+`)
+
+	if cfg.Runtime.Quantization != QuantizationFloat32 {
+		t.Fatalf("runtime.quantization = %q, want %q", cfg.Runtime.Quantization, QuantizationFloat32)
+	}
+	if cfg.Runtime.Search.PrefilterDimension != 256 {
+		t.Fatalf("runtime.search.matryoshka_prefilter_dimension = %d, want 256", cfg.Runtime.Search.PrefilterDimension)
+	}
+}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -31,6 +31,16 @@ func Render(cfg *Config) (string, error) {
 		fmt.Fprintf(&builder, "root = %s\n", strconv.Quote(repo.Root))
 	}
 
+	if quantization := strings.TrimSpace(cfg.Runtime.Quantization); quantization != "" {
+		// Emit the standalone [runtime] table before any subtable so the
+		// bootstrap parser places `quantization` on rawRuntime, not on
+		// the last preceding [runtime.*] subtable. Without this, a
+		// migrate-config round-trip silently drops runtime.quantization
+		// (#340 — caught in adversarial review).
+		builder.WriteString("\n[runtime]\n")
+		fmt.Fprintf(&builder, "quantization = %s\n", strconv.Quote(quantization))
+	}
+
 	profileNames := make([]string, 0, len(cfg.Runtime.Profiles))
 	for name := range cfg.Runtime.Profiles {
 		profileNames = append(profileNames, name)

--- a/internal/index/corpus_snapshot.go
+++ b/internal/index/corpus_snapshot.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dusk-network/pituitary/internal/config"
 	stindex "github.com/dusk-network/stroma/v3/index"
 )
 
@@ -90,6 +91,42 @@ func OpenStromaSnapshotContext(ctx context.Context, db *sql.DB, indexPath string
 		return nil, fmt.Errorf("open stroma snapshot %s: %w", path, err)
 	}
 	return snapshot, nil
+}
+
+// readStoredSnapshotQuantizationContext returns the snapshot's stored
+// quantization metadata, normalized so an empty stored value resolves to
+// QuantizationFloat32. Older snapshots that predate stroma's quantization
+// metadata key are treated as float32 to match stroma's snapshot_read.go
+// default. Shared by the update-path eligibility gate
+// (validateStoredQuantizationContext) and the rebuild reuse-state loader
+// (loadReuseStateContext) so both layers see the same notion of "stored
+// quantization" and a single change-source can't desynchronize them.
+func readStoredSnapshotQuantizationContext(ctx context.Context, snapshotPath string) (string, error) {
+	snapshotDB, err := OpenReadOnlyContext(ctx, snapshotPath)
+	if err != nil {
+		return "", fmt.Errorf("open stroma snapshot %s for quantization read: %w", snapshotPath, err)
+	}
+	defer snapshotDB.Close()
+	stored, err := readOptionalMetadataValueContext(ctx, snapshotDB, "quantization")
+	if err != nil {
+		return "", fmt.Errorf("read snapshot quantization metadata: %w", err)
+	}
+	stored = strings.TrimSpace(stored)
+	if stored == "" {
+		return config.QuantizationFloat32, nil
+	}
+	return stored, nil
+}
+
+// normalizeConfiguredQuantization mirrors readStoredSnapshotQuantizationContext
+// for configured values: empty resolves to QuantizationFloat32 so a
+// configured "" and a stored "float32" compare equal at the gates.
+func normalizeConfiguredQuantization(configured string) string {
+	configured = strings.TrimSpace(configured)
+	if configured == "" {
+		return config.QuantizationFloat32
+	}
+	return configured
 }
 
 func readOptionalMetadataValueContext(ctx context.Context, db *sql.DB, key string) (string, error) {

--- a/internal/index/quantization_test.go
+++ b/internal/index/quantization_test.go
@@ -1,0 +1,189 @@
+package index
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dusk-network/pituitary/internal/config"
+	"github.com/dusk-network/pituitary/internal/source"
+)
+
+// TestRebuildWritesConfiguredQuantizationToSnapshotMetadata is the
+// rebuild-side end-to-end check that runtime.quantization survives all
+// the way through stindex.BuildOptions and lands in the published stroma
+// snapshot's metadata. Without this assertion, a regression in the
+// rebuild.go plumbing would silently revert the snapshot to float32.
+func TestRebuildWritesConfiguredQuantizationToSnapshotMetadata(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadFixtureConfigWithQuantization(t, config.QuantizationInt8)
+
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+
+	corpusDB := mustOpenCorpusReadOnly(t, cfg.Workspace.ResolvedIndexPath)
+	defer corpusDB.Close()
+
+	var got string
+	if err := corpusDB.QueryRow(`SELECT value FROM metadata WHERE key = 'quantization'`).Scan(&got); err != nil {
+		t.Fatalf("read snapshot metadata.quantization: %v", err)
+	}
+	if got != config.QuantizationInt8 {
+		t.Fatalf("snapshot metadata.quantization = %q, want %q", got, config.QuantizationInt8)
+	}
+}
+
+// TestUpdateAcrossQuantizationChangeForcesFullRebuild is the update-side
+// end-to-end check that mirrors the rebuild test above. A quantization
+// flip between rebuild and update must surface as
+// "quantization mismatch" out of stroma's SyncFromSource, get normalized
+// to an UpdatePreconditionError, and force the update path to fall back
+// to a full rebuild — preserving the AC that quantization changes are
+// not a reuse-compatible delta. This is the trip-wire that arms the
+// runtime.quantization knob; without the UpdateOptions plumbing in
+// update.go a configured int8 would silently keep reusing the stored
+// float32 snapshot.
+func TestUpdateAcrossQuantizationChangeForcesFullRebuild(t *testing.T) {
+	t.Parallel()
+
+	indexPath := filepath.Join(t.TempDir(), "pituitary.db")
+
+	cfg := loadFixtureConfigWithQuantizationAtIndexPath(t, "", indexPath)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("baseline Rebuild() error = %v", err)
+	}
+
+	cfgInt8 := loadFixtureConfigWithQuantizationAtIndexPath(t, config.QuantizationInt8, indexPath)
+	recordsInt8, err := source.LoadFromConfig(cfgInt8)
+	if err != nil {
+		t.Fatalf("second source.LoadFromConfig() error = %v", err)
+	}
+	result, err := UpdateContextWithOptions(context.Background(), cfgInt8, recordsInt8)
+	if err != nil {
+		t.Fatalf("UpdateContextWithOptions() error = %v", err)
+	}
+	if !result.Update {
+		t.Fatalf("result.Update = false, want true (still an update operation)")
+	}
+	if !result.FullRebuild {
+		t.Fatalf("result.FullRebuild = false, want true — quantization change must force rebuild rather than reuse")
+	}
+
+	corpusDB := mustOpenCorpusReadOnly(t, cfgInt8.Workspace.ResolvedIndexPath)
+	defer corpusDB.Close()
+	var got string
+	if err := corpusDB.QueryRow(`SELECT value FROM metadata WHERE key = 'quantization'`).Scan(&got); err != nil {
+		t.Fatalf("read snapshot metadata.quantization after rebuild: %v", err)
+	}
+	if got != config.QuantizationInt8 {
+		t.Fatalf("snapshot metadata.quantization = %q, want %q after forced rebuild", got, config.QuantizationInt8)
+	}
+}
+
+// TestRebuildAcrossQuantizationChangeReportsQuantizationReuseReason
+// pins the reuse-reporting fix paired with the no-diff fast-path
+// eligibility-gate fix. When a `--rebuild` runs after a quantization
+// flip, pituitary's loadReuseStateContext must short-circuit to the
+// "quantization" disabled reason — not silently keep the embedder-only
+// view that inflates ReusedArtifactCount/ReusedChunkCount while stroma
+// internally rejects reuse. Without this assertion the reporting layer
+// can desync from stroma's actual reuse behavior and a regression in
+// reuse.go is invisible.
+func TestRebuildAcrossQuantizationChangeReportsQuantizationReuseReason(t *testing.T) {
+	t.Parallel()
+
+	indexPath := filepath.Join(t.TempDir(), "pituitary.db")
+
+	cfg := loadFixtureConfigWithQuantizationAtIndexPath(t, "", indexPath)
+	records, err := source.LoadFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("source.LoadFromConfig() error = %v", err)
+	}
+	if _, err := Rebuild(cfg, records); err != nil {
+		t.Fatalf("baseline Rebuild() error = %v", err)
+	}
+
+	cfgInt8 := loadFixtureConfigWithQuantizationAtIndexPath(t, config.QuantizationInt8, indexPath)
+	recordsInt8, err := source.LoadFromConfig(cfgInt8)
+	if err != nil {
+		t.Fatalf("second source.LoadFromConfig() error = %v", err)
+	}
+	result, err := Rebuild(cfgInt8, recordsInt8)
+	if err != nil {
+		t.Fatalf("Rebuild() error = %v", err)
+	}
+	if result.ReuseDisabledReason == "" {
+		t.Fatalf("expected non-empty ReuseDisabledReason after quantization flip; result = %+v", result)
+	}
+	if got := result.ReuseDisabledReason; !strings.Contains(got, "quantization") {
+		t.Fatalf("ReuseDisabledReason = %q, want it to mention quantization", got)
+	}
+	if result.ReusedArtifactCount != 0 {
+		t.Fatalf("ReusedArtifactCount = %d, want 0 (reuse must be disabled across quantization change)", result.ReusedArtifactCount)
+	}
+	if result.ReusedChunkCount != 0 {
+		t.Fatalf("ReusedChunkCount = %d, want 0 (reuse must be disabled across quantization change)", result.ReusedChunkCount)
+	}
+}
+
+func loadFixtureConfigWithQuantization(tb testing.TB, quantization string) *config.Config {
+	tb.Helper()
+	return loadFixtureConfigWithQuantizationAtIndexPath(tb, quantization, filepath.Join(tb.TempDir(), "pituitary.db"))
+}
+
+func loadFixtureConfigWithQuantizationAtIndexPath(tb testing.TB, quantization, indexPath string) *config.Config {
+	tb.Helper()
+
+	repoRoot := repoRoot(tb)
+	configPath := filepath.Join(tb.TempDir(), "pituitary.toml")
+	body := `
+[workspace]
+root = "` + filepath.ToSlash(repoRoot) + `"
+index_path = "` + filepath.ToSlash(indexPath) + `"
+infer_applies_to = false
+`
+	if quantization != "" {
+		body += `
+[runtime]
+quantization = "` + quantization + `"
+`
+	}
+	body += `
+[runtime.embedder]
+provider = "fixture"
+model = "fixture-8d"
+timeout_ms = 1000
+max_retries = 0
+
+[[sources]]
+name = "specs"
+adapter = "filesystem"
+kind = "spec_bundle"
+path = "specs"
+
+[[sources]]
+name = "docs"
+adapter = "filesystem"
+kind = "markdown_docs"
+path = "docs"
+include = ["guides/*.md", "runbooks/*.md"]
+`
+	mustWriteFile(tb, configPath, body)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		tb.Fatalf("config.Load() error = %v", err)
+	}
+	return cfg
+}

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -109,7 +109,7 @@ func PrepareRebuildContextWithOptions(ctx context.Context, cfg *config.Config, r
 	if err != nil {
 		return nil, err
 	}
-	reuseState, err := loadReuseStateContext(ctx, currentSnapshotPath, embedder.Fingerprint(), dimension, options)
+	reuseState, err := loadReuseStateContext(ctx, currentSnapshotPath, embedder.Fingerprint(), dimension, cfg.Runtime.Quantization, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 	if err != nil {
 		return nil, err
 	}
-	reuseState, err := loadReuseStateContext(ctx, currentSnapshotPath, embedder.Fingerprint(), dimension, options)
+	reuseState, err := loadReuseStateContext(ctx, currentSnapshotPath, embedder.Fingerprint(), dimension, cfg.Runtime.Quantization, options)
 	if err != nil {
 		return nil, err
 	}
@@ -214,6 +214,7 @@ func rebuildContext(ctx context.Context, cfg *config.Config, records *source.Loa
 		Embedder:       embedder,
 		ChunkPolicy:    chunkPolicy,
 		Contextualizer: contextualizer,
+		Quantization:   cfg.Runtime.Quantization,
 	}
 	if !options.Full {
 		// Stroma rebuilds through Path+".new", so reusing the currently published

--- a/internal/index/reuse.go
+++ b/internal/index/reuse.go
@@ -31,7 +31,7 @@ type artifactChunkPlan struct {
 	artifactUnchanged  bool
 }
 
-func loadReuseStateContext(ctx context.Context, snapshotPath, embedderFingerprint string, embedderDimension int, options RebuildOptions) (*reuseState, error) {
+func loadReuseStateContext(ctx context.Context, snapshotPath, embedderFingerprint string, embedderDimension int, configuredQuantization string, options RebuildOptions) (*reuseState, error) {
 	if options.Full {
 		return &reuseState{artifacts: map[string]storedArtifact{}}, nil
 	}
@@ -58,6 +58,20 @@ func loadReuseStateContext(ctx context.Context, snapshotPath, embedderFingerprin
 	}
 	if stats.EmbedderFingerprint != embedderFingerprint || stats.EmbedderDimension != embedderDimension {
 		return emptyReuseState("existing stroma snapshot embedder does not match current runtime"), nil
+	}
+	// #340: reject cross-quantization reuse here as well as at stroma's
+	// own loadReuseState. Without this check stroma silently disables
+	// reuse internally while pituitary's reuseState still says
+	// "embedder unchanged → reuse OK", inflating the reported
+	// ReusedArtifactCount/ReusedChunkCount and surfacing a misleading
+	// ReuseDisabledReason. Snapshot.Stats() doesn't expose quantization,
+	// so read the metadata key directly via the shared helper.
+	storedQuantization, err := readStoredSnapshotQuantizationContext(ctx, snapshotPath)
+	if err != nil {
+		return emptyReuseState(fmt.Sprintf("read existing stroma snapshot quantization: %v", err)), nil
+	}
+	if storedQuantization != normalizeConfiguredQuantization(configuredQuantization) {
+		return emptyReuseState(fmt.Sprintf("existing stroma snapshot quantization %q does not match current runtime %q", storedQuantization, normalizeConfiguredQuantization(configuredQuantization))), nil
 	}
 
 	return loadStoredArtifactsContext(ctx, snapshot)

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -407,10 +407,12 @@ func searchSpecsHybrid(ctx context.Context, cfg *config.Config, query SearchSpec
 // This reads the business index's embedder_dimension. Pituitary keeps
 // the business DB and the referenced stroma snapshot's metadata in
 // lock-step at rebuild time, so reading either is equivalent for the
-// dimension check. Quantization is not validated here because pituitary
-// only writes float32 snapshots today; if int8 quantization is ever
-// added, mirror stroma's float32-only constraint here too so the
-// rejection still fires before the embedder is invoked.
+// dimension check. The quantization-vs-prefilter combination is rejected
+// at config-load time (validateRuntimeQuantization) so a non-float32
+// snapshot can never coexist with a configured matryoshka prefilter; if
+// a stale snapshot somehow does, stroma's snapshot search rejects the
+// pair with "SearchDimension is only supported for float32 indexes"
+// before a real embedder call.
 // preflightMatryoshkaPrefilterFromSnapshot is the snapshot-handle
 // variant for callers that already hold a stroma snapshot but no
 // SQLite handle (e.g. RetrieveOutlineContextWithSnapshotContext).

--- a/internal/index/update.go
+++ b/internal/index/update.go
@@ -133,7 +133,7 @@ func updateContext(ctx context.Context, cfg *config.Config, records *source.Load
 		return rebuildUpdateContext(ctx, cfg, records, diff, options, reporter, oldArtifacts, oldEdges)
 	}
 
-	reuseState, err := loadReuseStateContext(ctx, currentSnapshotPath, embedder.Fingerprint(), dimension, RebuildOptions{})
+	reuseState, err := loadReuseStateContext(ctx, currentSnapshotPath, embedder.Fingerprint(), dimension, cfg.Runtime.Quantization, RebuildOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -343,9 +343,30 @@ func validateIncrementalUpdateEligibilityContext(ctx context.Context, db *sql.DB
 			Reason: fmt.Sprintf("stroma snapshot path %s is a directory", snapshotPath),
 			Action: "run `pituitary index --rebuild`",
 		}
-	default:
-		return snapshotPath, nil
 	}
+	if err := validateStoredQuantizationContext(ctx, snapshotPath, cfg.Runtime.Quantization); err != nil {
+		return "", &UpdatePreconditionError{Reason: err.Error(), Action: "run `pituitary index --rebuild`"}
+	}
+	return snapshotPath, nil
+}
+
+// validateStoredQuantizationContext rejects an incremental update whose
+// configured runtime.quantization diverges from the stored snapshot's
+// quantization. Without this gate, a quantization-only config flip with
+// no record diffs takes the no-op fast path in updateStromaSnapshotContext
+// (line ~412) and silently keeps the stale storage format. Stroma's
+// SyncFromSource guards the changed-records path with the same check, but
+// the no-diff fast path bypasses that call entirely.
+func validateStoredQuantizationContext(ctx context.Context, snapshotPath, configured string) error {
+	stored, err := readStoredSnapshotQuantizationContext(ctx, snapshotPath)
+	if err != nil {
+		return err
+	}
+	want := normalizeConfiguredQuantization(configured)
+	if stored != want {
+		return fmt.Errorf("runtime.quantization changed since last rebuild (stored %q, configured %q)", stored, want)
+	}
+	return nil
 }
 
 // validateStoredChunkingConfigContext rejects an incremental update
@@ -466,6 +487,12 @@ func updateStromaSnapshotContext(
 		Embedder:       embedder,
 		ChunkPolicy:    chunkPolicy,
 		Contextualizer: contextualizer,
+		// #340: pass the configured quantization so stroma compares it
+		// against the stored metadata. A divergence surfaces as
+		// "quantization mismatch", which normalizeStromaUpdateError maps
+		// to a UpdatePreconditionError telling the operator to rebuild.
+		// Empty (the pre-#340 default) reuses the stored value.
+		Quantization: cfg.Runtime.Quantization,
 	}); err != nil {
 		if cleanupSnapshot != nil {
 			cleanupSnapshot()


### PR DESCRIPTION
## Summary

Expose stroma v3's quantization options behind a new `runtime.quantization` TOML key (default float32, opt-in int8/binary). Tight plumbing-only PR — int8/binary benchmark and docs deferred to follow-up issues.

Closes part of #340 (`runtime.quantization` config surface, int8/binary paths through rebuild → search end-to-end, quantization change triggers rebuild). Benchmark deliverable + docs recommendation tracked separately.

## What ships

- **`internal/config`** — new `runtime.quantization` field with accept-list validation; rejects `matryoshka_prefilter_dimension` + non-float32 at config-load time so users see a clean error rather than stroma's runtime rejection. `Render` emits the value so `migrate-config --write` round-trips cleanly. Parser allow-list updated so typos suggest the new field.
- **`internal/index/rebuild.go`** — plumb `cfg.Runtime.Quantization` into `stindex.BuildOptions`.
- **`internal/index/update.go`** — plumb into `stindex.UpdateOptions` for stroma's changed-records guard, **plus** new `validateStoredQuantizationContext` eligibility gate. Without the gate, the no-diff fast path in `updateStromaSnapshotContext` (line ~412) skips `SyncFromSource` entirely, so a quantization-only config flip with unchanged records would silently keep the stale storage shape.
- **`internal/index/reuse.go`** — extend `loadReuseStateContext` to reject cross-quantization reuse. Stroma's own reuse loader already rejects, but pituitary's reuseState was reporting "embedder unchanged → reuse OK" and inflating `ReusedArtifactCount`/`ReusedChunkCount` while stroma silently re-embedded. Now the two layers agree.
- **`internal/index/corpus_snapshot.go`** — shared helpers `readStoredSnapshotQuantizationContext` and `normalizeConfiguredQuantization` so the eligibility gate and reuse-state loader can't desync.

## Sibling-gap notes

This PR adds a config surface + threading through two adapters (rebuild + update). Adversarial review hunted for same-shape gaps:
- ✅ `updateStromaSnapshotContext` no-diff fast path — fixed via eligibility gate.
- ✅ `loadReuseStateContext` reuse reporting — fixed via shared helper.
- ✅ Parser allow-list error message — added `quantization`.
- ✅ `Render` round-trip — added `[runtime] quantization = "..."` block + regression tests.

## Test plan

- [x] `make ci` green (fmt, vet, full suite)
- [x] Config layer: defaults to empty, accept-list rejects unknown values, matryoshka conflict caught at load
- [x] Render: round-trips int8/binary, omits the block for the float32 default
- [x] Rebuild: snapshot metadata `quantization` matches configured value
- [x] Update: quantization flip with unchanged records forces `FullRebuild=true`
- [x] Rebuild: quantization flip surfaces `ReuseDisabledReason` mentioning quantization, zero reuse counts

## Out of scope (follow-ups)

- int8/binary benchmark on a representative corpus (snapshot size + precision@k/recall@k delta)
- Docs recommending int8 as the near-always-safe choice and calling out binary's rescore overhead
- `pituitary status` exposure of stored quantization (so users can verify their config is in force without running an update)
- Mirror quantization to the business DB metadata so the eligibility gate reads from the same authority as sibling gates (currently snapshot-side; minor architecture asymmetry noted in code comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)