### PR TITLE
Vendor nantobv-shared AGENTS.md block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,83 @@
 
 Pituitary is a consistency governance tool that keeps specifications, documentation, and code aligned. It builds a temporal, confidence-weighted governance graph from spec bundles and docs, then runs overlap, drift, compliance, impact, and freshness analysis against it. The current repo is focused on local filesystem inputs, Markdown docs, SQLite-backed indexing, a CLI-first interface, an optional MCP wrapper, and repo CI validation.
 
+<!-- BEGIN nantobv-shared (sync via nantobv/.github/scripts/sync-agents-shared.sh) -->
+## Org-wide policy (nantobv-shared)
+
+The bullets in this section are the org-wide floor for AI agents working on
+any nantobv project. They are vendored verbatim from
+[`nantobv/.github/AGENTS.shared.md`](https://github.com/nantobv/.github/blob/main/AGENTS.shared.md);
+refresh the local copy with
+[`scripts/sync-agents-shared.sh`](https://github.com/nantobv/.github/blob/main/scripts/sync-agents-shared.sh).
+Project-specific rules live in each repo's own `AGENTS.md` sections outside
+this block.
+
+**Planning and approval**
+
+- Read the repo's `AGENTS.md`, `README.md`, and the documents they point at
+  before deep implementation work.
+- For non-trivial changes, propose the plan (files you expect to touch and
+  why, approach, rationale) and wait for approval before writing code. Plan
+  mode satisfies this; a dedicated planning skill or brainstorming ceremony
+  is not required.
+- Show diffs and wait for approval before committing or pushing, unless the
+  user has invoked a publish workflow (e.g. `cpprrm`) that explicitly
+  authorizes commit/push for the current task and no stronger repo or
+  security gate applies.
+
+**Git hygiene**
+
+- Run `git status` and `git diff --minimal` before any commit.
+- Stage explicit paths. Never use `git add .`.
+- Keep unrelated local files out of commits, including local `.ccd.toml` and
+  harness work directories unless the task explicitly targets them.
+
+**Validation and evidence**
+
+- Run the smallest deterministic check that proves the change. Repo-specific
+  gates (`make verify`, `cargo test`, `go test ./...`, etc.) are defined in
+  each repo's Testing section and take precedence over this floor.
+- Before claiming work is complete, fixed, or passing, run the relevant
+  verification command and cite the actual output. Do not assert success
+  without evidence.
+- If you skip validation, state the reason explicitly.
+
+**Safety**
+
+- No secrets in tracked files, docs, workflows, fixtures, diagnostics, or
+  generated outputs.
+- Do not overwrite user changes or reset the worktree without explicit
+  approval.
+- Do not flip repository visibility or licensing policy without an explicit
+  decision from the operator.
+- Treat external services and model calls as opt-in unless a repo policy or
+  explicit user request grants narrow approval.
+- Prefer deterministic behavior, explicit metadata, and small reversible
+  changes.
+
+**Source files**
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and other model-instruction source
+  files are user-owned and maintainer-authored. Tooling in this org does not
+  overwrite or render replacement bodies for them except for explicit
+  maintainer-requested edits to those files.
+
+**External review (standing grant)**
+
+- Every nantobv repo that vendors this block grants standing approval to
+  invoke the bundled `claude-adversarial-review` skill on the selected local
+  diff when the user explicitly asks for that skill. Treat the explicit
+  request as the approval; do not ask for a second confirmation.
+- The approval is narrow: it applies only to the selected repo diff, only to
+  the `claude-adversarial-review` skill, and only with that skill's
+  read-only tool permissions. It does not approve sending secrets, unrelated
+  files, whole-home context, or data to other external services.
+- After an adversarial review returns, evaluate findings on their merits.
+  Address real correctness, maintainability, or contract-honesty issues with
+  proportionate changes. Do not add broad machinery, process, or abstraction
+  solely to satisfy a speculative review point.
+<!-- END nantobv-shared -->
+
 ## Coding Standards
 
 - Read [README.md](README.md) and [ARCHITECTURE.md](ARCHITECTURE.md) before deep implementation work. Use the active GitHub issues for backlog and priority context.
@@ -26,19 +103,11 @@ Pituitary is a consistency governance tool that keeps specifications, documentat
 ## Workflow
 
 - Keep GitHub issues aligned with the repo docs and in priority order.
-- When planning or implementing, name the files you expect to touch and why.
-- Run `git status` and `git diff --minimal` before any commit.
-- Stage explicit paths. Never use `git add .`.
-- Show diffs and wait for approval before committing or pushing.
 
 ## Testing
 
-- Run the smallest check that proves the change.
 - Prefer `make fmt`, `make test`, `make vet`, and `make ci` where applicable.
-- If you skip validation, state the reason explicitly.
 
 ## Safety
 
-- No secrets in tracked files, docs, or fixtures.
 - Stay within the active issue or approved work item and call out scope drift when it appears.
-- Do not overwrite user changes or reset the worktree without explicit approval.


### PR DESCRIPTION
## Summary

- Embeds the canonical org-wide AI agent policy from [`nantobv/.github/AGENTS.shared.md`](https://github.com/nantobv/.github/blob/main/AGENTS.shared.md) between `<!-- BEGIN nantobv-shared --> ... <!-- END nantobv-shared -->` markers.
- Trims local Workflow / Testing / Safety to project-specific rules only: GitHub issue alignment, `make fmt/test/vet/ci`, and scope-drift callouts.

## Context

Wave 2 of the org-wide AGENTS.md rollout — see [nantobv/.github#20](https://github.com/nantobv/.github/pull/20) for the shared-block mechanism. Companion PRs: [stroma-rs#25](https://github.com/nantobv/stroma-rs/pull/25), [hippocampus-rs#5](https://github.com/nantobv/hippocampus-rs/pull/5), [hippocampus#9](https://github.com/nantobv/hippocampus/pull/9), [stroma#202](https://github.com/nantobv/stroma/pull/202).

The reusable `agents-shared-check.yml` caller workflow is intentionally **not** added in this PR; it will land in a follow-up wave after every active repo has the marker block.

## Test plan

- [x] Sync script ran cleanly with `NANTOBV_SHARED_PATH` against local nantobv clone.
- [x] Net diff: 77 insertions, 8 deletions in `AGENTS.md` only.
- [x] Lefthook pre-commit `block-secrets` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)