### PR TITLE
ci: adopt org-wide reusable workflows + SHA-pin actions

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -1,0 +1,19 @@
+# Org-wide CI baseline.
+# Calls nantobv/.github reusable workflows for Go CI + pinact enforcement.
+# Runs alongside the existing ci.yml (which owns smoke-sqlite-vec, macos,
+# docker, goreleaser, and other project-specific tests).
+name: CI baseline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  go:
+    uses: nantobv/.github/.github/workflows/go-ci.yml@main
+    with:
+      go-version: 'stable'
+
+  pinact-check:
+    uses: nantobv/.github/.github/workflows/pinact-check.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -72,10 +72,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Build contributor Dockerfile
         run: docker build --progress=plain --tag pituitary-dev:${{ github.sha }} .

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1.0.122
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ runner.temp }}/bun/bin/bun

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1.0.122
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ runner.temp }}/bun/bin/bun

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,19 @@ jobs:
         run: git config --global core.autocrlf input
 
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Install Windows CGO toolchain
         id: msys2
         if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           msystem: UCRT64
           update: true
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run GoReleaser packaging
         if: runner.os != 'Windows'
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run GoReleaser packaging
         if: runner.os == 'Windows'
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -76,7 +76,7 @@ jobs:
           CC: ${{ runner.os == 'Windows' && format('{0}/ucrt64/bin/gcc.exe', steps.msys2.outputs.msys2-location) || '' }}
 
       - name: Upload packaged artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ matrix.artifact_name }}
           path: |
@@ -91,17 +91,17 @@ jobs:
       TAG: ${{ github.ref_name }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 
       - name: Download packaged artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           pattern: release-*
           merge-multiple: true

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+version: 3
+
+ignore_actions:
+  # Reusable workflows in nantobv/.github are referenced at @main so that
+  # org-wide CI updates propagate without per-repo PRs.
+  - name: nantobv/.github/.*
+    ref: main

--- a/action.yml
+++ b/action.yml
@@ -56,13 +56,13 @@ runs:
   using: "composite"
   steps:
     - name: Check out repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         fetch-depth: 1
 
     - name: Resolve Pituitary version
       id: resolve-version
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           const explicit = `${{ inputs.pituitary-version }}`.trim();
@@ -117,7 +117,7 @@ runs:
 
     - name: List changed pull request files
       id: changed-files
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           if (context.eventName !== 'pull_request') {
@@ -146,7 +146,7 @@ runs:
 
     - name: Post or update pull request comment
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         COMMENT_BODY: ${{ steps.review-spec.outputs.comment-body }}
         HAS_REVIEWS: ${{ steps.review-spec.outputs.has-reviews }}


### PR DESCRIPTION
Adopts the org-wide reusable CI workflows from `nantobv/.github` and SHA-pins every third-party action.

## New: `.github/workflows/baseline.yml`

Calls `go-ci.yml` (lint / test / vuln-scan) and `pinact-check.yml` (enforces action pinning) from `nantobv/.github`.

Runs alongside the existing `ci.yml` which keeps the project-specific tests: smoke-sqlite-vec, macOS matrix, docker build, goreleaser check, docs link check.

## SHA pinning

`pinact run` was applied to every workflow file plus `action.yml` (this repo publishes a composite action). Every third-party action now uses commit SHAs with a version comment.

`.pinact.yaml` configures the ignore rule for reusable workflow refs.

## Order

Will only fully pass CI after [`nantobv/.github#4`](https://github.com/nantobv/.github/pull/4) is merged.