### PR TITLE
ci: migrate Claude workflow to org reusable (author gate + SHA-pinned bun)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,15 @@
+# Created from the nantobv/.github workflow template "Claude Code".
+# Wires this repo into the nantobv reusable Claude Code responder.
+#
+# Prerequisites (one-time, org-level — already in place for nantobv):
+#   - The Anthropic Claude GitHub App installed on the org with
+#     "All repositories" scope.
+#   - An org-level Actions secret CLAUDE_CODE_OAUTH_TOKEN reachable
+#     from this repo.
+#
+# Behavior, security gate (@claude must come from OWNER/MEMBER/COLLABORATOR),
+# and SHA-pinned action versions live in the reusable workflow:
+#   nantobv/.github/.github/workflows/claude-reusable.yml
 name: Claude Code
 
 on:
@@ -6,56 +18,31 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    # Only `opened`. Adding `assigned` would re-fire @claude on every
+    # assignment change of an issue whose body/title already contains
+    # @claude, burning quota on routine triage actions.
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+# Caller-level permissions must be at least as broad as what the
+# reusable workflow's job-level block requests, otherwise GitHub
+# pre-validates and rejects the run with `startup_failure` before any
+# job starts. These mirror claude-reusable.yml's `jobs.claude.permissions:`
+# block one-for-one. Each is required: contents (post a comment / branch),
+# issues + pull-requests (write replies), id-token (OIDC for the
+# action's auth), actions read (read workflow context).
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-
-      - name: Install Bun
-        env:
-          BUN_INSTALL: ${{ runner.temp }}/bun
-        run: |
-          curl -fsSL https://bun.sh/install | bash
-          echo "$BUN_INSTALL/bin" >> "$GITHUB_PATH"
-          "$BUN_INSTALL/bin/bun" --version
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1.0.122
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          path_to_bun_executable: ${{ runner.temp }}/bun/bin/bun
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+    uses: nantobv/.github/.github/workflows/claude-reusable.yml@main # zizmor: ignore[unpinned-uses] same-org reusable workflow tracks @main by design; matching exception lives in .pinact.yaml.
+    # Pass only the secret the reusable declares it needs; avoid the
+    # blast radius of `secrets: inherit`.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,25 @@ permissions:
 
 jobs:
   claude:
-    uses: nantobv/.github/.github/workflows/claude-reusable.yml@main # zizmor: ignore[unpinned-uses] same-org reusable workflow tracks @main by design; matching exception lives in .pinact.yaml.
+    # Short-circuit before invoking the reusable: only fire when an
+    # @claude mention comes from OWNER/MEMBER/COLLABORATOR. Without
+    # this, every issue comment / PR review on this repo spins up a
+    # runner just to let the reusable's identical filter no-op. The
+    # reusable keeps the same filter as defense-in-depth.
+    if: |
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+    uses: nantobv/.github/.github/workflows/claude-reusable.yml@main # zizmor: ignore[unpinned-uses] same-org reusable workflow tracks @main by design; pinact exception declared org-wide in nantobv/.github/.pinact.yaml.
     # Pass only the secret the reusable declares it needs; avoid the
     # blast radius of `secrets: inherit`.
     secrets:


### PR DESCRIPTION
## Summary

Migrates this repo's `.github/workflows/claude.yml` from the standalone "direct" workflow shipped by the `/install-github-app` skill to the **hardened thin-caller** pattern backed by the org-wide reusable workflow at `nantobv/.github/.github/workflows/claude-reusable.yml@main`.

### Why

The previous file (verbatim from the install-github-app template) was missing several hardenings the org has since adopted on `nantobv/.github`:

| Concern | Before (this repo, today) | After (this PR) |
| --- | --- | --- |
| **Author gate** | None — anyone who can comment fires `@claude` | `OWNER`/`MEMBER`/`COLLABORATOR` only. Critical for any public repo. |
| **Bun install** | `curl https://bun.sh/install \| bash` (no SHA pin) | SHA-pinned `oven-sh/setup-bun@0c5077e5… # v2.2.0` |
| **`issues:` retrigger** | `[opened, assigned]` — every reassignment re-fires Claude on issues whose body already says `@claude` | `[opened]` only |
| **Updates** | Per-repo file copies, drift accumulates | Single source of truth in `nantobv/.github`; future tightening lands without per-repo PRs |

### What changes

`.github/workflows/claude.yml` goes from ~50 lines of direct workflow to a ~30-line thin caller. All behavior — security gate, action SHAs, bun bootstrap, permissions — lives in the reusable workflow. The contract on the `@claude` UX is unchanged.

### Prereqs (already in place at the org level)

- Anthropic Claude GitHub App installed on `nantobv` with "All repositories" scope
- `CLAUDE_CODE_OAUTH_TOKEN` org secret reachable by this repo
- End-to-end validated on `nantobv/.github` (smoke test issue #17 → "pong" in 9s)

## Test plan

- [ ] CI green on this PR
- [ ] After merge, open an issue here and comment `@claude reply with "pong"` to confirm the responder still fires. Run logs at this repo's Actions tab → "Claude Code" workflow.
- [ ] Try the same `@claude` comment from a non-member account (if applicable) to confirm the author gate now blocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)