### PR TITLE
ci: make CI baseline green — gofumpt, .golangci.yml, dead-code cleanup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+# Project-level golangci-lint config for pituitary.
+#
+# Tuned to keep meaningful safety lints on (govet, staticcheck SA*,
+# ineffassign, errcheck for non-close/non-cleanup calls) while
+# suppressing style suggestions and idiomatic patterns:
+#
+#   * errcheck:    skip fmt.Fprint family + Close() + os.Remove cleanup +
+#                  Scan in tests
+#   * staticcheck: skip QF* (quickfix style) and ST1000 (package docs)
+#
+# Real findings (ineffassign, unused) still fail CI.
+version: "2"
+
+linters:
+  default: standard
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintln
+        - fmt.Fprintf
+        - io.Copy
+        - os.Remove
+    staticcheck:
+      checks:
+        - all
+        - -QF*
+        - -ST1000
+  exclusions:
+    rules:
+      # Defer-close patterns on io.Closer values: not actionable in CLI code.
+      - linters:
+          - errcheck
+        text: "Error return value of `[^`]+\\.Close` is not checked"
+      # Tests don't need to check Scan errors on sql.Row.
+      - path: _test\.go
+        linters:
+          - errcheck
+        text: "Error return value of `\\(\\*database/sql\\.Row\\)\\.Scan` is not checked"

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -599,7 +599,8 @@ func renderTextReport(w io.Writer, report *benchmarkReport) {
 	fmt.Fprintf(w, "config: %s\n", report.ConfigPath)
 	fmt.Fprintf(w, "cases: %s\n", report.CasesDir)
 	fmt.Fprintf(w, "analysis runtime: %s\n", defaultString(report.AnalysisProvider, "disabled"))
-	fmt.Fprintf(w, "summary: %d/%d passed | mean latency %.2fms | runtime-used %d case(s)\n\n",
+	fmt.Fprintf(
+		w, "summary: %d/%d passed | mean latency %.2fms | runtime-used %d case(s)\n\n",
 		report.Summary.PassedCases,
 		report.Summary.TotalCases,
 		report.Summary.MeanLatencyMS,

--- a/cmd/config_path.go
+++ b/cmd/config_path.go
@@ -57,8 +57,10 @@ type configResolutionCandidate struct {
 	Detail     string `json:"detail,omitempty"`
 }
 
-type cliConfigPathContextKey struct{}
-type cliLoggerContextKey struct{}
+type (
+	cliConfigPathContextKey struct{}
+	cliLoggerContextKey     struct{}
+)
 
 func parseGlobalCLIOptions(args []string) (cliGlobalOptions, []string, error) {
 	fs := flag.NewFlagSet("pituitary", flag.ContinueOnError)

--- a/cmd/presentation.go
+++ b/cmd/presentation.go
@@ -106,99 +106,116 @@ func (p renderPresentation) headerMark() string {
 	}
 	return p.bold("---*")
 }
+
 func (p renderPresentation) cross() string {
 	if p.utf8 {
 		return p.red("✗")
 	}
 	return p.red("x")
 }
+
 func (p renderPresentation) check() string {
 	if p.utf8 {
 		return p.green("✓")
 	}
 	return p.green("+")
 }
+
 func (p renderPresentation) arrow() string {
 	if p.utf8 {
 		return p.yellow("→")
 	}
 	return p.yellow("->")
 }
+
 func (p renderPresentation) info() string {
 	if p.utf8 {
 		return p.dim("ℹ")
 	}
 	return p.dim("i")
 }
+
 func (p renderPresentation) treeMid() string {
 	if p.utf8 {
 		return p.dim("├─")
 	}
 	return p.dim("|-")
 }
+
 func (p renderPresentation) treeLast() string {
 	if p.utf8 {
 		return p.dim("└─")
 	}
 	return p.dim("\\-")
 }
+
 func (p renderPresentation) treeBranch(last bool) string {
 	if last {
 		return p.treeLast()
 	}
 	return p.treeMid()
 }
+
 func (p renderPresentation) treeItem(last bool) string {
 	return p.treeBranch(last)
 }
+
 func (p renderPresentation) blockHigh() string {
 	if p.utf8 {
 		return p.red("██")
 	}
 	return p.red("[!]")
 }
+
 func (p renderPresentation) blockMedium() string {
 	if p.utf8 {
 		return p.yellow("▒▒")
 	}
 	return p.yellow("[~]")
 }
+
 func (p renderPresentation) okBadge() string {
 	if p.utf8 {
 		return p.green("██ OK")
 	}
 	return p.green("[OK]")
 }
+
 func (p renderPresentation) driftBadge() string {
 	if p.utf8 {
 		return p.red("██ DRIFT")
 	}
 	return p.red("[DRIFT]")
 }
+
 func (p renderPresentation) reviewBadge() string {
 	if p.utf8 {
 		return p.yellow("▒▒ REVIEW")
 	}
 	return p.yellow("[REVIEW]")
 }
+
 func (p renderPresentation) conflictBadge() string {
 	if p.utf8 {
 		return p.red("██ CONFLICT")
 	}
 	return p.red("[CONFLICT]")
 }
+
 func (p renderPresentation) compliantBadge() string {
 	if p.utf8 {
 		return p.green("██ OK")
 	}
 	return p.green("[OK]")
 }
+
 func (p renderPresentation) unspecifiedBadge() string {
 	if p.utf8 {
 		return p.yellow("▒▒ UNSPEC")
 	}
 	return p.yellow("[UNSPEC]")
 }
+
 func (p renderPresentation) headerLine(command, suffix string) string {
 	line := p.headerMark() + " " + p.white(command)
 	if suffix != "" {

--- a/cmd/render_review.go
+++ b/cmd/render_review.go
@@ -728,7 +728,8 @@ func renderReviewHTMLOverlapSection(w io.Writer, result *analysis.ReviewResult, 
 	}
 	fmt.Fprint(w, "</p><ul class=\"compact-list\">\n")
 	for _, item := range result.Overlap.Overlaps {
-		fmt.Fprintf(w, "<li><strong><code>%s</code></strong> %s <span class=\"muted\">(%s, %.3f, %s)</span></li>\n",
+		fmt.Fprintf(
+			w, "<li><strong><code>%s</code></strong> %s <span class=\"muted\">(%s, %.3f, %s)</span></li>\n",
 			escape(item.Ref),
 			escape(item.Title),
 			escape(item.Relationship),
@@ -823,7 +824,8 @@ func renderReviewHTMLImpactedDocs(w io.Writer, result *analysis.AnalyzeImpactRes
 		}
 		fmt.Fprint(w, ")</span>")
 		if item.Evidence != nil {
-			fmt.Fprintf(w, "<br><span class=\"subtle\">Evidence: %s / %s -> %s / %s</span>",
+			fmt.Fprintf(
+				w, "<br><span class=\"subtle\">Evidence: %s / %s -> %s / %s</span>",
 				escape(item.Evidence.SpecRef),
 				escape(displayDefault(item.Evidence.SpecSection, "(body)")),
 				escape(item.Evidence.DocSourceRef),

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -150,7 +150,8 @@ func runStatusContext(ctx context.Context, args []string, stdout, stderr io.Writ
 	if showFamilies && !compact && statusOut != nil && statusOut.IndexExists {
 		familyResult, err := index.DiscoverFamiliesContext(ctx, result.Index.IndexPath)
 		if err != nil {
-			statusOut.Guidance = append(statusOut.Guidance,
+			statusOut.Guidance = append(
+				statusOut.Guidance,
 				fmt.Sprintf("unable to discover families: %v", err),
 			)
 		} else {

--- a/internal/analysis/doc_drift.go
+++ b/internal/analysis/doc_drift.go
@@ -20,8 +20,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var requestsPerMinutePattern = regexp.MustCompile(`(?i)(\d+)\s+requests per minute`)
-var artifactReferencePattern = regexp.MustCompile(`(?i)[a-z0-9][a-z0-9._-]*\.(?:db|json|md|toml|yaml|yml)`)
+var (
+	requestsPerMinutePattern = regexp.MustCompile(`(?i)(\d+)\s+requests per minute`)
+	artifactReferencePattern = regexp.MustCompile(`(?i)[a-z0-9][a-z0-9._-]*\.(?:db|json|md|toml|yaml|yml)`)
+)
 
 const (
 	driftClassificationSemantic = "semantic_contradiction"
@@ -1130,13 +1132,15 @@ func artifactMentionsFromSections(sections []embeddedSection) map[string][]artif
 				continue
 			}
 			lower := strings.ToLower(line)
-			active := containsAny(lower,
+			active := containsAny(
+				lower,
 				" read ", " reads ", " load ", " loads ",
 				" write ", " writes ", " uses ", " use ",
 				" cache", " cached", " storing ", " stored ",
 				" refresh", " refreshes ", " startup", " start ",
 			)
-			aligned := containsAny(lower,
+			aligned := containsAny(
+				lower,
 				"optional", "derived", "historical", "history", "archive",
 				"legacy", "not part of", "not required", "must not",
 				"implementation detail", "safe to discard",
@@ -1236,12 +1240,14 @@ func classifyArtifactConstraint(line, artifact string) (string, string, bool) {
 	}
 
 	switch {
-	case containsAny(runtimeLocal,
+	case containsAny(
+		runtimeLocal,
 		"must not read", "must not load", "must not parse",
 		"must not reparse", "must not treat",
 	):
 		return "runtime_input", "not a canonical runtime input", true
-	case containsAny(local,
+	case containsAny(
+		local,
 		artifact+"` is not a required artifact",
 		artifact+" is not a required artifact",
 		artifact+"` is not part of the accepted runtime contract",
@@ -1250,9 +1256,11 @@ func classifyArtifactConstraint(line, artifact string) (string, string, bool) {
 		artifact+" is not part of the persisted runtime contract",
 	):
 		return "contract", "not part of the accepted runtime contract", true
-	case containsAny(lower,
+	case containsAny(
+		lower,
 		"legacy derived files",
-	) && containsAny(lower,
+	) && containsAny(
+		lower,
 		"not part of the accepted runtime contract",
 		"not part of the persisted runtime contract",
 	):

--- a/internal/chunk/policy_test.go
+++ b/internal/chunk/policy_test.go
@@ -46,7 +46,8 @@ func TestResolve_ZeroConfigDefaultsDocsToLateChunk(t *testing.T) {
 	if docPolicy.ParentMaxTokens != DefaultDocLateChunkParentMaxTokens ||
 		docPolicy.ChildMaxTokens != DefaultDocLateChunkChildMaxTokens ||
 		docPolicy.ChildOverlapTokens != DefaultDocLateChunkChildOverlapTokens {
-		t.Fatalf("default doc LateChunkPolicy = %+v, want parent=%d child=%d overlap=%d",
+		t.Fatalf(
+			"default doc LateChunkPolicy = %+v, want parent=%d child=%d overlap=%d",
 			docPolicy,
 			DefaultDocLateChunkParentMaxTokens,
 			DefaultDocLateChunkChildMaxTokens,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1340,7 +1340,8 @@ func validateRuntimeQuantization(errs *validationErrors, label string, quantizat
 	switch quantization {
 	case "", QuantizationFloat32, QuantizationInt8, QuantizationBinary:
 	default:
-		errs.add("%s: unsupported value %q (supported: %q, %q, %q)",
+		errs.add(
+			"%s: unsupported value %q (supported: %q, %q, %q)",
 			label, quantization,
 			QuantizationFloat32, QuantizationInt8, QuantizationBinary,
 		)
@@ -1423,7 +1424,8 @@ func validateChunkingContextualizer(errs *validationErrors, label string, cfg Ch
 		ChunkContextualizerFormatRefTitle:
 		// valid
 	default:
-		errs.add("%s.format: unsupported format %q (supported: %q, %q)",
+		errs.add(
+			"%s.format: unsupported format %q (supported: %q, %q)",
 			label, cfg.Format,
 			ChunkContextualizerFormatTitleAncestry,
 			ChunkContextualizerFormatRefTitle,
@@ -1452,7 +1454,8 @@ func validateSearchConfig(errs *validationErrors, label string, cfg SearchConfig
 	case "", SearchRerankerHistorical, SearchRerankerArmAwareHistorical:
 		// valid
 	default:
-		errs.add("%s.reranker: unsupported reranker %q (supported: %q, %q)",
+		errs.add(
+			"%s.reranker: unsupported reranker %q (supported: %q, %q)",
 			label, cfg.Reranker,
 			SearchRerankerHistorical,
 			SearchRerankerArmAwareHistorical,
@@ -1478,7 +1481,8 @@ func validateFusionConfig(errs *validationErrors, label string, cfg FusionConfig
 			errs.add("%s.k: must be > 0 for strategy %q", label, SearchFusionStrategyRRF)
 		}
 	default:
-		errs.add("%s.strategy: unsupported strategy %q (supported: %q, %q)",
+		errs.add(
+			"%s.strategy: unsupported strategy %q (supported: %q, %q)",
 			label, cfg.Strategy,
 			SearchFusionStrategyDefault,
 			SearchFusionStrategyRRF,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1536,11 +1536,9 @@ func resolveRuntimeProvider(provider RuntimeProvider, profiles map[string]Runtim
 	}
 	if !endpointResolved && hasProfile && profile.endpointSet {
 		resolved.Endpoint = profile.Endpoint
-		endpointResolved = true
 	}
 	if !apiKeyEnvResolved && hasProfile && profile.apiKeyEnvSet {
 		resolved.APIKeyEnv = profile.APIKeyEnv
-		apiKeyEnvResolved = true
 	}
 	if !timeoutResolved && hasProfile && profile.timeoutMSSet {
 		resolved.TimeoutMS = profile.TimeoutMS

--- a/internal/index/freshness.go
+++ b/internal/index/freshness.go
@@ -135,7 +135,8 @@ func InspectFreshnessContext(ctx context.Context, cfg *config.Config) (*Freshnes
 	}
 	defer db.Close()
 
-	metadata, err := readMetadataContext(ctx, db,
+	metadata, err := readMetadataContext(
+		ctx, db,
 		"schema_version",
 		"embedder_fingerprint",
 		"source_fingerprint",

--- a/internal/index/graph_validation_test.go
+++ b/internal/index/graph_validation_test.go
@@ -34,11 +34,13 @@ func TestInspectRelationGraphDetectsSupersedesCycleAndContradictions(t *testing.
 	t.Parallel()
 
 	status := InspectRelationGraph([]model.SpecRecord{
-		specWithRelations("SPEC-200",
+		specWithRelations(
+			"SPEC-200",
 			model.Relation{Type: model.RelationSupersedes, Ref: "SPEC-201"},
 			model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-201"},
 		),
-		specWithRelations("SPEC-201",
+		specWithRelations(
+			"SPEC-201",
 			model.Relation{Type: model.RelationSupersedes, Ref: "SPEC-200"},
 			model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-200"},
 		),
@@ -79,10 +81,12 @@ func TestInspectRelationGraphAllowsMutualRelatesToWithoutCycle(t *testing.T) {
 	t.Parallel()
 
 	status := InspectRelationGraph([]model.SpecRecord{
-		specWithRelations("SPEC-400",
+		specWithRelations(
+			"SPEC-400",
 			model.Relation{Type: model.RelationRelatesTo, Ref: "SPEC-401"},
 		),
-		specWithRelations("SPEC-401",
+		specWithRelations(
+			"SPEC-401",
 			model.Relation{Type: model.RelationRelatesTo, Ref: "SPEC-400"},
 		),
 	})
@@ -96,7 +100,8 @@ func TestInspectRelationGraphAllowsRelatesToAlongsideDependsOn(t *testing.T) {
 	t.Parallel()
 
 	status := InspectRelationGraph([]model.SpecRecord{
-		specWithRelations("SPEC-500",
+		specWithRelations(
+			"SPEC-500",
 			model.Relation{Type: model.RelationDependsOn, Ref: "SPEC-501"},
 			model.Relation{Type: model.RelationRelatesTo, Ref: "SPEC-502"},
 		),
@@ -113,7 +118,8 @@ func TestInspectRelationGraphDetectsRelatesToSelfReference(t *testing.T) {
 	t.Parallel()
 
 	status := InspectRelationGraph([]model.SpecRecord{
-		specWithRelations("SPEC-600",
+		specWithRelations(
+			"SPEC-600",
 			model.Relation{Type: model.RelationRelatesTo, Ref: "SPEC-600"},
 		),
 	})

--- a/internal/index/openai_embedder.go
+++ b/internal/index/openai_embedder.go
@@ -40,8 +40,10 @@ type openAICompatibleEmbedder struct {
 	dimension int
 }
 
-var _ Embedder = (*openAICompatibleEmbedder)(nil)
-var _ stembed.ContextualEmbedder = (*openAICompatibleEmbedder)(nil)
+var (
+	_ Embedder                   = (*openAICompatibleEmbedder)(nil)
+	_ stembed.ContextualEmbedder = (*openAICompatibleEmbedder)(nil)
+)
 
 func newOpenAICompatibleEmbedder(cfg config.RuntimeProvider) (Embedder, error) {
 	endpoint := strings.TrimRight(strings.TrimSpace(cfg.Endpoint), "/")

--- a/internal/index/rebuild.go
+++ b/internal/index/rebuild.go
@@ -358,17 +358,6 @@ func publishBusinessIndexContext(ctx context.Context, cfg *config.Config, record
 	return nil
 }
 
-func cloneMetadata(metadata map[string]string) map[string]string {
-	if len(metadata) == 0 {
-		return map[string]string{}
-	}
-	cloned := make(map[string]string, len(metadata))
-	for key, value := range metadata {
-		cloned[key] = value
-	}
-	return cloned
-}
-
 func finalizeBusinessIndexContext(ctx context.Context, db *sql.DB, cfg *config.Config, records *source.LoadResult, result *RebuildResult, snapshotPath string) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/index/retrieval_armb_bench_test.go
+++ b/internal/index/retrieval_armb_bench_test.go
@@ -337,7 +337,8 @@ func armBPromptContext(outline *OutlineContextResult) (string, []armBContextSect
 					continue
 				}
 				seen[section.ChunkID] = struct{}{}
-				fmt.Fprintf(&builder, "[chunk:%d ref:%s role:%s heading:%s]\n%s\n\n",
+				fmt.Fprintf(
+					&builder, "[chunk:%d ref:%s role:%s heading:%s]\n%s\n\n",
 					section.ChunkID,
 					section.Ref,
 					section.Role,

--- a/internal/index/status.go
+++ b/internal/index/status.go
@@ -221,7 +221,8 @@ func queryGovernanceHotspotsContext(ctx context.Context, db *sql.DB) (*Governanc
 }
 
 func queryGovernanceSpecHotspotsContext(ctx context.Context, db *sql.DB, hasConfidence bool) ([]GovernanceSpecHotspot, error) {
-	query := fmt.Sprintf(`
+	query := fmt.Sprintf(
+		`
 SELECT
   s.ref,
   COALESCE(s.title, ''),
@@ -270,7 +271,8 @@ LIMIT 5`,
 }
 
 func queryGovernanceArtifactHotspotsContext(ctx context.Context, db *sql.DB, hasConfidence bool, filter string, orderBy string) ([]GovernanceArtifactHotspot, error) {
-	aggregateQuery := fmt.Sprintf(`
+	aggregateQuery := fmt.Sprintf(
+		`
 SELECT
   e.to_ref AS ref,
   COALESCE(a.title, '') AS title,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1066,7 +1066,8 @@ func buildPituitaryBinary(t *testing.T) string {
 
 	cmd := exec.Command("go", "build", "-o", binaryPath, ".")
 	cmd.Dir = repoRoot
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		"CGO_ENABLED=1",
 	)
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -23,8 +23,10 @@ const (
 	RelationRelatesTo  = sdk.RelationRelatesTo
 )
 
-type Relation = sdk.Relation
-type InferenceFieldConfidence = sdk.InferenceFieldConfidence
-type InferenceConfidence = sdk.InferenceConfidence
-type SpecRecord = sdk.SpecRecord
-type DocRecord = sdk.DocRecord
+type (
+	Relation                 = sdk.Relation
+	InferenceFieldConfidence = sdk.InferenceFieldConfidence
+	InferenceConfidence      = sdk.InferenceConfidence
+	SpecRecord               = sdk.SpecRecord
+	DocRecord                = sdk.DocRecord
+)


### PR DESCRIPTION
Makes the org-wide CI baseline reach green on pituitary. Three pieces:

## 1. `gofumpt -w .` (15 files)

Mechanical formatting cleanup the Lint job's `gofumpt` step demanded. No semantic changes.

## 2. `.golangci.yml` (new)

The reusable workflow runs golangci-lint v2 against a never-linted codebase, which surfaced 40 findings — most stylistic. Added a project config that:

| Linter | Tweak |
|---|---|
| `errcheck` | Exclude `fmt.Fprint*`, `io.Copy`, `os.Remove`, all `io.Closer.Close()` (regex), and `(*sql.Row).Scan` in tests |
| `staticcheck` | Drop `QF*` (quickfix style) and `ST1000` (package-doc requirement) |
| Everything else | Untouched |

## 3. Real dead code removed in-place

The config does NOT mask `ineffassign` or `unused`. Two real findings:

- `internal/config/config.go`: two assignments to `endpointResolved` / `apiKeyEnvResolved` that were the **last writes in scope** (verified by grep). Removed.
- `internal/index/rebuild.go`: `cloneMetadata` function with **zero callers**. Removed.

## Verification

Locally:
```
go build ./...                                           # OK
go test ./internal/config/... ./internal/index/...       # OK
golangci-lint run --timeout=2m                           # 0 issues
```

Empty commit `d20e080` was a re-trigger to flush the cached reusable workflow content after `nantobv/.github#6` merged; squash on merge collapses it.